### PR TITLE
Fixed support for Japanese search

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -156,6 +156,9 @@
         <script src="{{ path }}/lunr.stemmer.support.js"></script>
         {% for language in languages | map("trim") %}
           {% if language != "en" %}
+            {% if language == "jp" %}
+              <script src="{{ path }}/tinyseg.js"></script>
+            {% endif %}
             <script src="{{ path }}/lunr.{{ language }}.js"></script>
           {% endif %}
         {% endfor %}

--- a/src/base.html
+++ b/src/base.html
@@ -284,6 +284,9 @@
         <script src="{{ path }}/lunr.stemmer.support.js"></script>
         {% for language in languages | map("trim") %}
           {% if language != "en" %}
+            {% if language == "jp" %}
+              <script src="{{ path }}/tinyseg.js"></script>
+            {% endif %}
             <script src="{{ path }}/lunr.{{ language }}.js"></script>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
When I set ```jp``` to ```search.languages```, the following JS error is output to a browser console.

```
Uncaught TypeError: e.TinySegmenter is not a constructor
```

The ```lunr.jp.js``` requires ```tinyseg.js```. (https://github.com/MihaiValentin/lunr-languages/pull/6)

So I fixed to load ```tinyseg.js``` when ```jp``` is in ```search.languages```.