### PR TITLE
Use HTTPS for links to www.mkdocs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Material Design theme for [MkDocs][1].
 
 [![Material for MkDocs](docs/assets/images/material.png)][2]
 
-  [1]: http://www.mkdocs.org
+  [1]: https://www.mkdocs.org
   [2]: https://squidfunk.github.io/mkdocs-material/
 
 ## Quick start

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -13,7 +13,7 @@ necessary to preserve the desired style.
 few tweaks to an existing theme, you can just add your stylesheets and
 JavaScript files to the `docs` directory.
 
-  [1]: http://www.mkdocs.org
+  [1]: https://www.mkdocs.org
 
 ### Additional stylesheets
 
@@ -57,7 +57,7 @@ extra_javascript:
 
 Further assistance can be found in the [MkDocs documentation][2].
 
-  [2]: http://www.mkdocs.org/user-guide/styling-your-docs/#customizing-a-theme
+  [2]: https://www.mkdocs.org/user-guide/styling-your-docs/#customizing-a-theme
 
 ## Extending the theme
 
@@ -66,7 +66,7 @@ extend the theme. From version 0.16 on MkDocs implements [theme extension][3],
 an easy way to override parts of a theme without forking and changing the
 main theme.
 
-  [3]: http://www.mkdocs.org/user-guide/styling-your-docs/#using-the-theme_dir
+  [3]: https://www.mkdocs.org/user-guide/styling-your-docs/#using-the-theme-custom_dir
 
 ### Setup and theme structure
 
@@ -167,7 +167,7 @@ The Material theme provides the following template blocks:
 
 For more on this topic refer to the [MkDocs documentation][4]
 
-  [4]: http://www.mkdocs.org/user-guide/styling-your-docs/#overriding-template-blocks
+  [4]: https://www.mkdocs.org/user-guide/styling-your-docs/#overriding-template-blocks
 
 ## Theme development
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ pip install mkdocs && mkdocs --version
 
 Material requires MkDocs >= 0.17.1.
 
-  [1]: http://www.mkdocs.org
+  [1]: https://www.mkdocs.org
 
 ### Installing Material
 
@@ -537,7 +537,7 @@ set explicitly by setting `extra.repo_icon` to `github`, `gitlab` or
     guidance regarding the `edit_uri` attribute, which defines whether the edit
     button is shown or not.
 
-  [19]: http://www.mkdocs.org/user-guide/configuration/#edit_uri
+  [19]: https://www.mkdocs.org/user-guide/configuration/#edit_uri
 
 ### Adding social links
 
@@ -636,7 +636,7 @@ Material theme including more information regarding installation and usage:
 * [Permalinks][29]
 * [PyMdown Extensions][30]
 
-  [24]: http://www.mkdocs.org/user-guide/writing-your-docs/#markdown-extensions
+  [24]: https://www.mkdocs.org/user-guide/writing-your-docs/#markdown-extensions
   [25]: extensions/admonition.md
   [26]: extensions/codehilite.md
   [27]: extensions/footnotes.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ guidelines.
 
 [![Material for MkDocs](assets/images/material.png)](assets/images/material.png)
 
-  [1]: http://www.mkdocs.org
+  [1]: https://www.mkdocs.org
   [2]: https://material.io/guidelines/material-design/
 
 ## Quick start

--- a/material/partials/footer.html
+++ b/material/partials/footer.html
@@ -45,7 +45,7 @@
           </div>
         {% endif %}
         powered by
-        <a href="http://www.mkdocs.org">MkDocs</a>
+        <a href="https://www.mkdocs.org">MkDocs</a>
         and
         <a href="https://squidfunk.github.io/mkdocs-material/">
           Material for MkDocs</a>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -88,7 +88,7 @@
           </div>
         {% endif %}
         powered by
-        <a href="http://www.mkdocs.org">MkDocs</a>
+        <a href="https://www.mkdocs.org">MkDocs</a>
         and
         <a href="https://squidfunk.github.io/mkdocs-material/">
           Material for MkDocs</a>


### PR DESCRIPTION
To prevent the unnecessary HTTP 301 (and reduce the redirects noise when running the W3C link checker tool against generated pages).

Also fixes the anchor fragment for `#using-the-theme-custom_dir`.