### PR TITLE
Update EmojiOne demo url

### DIFF
--- a/docs/extensions/pymdown.md
+++ b/docs/extensions/pymdown.md
@@ -69,7 +69,7 @@ emojis. Happy scrolling :tada:
     [EmojiOne license][8] to ensure proper usage and attribution.
 
   [4]: https://facelessuser.github.io/pymdown-extensions/extensions/emoji/
-  [5]: http://emojione.com/demo/
+  [5]: https://emoji.codes/
   [6]: http://emojione.com
   [7]: https://creativecommons.org/licenses/by/4.0/legalcode
   [8]: http://emojione.com/licensing/


### PR DESCRIPTION
The link http://emojione.com/demo does not exist anymore and it is replace by https://emoji.codes/