### PR TITLE
Use relative link for fetching of search index

### DIFF
--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -288,7 +288,7 @@ function initialize(config) { // eslint-disable-line func-style
     new Material.Event.Listener("[data-md-component=query]", [
       "focus", "keyup", "change"
     ], new Material.Search.Result("[data-md-component=result]", () => {
-      return fetch(`${config.url.base}/${
+      return fetch(`/${
         config.version < "0.17" ? "mkdocs" : "search"
       }/search_index.json`, {
         credentials: "same-origin"


### PR DESCRIPTION
We use:
mkdocs 1.0.4
mkdocs-material 3.0.4

Without that change we experienced an issue using the search on a 404 page.

It was trying to fetch `search_index.json` from `https://search/search_index.json` even though the `site_url` was correctly set in the configuration.

With this change it is fetched from the relative link `/search/search_index.json` and the browser applies this relative link to the domain link and it works for us.

Not sure if the usage of `config.url.base` in line 298 in the same file also needs to be changed.

Please let me know if you need more information e.g. about the configuration we use.