### PR TITLE
Add option to link to GitHub release

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,6 +103,25 @@ extra:
   logo: 'images/logo.png'
 ```
 
+### Link to GitHub releases page
+
+If your project has a GitHub url configured, the default behavior is that a
+downlink button is displayed, linking to the source download of the given
+`extra.version` or `master` branch. To link to the releases page instead,
+set `extra.github.download_release` to `true`. It will link to the release of
+the given `extra.version` or when no `extra.version` is given, the latest
+release:
+
+``` yaml
+repo_name: GitHub
+repo_url: https://github.com/squidfunk/mkdocs-material
+
+extra:
+  github:
+    download_release: true
+```
+
+
 ### Changing the color palette
 
 Material defines a default hue for every primary and accent color on Google's

--- a/material/drawer.html
+++ b/material/drawer.html
@@ -26,7 +26,7 @@
       {% if repo_name == "GitHub" and repo_url %}
         <ul class="repo">
           <li class="repo-download">
-            {% if config.extra.github.download_release %}
+            {% if config.extra.github and config.extra.github.download_release %}
               {% set version = config.extra.version | default("../latest") %}
               <a href="{{ repo_url }}/releases/tag/{{ version }}" target="_blank" title="Download" data-action="download">
                 <i class="icon icon-download"></i> Download

--- a/material/drawer.html
+++ b/material/drawer.html
@@ -26,10 +26,17 @@
       {% if repo_name == "GitHub" and repo_url %}
         <ul class="repo">
           <li class="repo-download">
-            {% set version = config.extra.version | default("master") %}
-            <a href="{{ repo_url }}/archive/{{ version }}.zip" target="_blank" title="Download" data-action="download">
-              <i class="icon icon-download"></i> Download
-            </a>
+            {% if config.extra.github.download_release %}
+              {% set version = config.extra.version | default("../latest") %}
+              <a href="{{ repo_url }}/releases/tag/{{ version }}" target="_blank" title="Download" data-action="download">
+                <i class="icon icon-download"></i> Download
+              </a>
+            {% else %}
+              {% set version = config.extra.version | default("master") %}
+              <a href="{{ repo_url }}/archive/{{ version }}.zip" target="_blank" title="Download" data-action="download">
+                <i class="icon icon-download"></i> Download
+              </a>
+            {% endif %}
           </li>
           <li class="repo-stars">
             <a href="{{ repo_url }}/stargazers" target="_blank" title="Stargazers" data-action="star">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ theme_dir: material
 extra:
   version: 0.2.4
   logo: images/logo.png
+  github:
+    download_release: true
   author:
     github: squidfunk
     twitter: squidfunk

--- a/src/drawer.html
+++ b/src/drawer.html
@@ -41,11 +41,19 @@
       {% if repo_name == "GitHub" and repo_url %}
         <ul class="repo">
           <li class="repo-download">
-            {% set version = config.extra.version | default("master") %}
-            <a href="{{ repo_url }}/archive/{{ version }}.zip" target="_blank"
-              title="Download" data-action="download">
-              <i class="icon icon-download"></i> Download
-            </a>
+            {% if config.extra.github.download_release %}
+              {% set version = config.extra.version | default("../latest") %}
+              <a href="{{ repo_url }}/releases/tag/{{ version }}" target="_blank"
+                title="Download" data-action="download">
+                <i class="icon icon-download"></i> Download
+              </a>
+            {% else %}
+              {% set version = config.extra.version | default("master") %}
+              <a href="{{ repo_url }}/archive/{{ version }}.zip" target="_blank"
+                title="Download" data-action="download">
+                <i class="icon icon-download"></i> Download
+              </a>
+            {% endif %}
           </li>
           <li class="repo-stars">
             <a href="{{ repo_url }}/stargazers" target="_blank"

--- a/src/drawer.html
+++ b/src/drawer.html
@@ -41,7 +41,7 @@
       {% if repo_name == "GitHub" and repo_url %}
         <ul class="repo">
           <li class="repo-download">
-            {% if config.extra.github.download_release %}
+            {% if config.extra.github and config.extra.github.download_release %}
               {% set version = config.extra.version | default("../latest") %}
               <a href="{{ repo_url }}/releases/tag/{{ version }}" target="_blank"
                 title="Download" data-action="download">


### PR DESCRIPTION
First of all, you did great work with your theme! I'm considering to use it for the documentation of some of my themes :-)

One thing that was missing in my opinion was an option to link to a GitHub release instead of the source download. This pull-request implements this option. Please let me know what you think.

If you decide to merge it, would be be able to push a new release to pypi so I can start using it?