### PR TITLE
Use type="search" - more semantically correct

### DIFF
--- a/material/partials/search.html
+++ b/material/partials/search.html
@@ -3,7 +3,7 @@
   <label class="md-search__overlay" for="search"></label>
   <div class="md-search__inner">
     <form class="md-search__form" name="search">
-      <input type="text" class="md-search__input" name="query" required placeholder="{{ lang.t('search.placeholder') }}" accesskey="s" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="query">
+      <input type="search" class="md-search__input" name="query" required placeholder="{{ lang.t('search.placeholder') }}" accesskey="s" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="query">
       <label class="md-icon md-search__icon" for="search"></label>
       <button type="reset" class="md-icon md-search__icon" data-md-component="reset">close</button>
     </form>


### PR DESCRIPTION
type="search"- more semantically correct and has accessibility benefits. Very old browsers which don't recognise type=search will fallback to type=text so there are no compatibility issues. I've tested this locally and works the same as before.