### PR TITLE
Use `extra.version` if it is available when generating source partial

### DIFF
--- a/material/partials/source.html
+++ b/material/partials/source.html
@@ -12,7 +12,9 @@
   <div class="md-source__repository">
     {{ repo_name }}
     <ul class="md-source__facts">
-      <li class="md-source__fact">v0.2.4</li>                             
+      {% if config.extra.version %}
+        <li class="md-source__fact">v{{ config.extra.version }}</li>
+      {% endif %}
     </ul>
   </div>
 </a>

--- a/src/partials/source.html
+++ b/src/partials/source.html
@@ -41,7 +41,9 @@
   <div class="md-source__repository">
     {{ repo_name }}
     <ul class="md-source__facts">
-      <li class="md-source__fact">v0.2.4</li>                             <!-- TODO: make dynamic -->
+      {% if config.extra.version %}
+        <li class="md-source__fact">v{{ config.extra.version }}</li>
+      {% endif %}
     </ul>
   </div>
 </a>


### PR DESCRIPTION
A very small change remove the hardcoded version in `source.html`. It now uses `extra.version` set in the `mkdocs.yml` config.

In future, it may be possible to retrieve this information from the Github API along with the stargazers and fork counts.