### PR TITLE
Better Attrtibution

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -190,16 +190,8 @@
           <!-- Copyright and theme information -->
           <aside class="copyright" role="note">
             {% if copyright %}
-              {{ copyright }} &ndash;
+              {{ copyright }}
             {% endif %}
-            Documentation built with
-            <a href="http://www.mkdocs.org" target="_blank">MkDocs</a>
-            using the
-            <a href="http://squidfunk.github.io/mkdocs-material/"
-              target="_blank">
-              Material
-            </a>
-            theme.
           </aside>
 
           <!-- Footer -->
@@ -269,5 +261,6 @@
         });
       </script>
     {% endif %}
+    <!--Documentation built with MkDocs (http://www.mkdocs.org) using the  Material (http://squidfunk.github.io/mkdocs-material/) theme.-->
   </body>
 </html>


### PR DESCRIPTION
Better attribution SEO wise is the one which is inside the code and doesn't link back. As discussed in #53 issue. Also, SEO wise it is a death sentence to your products since Penguin doesn't like such links. Research on "widget link and penguin"
