### PR TITLE
Handle when no config.repo_url is available

### DIFF
--- a/material/assets/javascripts/application.js
+++ b/material/assets/javascripts/application.js
@@ -739,6 +739,7 @@ var Application =
 	      /* Retrieve the facts for the given repository type */
 	      ;(function () {
 	        var el = document.querySelector("[data-md-source]");
+	        if (!el) return Promise.resolve([]);
 	        switch (el.dataset.mdSource) {
 	          case "github":
 	            return new _Material2.default.Source.Adapter.GitHub(el).fetch();

--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -34,13 +34,13 @@
         {% endblock %}
       </div>
       <div class="md-flex__cell md-flex__cell--shrink">
-        <div class="md-header-nav__source">
-          {% block repo %}
-            {% if config.repo_url %}
+        {% block repo %}
+          {% if config.repo_url %}
+            <div class="md-header-nav__source">
               {% include "partials/source.html" %}
-            {% endif %}
-          {% endblock %}
-        </div>
+            </div>
+          {% endif %}
+        {% endblock %}
       </div>
     </div>
   </nav>

--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -196,6 +196,7 @@ export default class Application {
     /* Retrieve the facts for the given repository type */
     ;(() => {
       const el = document.querySelector("[data-md-source]")
+      if (!el) return Promise.resolve([])
       switch (el.dataset.mdSource) {
         case "github": return new Material.Source.Adapter.GitHub(el).fetch()
         default: return Promise.resolve([])

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -74,13 +74,13 @@
 
       <!-- Repository containing source -->
       <div class="md-flex__cell md-flex__cell--shrink">
-        <div class="md-header-nav__source">
-          {% block repo %}
-            {% if config.repo_url %}
+        {% block repo %}
+          {% if config.repo_url %}
+            <div class="md-header-nav__source">
               {% include "partials/source.html" %}
-            {% endif %}
-          {% endblock %}
-        </div>
+            </div>
+          {% endif %}
+        {% endblock %}
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Prior to this fix, there would be a gap next to the search bar because `md-header-nav__source` has a `23rem` width set. I believe the width is set to assist with transition once that content is available, so instead of removing the declaration I've just shifted when that element will be added to the page.