### PR TITLE
Fixed the scroll error in Chrome with small inner content

### DIFF
--- a/src/assets/stylesheets/layout/_base.scss
+++ b/src/assets/stylesheets/layout/_base.scss
@@ -109,7 +109,7 @@ hr {
 
     // If the browser supports calc(), no JavaScript is necessary
     .csscalc & {
-      min-height: calc(100% - #{5.6rem - 3rem});
+      min-height: calc(95% - #{5.6rem - 3rem});
 
       // Hack: Firefox doesn't correctly calculate min-height, as it takes the
       // top margin into account which leads to the container overflowing its
@@ -119,7 +119,7 @@ hr {
       // stylelint-disable-next-line function-url-quotes
       @-moz-document url-prefix() {
         & {
-          min-height: calc(100% - 5.6rem);
+          min-height: calc(95% - 5.6rem);
         }
       }
     }


### PR DESCRIPTION
This fixes the issue reported in #159 where the _min-height_ of the _md-main__inner_ calculated to 100% would result in undesired behavior in Chrome. This was the simplest solution I found because changing other containers resulted into Firefox _min-height_ bugs.

This was tested in Chrome 56, Firefox 51 and IE 11.