### PR TITLE
Opening edit link in new tab

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -272,6 +272,7 @@
                 {% if page.edit_url %}
                   <a href="{{ page.edit_url }}"
                       title="{{ lang.t('edit.link.title') }}"
+                      target="_blank"
                       class="md-icon md-content__icon">&#xE3C9;<!-- edit --></a>
                 {% endif %}
 


### PR DESCRIPTION
I serve my project's MkDocs inside an iframe and GitLab prevents itself from being iframe'd, so when you click edit you get a nice big `Blocked by Content Security Policy` page.

Plus, I feel like this is a better user workflow anyway. This way you still have the original tab open to refer back to if needed while making edits.