### PR TITLE
Duplicate slashes in source file URLs

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -146,7 +146,9 @@
                     <h2 id="__source">{{ lang.t("meta.source") }}</h2>
                     {% set path = page.meta.path | default([""]) %}
                     {% set file = page.meta.source %}
-                    <a href="{{ [config.repo_url, path, file] | join('/') }}" title="{{ file }}" class="md-source-file">
+                    <a href="{{ config.repo_url }}
+                             {{ [path, file] | join('/') }}"
+                        title="{{ file }}" class="md-source-file">
                       {{ file }}
                     </a>
                   {% endif %}

--- a/material/base.html
+++ b/material/base.html
@@ -146,8 +146,7 @@
                     <h2 id="__source">{{ lang.t("meta.source") }}</h2>
                     {% set path = page.meta.path | default([""]) %}
                     {% set file = page.meta.source %}
-                    <a href="{{ config.repo_url }}
-                             {{ [path, file] | join('/') }}"
+                    <a href="{{ config.repo_url + [path, file] | join('/') }}"
                         title="{{ file }}" class="md-source-file">
                       {{ file }}
                     </a>

--- a/src/base.html
+++ b/src/base.html
@@ -277,8 +277,7 @@
                     <h2 id="__source">{{ lang.t("meta.source") }}</h2>
                     {% set path = page.meta.path | default([""]) %}
                     {% set file = page.meta.source %}
-                    <a href="{{ config.repo_url }}
-                             {{ [path, file] | join('/') }}"
+                    <a href="{{ config.repo_url + [path, file] | join('/') }}"
                         title="{{ file }}" class="md-source-file">
                       {{ file }}
                     </a>

--- a/src/base.html
+++ b/src/base.html
@@ -277,7 +277,8 @@
                     <h2 id="__source">{{ lang.t("meta.source") }}</h2>
                     {% set path = page.meta.path | default([""]) %}
                     {% set file = page.meta.source %}
-                    <a href="{{ [config.repo_url, path, file] | join('/') }}"
+                    <a href="{{ config.repo_url }}
+                             {{ [path, file] | join('/') }}"
                         title="{{ file }}" class="md-source-file">
                       {{ file }}
                     </a>


### PR DESCRIPTION
Hi,

There is an issue with source URLs built by the template from `source` and `path` page metadata. The generated URLs include double slashes between the repository URL and the rest of the path. I don't know for Github, but Bitbucket is unable to handle such URLs correctly.

The source of the issue is that the `config.repo_url` variable is normalized by mkdocs to always include a trailing slash. As a consequence, the `join()` filter adds a trailing slash where it is not needed. 

The attached pull request excludes the `config.repo_url` variable from the `join()` operation, assuming repo URLs always include a trailing slash thanks to mkdocs normalization.

Thanks,

Marin.