### PR TITLE
Set favicon type when using png

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -57,7 +57,7 @@
             href="{{ base_url }}/{{ config.site_favicon }}">
       {% else %}
         <link rel="shortcut icon"
-            href="{{ base_url }}/assets/images/favicon.png">
+            href="{{ base_url }}/assets/images/favicon.png" type="image/png">
       {% endif %}
 
       <!-- Generator banner -->


### PR DESCRIPTION
When I upgraded from 1.3.0 to 1.4.1 the favicon stopped working when building sites. I think this is why.