### PR TITLE
Do not preconnect if Google Fonts are disabled

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -124,10 +124,9 @@
 
     <!-- Webfonts -->
     {% block fonts %}
-      <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
-
       <!-- Load fonts from Google -->
       {% if font != false %}
+        <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
         <link rel="stylesheet" type="text/css"
             href="https://fonts.googleapis.com/css?family={{
               font.text | replace(' ', '+')  + ':300,400,400i,700|' +


### PR DESCRIPTION
Even when Google Fonts are disabled for GDPR reasons, a preconnect to Google was still initiated, which transfers the user's IP to Google without consent. With this PR, the preconnect link is only added when fonts are enabled.