### PR TITLE
Make it clearer mkdocs.yml should exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install with `pip`:
 pip install mkdocs-material
 ```
 
-Add the following line to your `mkdocs.yml`:
+Append the following line to your existing `mkdocs.yml`:
 
 ``` yaml
 theme: 'material'


### PR DESCRIPTION
Make it clearer that `mkdocs.yml` should exist already and the `theme` line should be added to it.

Otherwise you might follow the README as a new Mkdocs user and be confused why it complains about a missing mandatory field such as `site_name`.