### PR TITLE
Remove deprecated Markdown config format in docs.

### DIFF
--- a/docs/extensions/codehilite.md
+++ b/docs/extensions/codehilite.md
@@ -115,7 +115,8 @@ Line numbers can be added by enabling the `linenums` flag in your `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
-  - codehilite(linenums=true)
+  - codehilite: 
+      linenums:true
 ```
 
 Example:

--- a/docs/extensions/permalinks.md
+++ b/docs/extensions/permalinks.md
@@ -13,7 +13,8 @@ To enable permalinks, add the following to your `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
-  - toc(permalink=true)
+  - toc:
+      permalink: true
 ```
 
 This will add a link containing the paragraph symbol `¶` at the end of each
@@ -23,7 +24,8 @@ permalink, a string can be passed, e.g.:
 
 ``` markdown
 markdown_extensions:
-  - toc(permalink=Link)
+  - toc:
+      permalink: Link
 ```
 
 ## Usage

--- a/docs/extensions/pymdown.md
+++ b/docs/extensions/pymdown.md
@@ -21,7 +21,8 @@ package are recommended to be used together with the Material theme:
 ``` yaml
 markdown_extensions:
   - pymdownx.arithmatex
-  - pymdownx.betterem(smart_enable=all)
+  - pymdownx.betterem:
+      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details
@@ -32,7 +33,8 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences
-  - pymdownx.tasklist(custom_checkbox=true)
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.tilde
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -486,8 +486,10 @@ but highly recommended, so they should be switched on at all times:
 ``` yaml
 markdown_extensions:
   - admonition
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite: 
+      guess_lang: false
+  - toc:
+      permalink: true
 ```
 
 For more information, see the following list of extensions supported by the
@@ -554,6 +556,8 @@ google_analytics:
 # Extensions
 markdown_extensions:
   - admonition
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite:
+      guess_lang: false
+  - toc:
+      permalink: true
 ```


### PR DESCRIPTION
Support for including Markdown extension configs in the extension name has been [deprecated][1] and will not work in any future released of Python-Markdown. MkDocs has offered full support for defining extension configs [since version 0.13][2] and everyone should be using that format.

[1]: https://pythonhosted.org/Markdown/release-2.6.html#extension-configuration-as-part-of-extension-name-deprecated
[2]: http://www.mkdocs.org/about/release-notes/#other-changes-and-additions-to-version-0130