### PR TITLE
User overflow:auto instead of overflow:scroll

### DIFF
--- a/src/assets/stylesheets/layout/_nav.scss
+++ b/src/assets/stylesheets/layout/_nav.scss
@@ -260,7 +260,7 @@
       // List of items
       .md-nav__list {
         flex: 1;
-        overflow-y: scroll;
+        overflow-y: auto;
       }
 
       // List item

--- a/src/assets/stylesheets/layout/_sidebar.scss
+++ b/src/assets/stylesheets/layout/_sidebar.scss
@@ -108,7 +108,7 @@
   // Wrapper for scrolling on overflow
   &__scrollwrap {
     margin: 2.4rem 0.4rem;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     // [tablet -]: Adjust margins
     @include break-to-device(tablet) {


### PR DESCRIPTION
Firefox does not support scrollbars customization like webkit does
because it is not part of the CSS standard. So it is better to hide the
scrollbars when they are not needed.

Fix #96

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>