### PR TITLE
Improve printing of code blocks

### DIFF
--- a/src/assets/stylesheets/base/_typeset.scss
+++ b/src/assets/stylesheets/base/_typeset.scss
@@ -166,6 +166,11 @@ kbd {
     background-color: $md-code-background;
     color: $md-code-color;
     font-size: 85%;
+
+    // Wrap text and hide scollbars
+    @media print {
+      white-space: pre-wrap;
+    }
   }
 
   // Inline code blocks, correct relative ems for smaller font size

--- a/src/assets/stylesheets/layout/_clipboard.scss
+++ b/src/assets/stylesheets/layout/_clipboard.scss
@@ -38,6 +38,11 @@
   // Hack: put everything on the GPU to omit flickering
   backface-visibility: hidden;
 
+  // Hide for print
+  @media print {
+    display: none;
+  }
+
   // Icon
   &::before {
     @extend %md-icon;


### PR DESCRIPTION
 - Hide clipboard icon
 - Wrap code and hide the scrollbar

---

**Before**
<img width="508" alt="screen shot 2017-10-15 at 21 53 45" src="https://user-images.githubusercontent.com/8417/31592091-dd41604c-b1f3-11e7-92e0-91935818b5fb.png">

**After**
<img width="509" alt="screen shot 2017-10-15 at 21 54 01" src="https://user-images.githubusercontent.com/8417/31592093-e26e9620-b1f3-11e7-932e-a5b984b7031a.png">
