### PR TITLE
Changed yarn to latest version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ cache:
 
 # Install yarn as Travis doesn't support it out of the box
 before_install:
-  - npm install -g yarn@v0.22.0
+  - npm install -g yarn@v1.3.2
 
 # Install dependencies
 install:


### PR DESCRIPTION
- yarn written in .travis.yml seems to be old version. **(It's deprecated)**
- rewritten to the latest version. (v1.3.2)
- Build was passing on Travis CI.
- If there is any reason, please be rejected.