### PR TITLE
Fixing table border when not used as the first row but the first column

### DIFF
--- a/src/assets/stylesheets/modules/article/_appearance.scss
+++ b/src/assets/stylesheets/modules/article/_appearance.scss
@@ -93,20 +93,6 @@
     th {
       background: mix($primary, $white, 75%);
       color: $white;
-
-      /*
-       * Round upper left border
-       */
-      &:first-child {
-        border-top-left-radius: 3px;
-      }
-
-      /*
-       * Round upper right border
-       */
-      &:last-child {
-        border-top-right-radius: 3px;
-      }
     }
 
     /*
@@ -114,6 +100,46 @@
      */
     td {
       border-top: 1px solid rgba($black, 0.05);
+    }
+
+    /*
+     * First and last line round borders
+     */
+    tr {
+      &:first-child {
+        th {
+          /*
+           * Round upper left border
+           */
+          &:first-child {
+            border-top-left-radius: 3px;
+          }
+
+          /*
+           * Round upper right border
+           */
+          &:last-child {
+            border-top-right-radius: 3px;
+          }
+        }
+      }
+      &:last-child {
+        th {
+          /*
+           * Round upper left border
+           */
+          &:first-child {
+            border-bottom-left-radius: 3px;
+          }
+
+          /*
+           * Round upper right border
+           */
+          &:last-child {
+            border-bottom-right-radius: 3px;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When the <th> is used as a column header, the first cell of each row appears rounded.
This fixes the problem.

However, as the table already has a "rounded corner attribute", I am no even sure that such rules are necessary. What do you think ?