### PR TITLE
Generate Edit button only if page.edit_url

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -129,7 +129,7 @@
           <div class="md-content">
             <article class="md-content__inner md-typeset">
               {% block content %}
-                {% if config.edit_uri %}
+                {% if page.edit_url %}
                   <a href="{{ page.edit_url }}" title="{{ lang.t('edit.link.title') }}" class="md-icon md-content__icon">&#xE3C9;</a>
                 {% endif %}
                 {% if not "\x3ch1" in page.content %}

--- a/src/base.html
+++ b/src/base.html
@@ -242,7 +242,7 @@
               {% block content %}
 
                 <!-- Edit button, if URL was defined -->
-                {% if config.edit_uri %}
+                {% if page.edit_url %}
                   <a href="{{ page.edit_url }}"
                       title="{{ lang.t('edit.link.title') }}"
                       class="md-icon md-content__icon">&#xE3C9;<!-- edit --></a>


### PR DESCRIPTION
Can you review this small change? I was planning to add custom urls for edition to mkdocs and I found out that your Edit Button wasn't generated if the `config.edit_uri` wasn't set. 