### PR TITLE
Fix dependency conflict on tornado with latest mkdocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,3 @@
 mkdocs>=0.17.1
 Pygments>=2.2
 pymdown-extensions>=4.11
-
-# Temporary fix for build errors on Travis
-tornado<5


### PR DESCRIPTION
I'm getting `error: tornado 4.5.3 is installed but tornado>=5.0 is required by {'mkdocs'}` there is a conflict on tornado version dependency between `mkdocs-material` and `mkdocs`.

One way to fix it, is to try to lift off temporary workaround which was used to fix a travis build.
Another way would be to limit the version to `mkdocs<=0.17.5`.

Let's see what travis thinks about this.