### PR TITLE
Fix inline code snippets in list

### DIFF
--- a/src/assets/stylesheets/modules/article/_layout.scss
+++ b/src/assets/stylesheets/modules/article/_layout.scss
@@ -188,7 +188,7 @@
   /*
    * Inline code snippets must not wrap
    */
-  p > code {
+  p > code, li > code {
     white-space: nowrap;
     padding: 2px 4px;
   }


### PR DESCRIPTION
A small fix to not wrap inline code snippets in list:

<img width="363" alt="20160702_184958" src="https://cloud.githubusercontent.com/assets/3684918/16541238/e46b9300-4085-11e6-86e1-db115c6fd531.png">
