### PR TITLE
Feature/hidemenuitemasextraoption

### DIFF
--- a/src/partials/nav-item.html
+++ b/src/partials/nav-item.html
@@ -46,10 +46,10 @@
     <!-- Active checkbox expands items contained within nested section -->
     {% if nav_item.active %}
       <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-        type="checkbox" id="{{ path }}" checked />
+          type="checkbox" id="{{ path }}" checked />
     {% else %}
       <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-        type="checkbox" id="{{ path }}" />
+          type="checkbox" id="{{ path }}" />
     {% endif %}
 
     <!-- Expand active pages -->
@@ -57,7 +57,7 @@
       {{ nav_item.title }}
     </label>
     <nav class="md-nav" data-md-component="collapsible"
-      data-md-level="{{ level }}">
+        data-md-level="{{ level }}">
       <label class="md-nav__title" for="{{ path }}">
         {{ nav_item.title }}
       </label>
@@ -81,7 +81,7 @@
 
     <!-- Active checkbox expands items contained within nested section -->
     <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
-      type="checkbox" id="toc" />
+        type="checkbox" id="toc" />
 
     <!-- Hack: see partials/toc.html for more information -->
     {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
@@ -95,7 +95,7 @@
       </label>
     {% endif %}
     <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
-      class="md-nav__link md-nav__link--active">
+        class="md-nav__link md-nav__link--active">
       {{ nav_item.title }}
     </a>
 
@@ -109,8 +109,8 @@
 {% else %}
   <li class="{{ class }}">
     <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
-      class="md-nav__link">
-        {{ nav_item.title }}
+        class="md-nav__link">
+      {{ nav_item.title }}
     </a>
   </li>
 {% endif %}

--- a/src/partials/nav-item.html
+++ b/src/partials/nav-item.html
@@ -39,80 +39,79 @@
 {% endif %}
 
 {% if showitem %}
+<!-- Main navigation item with nested items -->
+{% if nav_item.children %}
+  <li class="{{ class }} md-nav__item--nested">
 
-  <!-- Main navigation item with nested items -->
-  {% if nav_item.children %}
-    <li class="{{ class }} md-nav__item--nested">
+    <!-- Active checkbox expands items contained within nested section -->
+    {% if nav_item.active %}
+      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
+        type="checkbox" id="{{ path }}" checked />
+    {% else %}
+      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
+        type="checkbox" id="{{ path }}" />
+    {% endif %}
 
-      <!-- Active checkbox expands items contained within nested section -->
-      {% if nav_item.active %}
-        <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-          type="checkbox" id="{{ path }}" checked />
-      {% else %}
-        <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-          type="checkbox" id="{{ path }}" />
-      {% endif %}
-
-      <!-- Expand active pages -->
-      <label class="md-nav__link" for="{{ path }}">
+    <!-- Expand active pages -->
+    <label class="md-nav__link" for="{{ path }}">
+      {{ nav_item.title }}
+    </label>
+    <nav class="md-nav" data-md-component="collapsible"
+      data-md-level="{{ level }}">
+      <label class="md-nav__title" for="{{ path }}">
         {{ nav_item.title }}
       </label>
-      <nav class="md-nav" data-md-component="collapsible"
-        data-md-level="{{ level }}">
-        <label class="md-nav__title" for="{{ path }}">
-          {{ nav_item.title }}
-        </label>
-        <ul class="md-nav__list" data-md-scrollfix>
+      <ul class="md-nav__list" data-md-scrollfix>
 
-          <!-- Render nested item list -->
-          {% set base = path %}
-          {% for nav_item in nav_item.children %}
-            {% set path = base + "-" + loop.index | string %}
-            {% set level = level + 1 %}
-            {% include "partials/nav-item.html"  %}
-          {% endfor %}
-        </ul>
-      </nav>
-    </li>
+        <!-- Render nested item list -->
+        {% set base = path %}
+        {% for nav_item in nav_item.children %}
+          {% set path = base + "-" + loop.index | string %}
+          {% set level = level + 1 %}
+          {% include "partials/nav-item.html"  %}
+        {% endfor %}
+      </ul>
+    </nav>
+  </li>
 
-  <!-- Currently active page -->
-  {% elif nav_item == page %}
-    <li class="{{ class }}">
-      {% set toc_ = page.toc %}
+<!-- Currently active page -->
+{% elif nav_item == page %}
+  <li class="{{ class }}">
+    {% set toc_ = page.toc %}
 
-      <!-- Active checkbox expands items contained within nested section -->
-      <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
-        type="checkbox" id="toc" />
+    <!-- Active checkbox expands items contained within nested section -->
+    <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
+      type="checkbox" id="toc" />
 
-      <!-- Hack: see partials/toc.html for more information -->
-      {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
-        {% set toc_ = (toc_ | first).children %}
-      {% endif %}
+    <!-- Hack: see partials/toc.html for more information -->
+    {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
+      {% set toc_ = (toc_ | first).children %}
+    {% endif %}
 
-      <!-- Render table of contents, if not empty -->
-      {% if toc_ | first is defined %}
-        <label class="md-nav__link md-nav__link--active" for="toc">
-          {{ nav_item.title }}
-        </label>
-      {% endif %}
-      <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
-        class="md-nav__link md-nav__link--active">
+    <!-- Render table of contents, if not empty -->
+    {% if toc_ | first is defined %}
+      <label class="md-nav__link md-nav__link--active" for="toc">
         {{ nav_item.title }}
-      </a>
+      </label>
+    {% endif %}
+    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+      class="md-nav__link md-nav__link--active">
+      {{ nav_item.title }}
+    </a>
 
-      <!-- Show table of contents -->
-      {% if toc_ | first is defined %}
-        {% include "partials/toc.html" %}
-      {% endif %}
-    </li>
+    <!-- Show table of contents -->
+    {% if toc_ | first is defined %}
+      {% include "partials/toc.html" %}
+    {% endif %}
+  </li>
 
-  <!-- Main navigation item -->
-  {% else %}
-    <li class="{{ class }}">
-      <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
-        class="md-nav__link">
-          {{ nav_item.title }}
-      </a>
-    </li>
-  {% endif %}
+<!-- Main navigation item -->
+{% else %}
+  <li class="{{ class }}">
+    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+      class="md-nav__link">
+        {{ nav_item.title }}
+    </a>
+  </li>
+{% endif %}
 {% endif %}

--- a/src/partials/nav-item.html
+++ b/src/partials/nav-item.html
@@ -26,78 +26,93 @@
   {% set class = "md-nav__item md-nav__item--active" %}
 {% endif %}
 
-<!-- Main navigation item with nested items -->
-{% if nav_item.children %}
-  <li class="{{ class }} md-nav__item--nested">
-
-    <!-- Active checkbox expands items contained within nested section -->
-    {% if nav_item.active %}
-      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-          type="checkbox" id="{{ path }}" checked />
-    {% else %}
-      <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
-          type="checkbox" id="{{ path }}" />
+<!-- Determine if navigation item should be visible -->
+{% set showitem = True %}
+{% if config.extra.hidemenuitems %}
+  {% set showitem = [] %}
+  {% for folderitem in config.extra.hidemenuitems %}
+    {% if nav_item.title.lower() == folderitem.lower() and not showitem %}
+      {% if showitem.append(True) %} {% endif %}
     {% endif %}
+  {% endfor %}
+  {% set showitem = False if showitem else True %}
+{% endif %}
 
-    <!-- Expand active pages -->
-    <label class="md-nav__link" for="{{ path }}">
-      {{ nav_item.title }}
-    </label>
-    <nav class="md-nav" data-md-component="collapsible"
-        data-md-level="{{ level }}">
-      <label class="md-nav__title" for="{{ path }}">
+{% if showitem %}
+
+  <!-- Main navigation item with nested items -->
+  {% if nav_item.children %}
+    <li class="{{ class }} md-nav__item--nested">
+
+      <!-- Active checkbox expands items contained within nested section -->
+      {% if nav_item.active %}
+        <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
+          type="checkbox" id="{{ path }}" checked />
+      {% else %}
+        <input class="md-toggle md-nav__toggle" data-md-toggle="{{ path }}"
+          type="checkbox" id="{{ path }}" />
+      {% endif %}
+
+      <!-- Expand active pages -->
+      <label class="md-nav__link" for="{{ path }}">
         {{ nav_item.title }}
       </label>
-      <ul class="md-nav__list" data-md-scrollfix>
+      <nav class="md-nav" data-md-component="collapsible"
+        data-md-level="{{ level }}">
+        <label class="md-nav__title" for="{{ path }}">
+          {{ nav_item.title }}
+        </label>
+        <ul class="md-nav__list" data-md-scrollfix>
 
-        <!-- Render nested item list -->
-        {% set base = path %}
-        {% for nav_item in nav_item.children %}
-          {% set path = base + "-" + loop.index | string %}
-          {% set level = level + 1 %}
-          {% include "partials/nav-item.html"  %}
-        {% endfor %}
-      </ul>
-    </nav>
-  </li>
+          <!-- Render nested item list -->
+          {% set base = path %}
+          {% for nav_item in nav_item.children %}
+            {% set path = base + "-" + loop.index | string %}
+            {% set level = level + 1 %}
+            {% include "partials/nav-item.html"  %}
+          {% endfor %}
+        </ul>
+      </nav>
+    </li>
 
-<!-- Currently active page -->
-{% elif nav_item == page %}
-  <li class="{{ class }}">
-    {% set toc_ = page.toc %}
+  <!-- Currently active page -->
+  {% elif nav_item == page %}
+    <li class="{{ class }}">
+      {% set toc_ = page.toc %}
 
-    <!-- Active checkbox expands items contained within nested section -->
-    <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
+      <!-- Active checkbox expands items contained within nested section -->
+      <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
         type="checkbox" id="toc" />
 
-    <!-- Hack: see partials/toc.html for more information -->
-    {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
-      {% set toc_ = (toc_ | first).children %}
-    {% endif %}
+      <!-- Hack: see partials/toc.html for more information -->
+      {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
+        {% set toc_ = (toc_ | first).children %}
+      {% endif %}
 
-    <!-- Render table of contents, if not empty -->
-    {% if toc_ | first is defined %}
-      <label class="md-nav__link md-nav__link--active" for="toc">
-        {{ nav_item.title }}
-      </label>
-    {% endif %}
-    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+      <!-- Render table of contents, if not empty -->
+      {% if toc_ | first is defined %}
+        <label class="md-nav__link md-nav__link--active" for="toc">
+          {{ nav_item.title }}
+        </label>
+      {% endif %}
+      <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
         class="md-nav__link md-nav__link--active">
-      {{ nav_item.title }}
-    </a>
+        {{ nav_item.title }}
+      </a>
 
-    <!-- Show table of contents -->
-    {% if toc_ | first is defined %}
-      {% include "partials/toc.html" %}
-    {% endif %}
-  </li>
+      <!-- Show table of contents -->
+      {% if toc_ | first is defined %}
+        {% include "partials/toc.html" %}
+      {% endif %}
+    </li>
 
-<!-- Main navigation item -->
-{% else %}
-  <li class="{{ class }}">
-    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+  <!-- Main navigation item -->
+  {% else %}
+    <li class="{{ class }}">
+      <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
         class="md-nav__link">
-      {{ nav_item.title }}
-    </a>
-  </li>
+          {{ nav_item.title }}
+      </a>
+    </li>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
I suggest this change to allow having markdown files that should be hidden from the menu. I needed this when I had articles that have linked sub articles and where I did not want the sub articles to show in the menu. This feature allow you to hide both menu items with children (folders with sub folders and all the markdown files within) and single page menu items. With this change, all you need to do is to update the mkdocs.yml with an extra option 'hidemenuitems' to hide menu items with specific title(s):

# Options
extra:
  hidemenuitems:
    - subarticles
    - media