### PR TITLE
Remove metadata from mkdocs.yml, allow mkdocs to build again

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,6 @@ pages:
     - Admonition: extensions/admonition.md
     - Codehilite: extensions/codehilite.md
     - Footnotes: extensions/footnotes.md
-    - Metadata: extensions/metadata.md
     - Permalinks: extensions/permalinks.md
     - PyMdown: extensions/pymdown.md
   - Specimen: specimen.md


### PR DESCRIPTION
Currently, `mkdocs build` results in an error, this change fixes that 👍 

```
mkdocs build --clean
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /Users/brendanabbott/Sites/mkdocs-material/site 
ERROR   -  file not found: /Users/brendanabbott/Sites/mkdocs-material/docs/extensions/metadata.md 
ERROR   -  Error building page extensions/metadata.md 
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 9, in <module>
    load_entry_point('mkdocs', 'console_scripts', 'mkdocs')()
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/brendanabbott/Sites/mkdocs/mkdocs/__main__.py", line 156, in build_command
    ), dirty=not clean)
  File "/Users/brendanabbott/Sites/mkdocs/mkdocs/commands/build.py", line 379, in build
    build_pages(config, dirty=dirty)
  File "/Users/brendanabbott/Sites/mkdocs/mkdocs/commands/build.py", line 332, in build_pages
    dump_json)
  File "/Users/brendanabbott/Sites/mkdocs/mkdocs/commands/build.py", line 179, in _build_page
    input_content = io.open(input_path, 'r', encoding='utf-8').read()
IOError: [Errno 2] No such file or directory: '/Users/brendanabbott/Sites/mkdocs-material/docs/extensions/metadata.md'
```