### PR TITLE
Add ability to disable Disqus via page meta

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -153,7 +153,7 @@
                 {% endblock %}
               {% endblock %}
               {% block disqus %}
-                {% if config.extra.disqus and not page.is_homepage %}
+                {% if config.extra.disqus and not page.is_homepage and not (page.meta and page.meta.no_disqus) %}
                   <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
                   {% include "partials/integrations/disqus.html" %}
                 {% endif %}


### PR DESCRIPTION
I just don't want to let people leave public comments on certain pages. For example, an `About Me` page, which I usually leave other method to contact me such as email.

Wondering people may want to disable Disqus on certain pages like me.