### PR TITLE
Added missing documentation for the site_favicon option

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,6 +286,15 @@ Additionally, for GitHub, the number of stars and forks is shown.
 
   [15]: http://www.mkdocs.org/user-guide/configuration/#edit_uri
 
+### Adding a favicon
+
+Adding a favicon to your site is very easy. Simply set the following variable
+via your project's `mkdocs.yml`:
+
+``` yaml
+site_favicon: 'images/favicon.ico'
+```
+
 ### Adding a logo
 
 Material makes it easy to add your logo. Your logo should have rectangular


### PR DESCRIPTION
I noticed this setting is the way to set the favicon in mkdocs-material (different from mkdocs's way), I found this setting in #22 and I wanted to add documentation for anyone else looking to change the favicon.