### PR TITLE
Do not using mkdocs force as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,4 @@ WORKDIR /docs
 EXPOSE 8000
 
 # Start development server by default
-ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
Signed-off-by: huzhifeng <huzhifeng@douyu.tv>

Do not using mkdocs as entrypoint, by default the default entrypoint will be ```sh```
that we can using the docker image to build or just get a shell into it . 

Please free entrypoint to us .do not force us using mkdocs as entrypoint