### PR TITLE
override def. Home w site_name, show site_name in header on 404 page

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -17,14 +17,20 @@
       <div class="md-flex__cell md-flex__cell--stretch">
         <span class="md-flex__ellipsis md-header-nav__title">
           {% block site_name %}
-            {% if page %}
-              {% for parent in page.ancestors %}
-                <span class="md-header-nav__parent">
-                  {{ parent.title }}
-                </span>
-              {% endfor %}
-            {% endif %}
-            {{ page.title | default(config.site_name, true) }}
+              {% if page %}
+                  {% for parent in page.ancestors %}
+                      <span class="md-header-nav__parent">
+                      {{ parent.title }}
+                      </span>
+                  {% endfor %}
+                  {% if page.title == "Home" %}
+                      {{ config.site_name }}
+                  {% else %}
+                      {{ page.title }}
+                  {% endif %}
+              {% else %}
+                  {{ config.site_name }}
+              {% endif %}
           {% endblock %}
         </span>
       </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ markdown_extensions:
 
 # Page tree
 pages:
-  - Material: index.md
+  - index.md
   - Getting started: getting-started.md
   - Extensions:
     - Admonition: extensions/admonition.md


### PR DESCRIPTION
Without specifying a page name in mkdocs.yml mkdocs will default to "Home", which is useful to have in the side-menu but prefer config.site_name be displayed by default in the header for index.md pages. 

This change also allows config.site_name to display on the 404 page. 