### PR TITLE
Add Google Font Preconnect

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -57,6 +57,7 @@
       <script src="{{ base_url }}/assets/javascripts/modernizr.1aa3b519.js"></script>
     {% endblock %}
     {% block fonts %}
+      <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
       {% if font != false %}
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{
               font.text | replace(' ', '+')  + ':300,400,400i,700|' +


### PR DESCRIPTION
Fixes: #712
Add <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin> to the head makes a slight improvement to the page load speed.

There's a good article about it here:
https://cdnplanet.com/blog/faster-google-webfonts-preconnect