### PR TITLE
Add site_name to example mkdocs.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ pip install mkdocs-material
 Add the following line to your `mkdocs.yml`:
 
 ``` yaml
+site_name: Test site
 theme: 'material'
 ```
 


### PR DESCRIPTION
`site_name` is a required field, so include it in the example.