### PR TITLE
Add a 'header' template block for easier customisation

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -18,7 +18,7 @@
       {% else %}
         <link rel="shortcut icon" href="{{ base_url }}/assets/images/favicon.ico">
       {% endif %}
-      <meta name="generator" content="mkdocs+mkdocs-material#0.2.1">
+      <meta name="generator" content="mkdocs+mkdocs-material#1.0.0">
     {% endblock %}
     {% block htmltitle %}
       {% if page.title %}
@@ -57,7 +57,9 @@
     <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="drawer">
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="search">
     <label class="md-overlay" data-md-overlay for="drawer"></label>
-    {% include "partials/header.html" %}
+    {% block header %}
+      {% include "partials/header.html" %}
+    {% endblock %}
     <div class="md-container">
       <main class="md-main">
         <div class="md-main__inner md-grid">

--- a/src/base.html
+++ b/src/base.html
@@ -124,7 +124,9 @@
     <label class="md-overlay" data-md-overlay for="drawer"></label>
 
     <!-- Application header -->
-    {% include "partials/header.html" %}
+    {% block header %}
+      {% include "partials/header.html" %}
+    {% endblock %}
 
     <!-- Container, necessary for web-application context -->
     <div class="md-container">


### PR DESCRIPTION
While this isn't one of the [designated blocks](http://www.mkdocs.org/user-guide/styling-your-docs/#overriding-template-blocks) that MkDocs provides, I've found that it's extremely helpful to have in this theme.

This is because this theme, unlike almost all of the other themes, heavily modifies to the header to include information other than navigation. Giving developers a hook to change this behaviour (or inject additional templating as I am doing), is really nice and comes at almost zero cost to this project :)