### PR TITLE
Render repo in header only with URL

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -34,13 +34,13 @@
           {% include "partials/search.html" %}
         {% endblock %}
       </div>
+      {% if config.repo_url %}
       <div class="md-flex__cell md-flex__cell--shrink">
         <div class="md-header-nav__source">
-          {% if config.repo_url %}
-            {% include "partials/source.html" %}
-          {% endif %}
+          {% include "partials/source.html" %}
         </div>
       </div>
+      {% endif %}
     </div>
   </nav>
 </header>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -78,13 +78,13 @@
       </div>
 
       <!-- Repository containing source -->
+      {% if config.repo_url %}
       <div class="md-flex__cell md-flex__cell--shrink">
         <div class="md-header-nav__source">
-          {% if config.repo_url %}
-            {% include "partials/source.html" %}
-          {% endif %}
+          {% include "partials/source.html" %}
         </div>
       </div>
+      {% endif %}
     </div>
   </nav>
 </header>


### PR DESCRIPTION
It is much wider when repo box is not wanted.

![](https://ipfs.io/ipfs/QmPHPURJR7ZnT8Qv751JMPYUtRUTBSjBAMchEerW3SzpNv)