### PR TITLE
add support for redirects via metadata extension

### DIFF
--- a/docs/extensions/metadata.md
+++ b/docs/extensions/metadata.md
@@ -48,6 +48,21 @@ see on the current page when you scroll to the top. It's as simple as:
 ``` markdown
 hero: Metadata enables hero teaser texts
 ```
+### Redirects
+
+It's sometimes necessary to move documents around in the navigation tree and
+redirect user from the old URL to the new one. The `redirect:` meta-tag allows
+to create a redirection from the current document to the address specified in
+the tag.
+
+For instance, if your document contains:
+
+``` markdown
+redirect: /new/url
+
+```
+accessing that document's URL will automatically redirect to `/new/url`.
+
 
 ### Linking sources
 

--- a/src/main.html
+++ b/src/main.html
@@ -22,12 +22,12 @@
 
 {% if page.meta.redirect %}
 <script>
-    document.location.replace({{ page.meta.redirect }})
+    // redirect anchors
+    var anchor = window.location.hash.substr(1);
+    location.href = '{{ page.meta.redirect }}' + (anchor?'#'+anchor:'');
 </script>
-<meta http-equiv="refresh" content="0; url={{ page.meta.redirect }}"/>
-<link rel="canonical" href="{{ page.meta.redirect }} " />
-{% else %}
-
-{% extends "base.html" %}
-
+<!-- no-js fallback -->
+<meta http-equiv="refresh" content="0; url={{ page.meta.redirect }}">
+<link rel="canonical" href="{{ page.meta.redirect }}">
 {% endif %}
+{% extends "base.html" %}

--- a/src/main.html
+++ b/src/main.html
@@ -29,5 +29,6 @@
 <!-- no-js fallback -->
 <meta http-equiv="refresh" content="0; url={{ page.meta.redirect }}">
 <link rel="canonical" href="{{ page.meta.redirect }}">
+<meta name="robots" content="noindex">
 {% endif %}
 {% extends "base.html" %}

--- a/src/main.html
+++ b/src/main.html
@@ -22,7 +22,7 @@
 
 {% if page.meta.redirect %}
 <script>
-    location.href = '{{ page.meta.redirect }}')
+    document.location.replace({{ page.meta.redirect }})
 </script>
 <meta http-equiv="refresh" content="0; url={{ page.meta.redirect }}"/>
 <link rel="canonical" href="{{ page.meta.redirect }} " />

--- a/src/main.html
+++ b/src/main.html
@@ -20,4 +20,14 @@
   IN THE SOFTWARE.
 -->
 
+{% if page.meta.redirect %}
+<script>
+    location.href = '{{ page.meta.redirect }}')
+</script>
+<meta http-equiv="refresh" content="0; url={{ page.meta.redirect }}"/>
+<link rel="canonical" href="{{ page.meta.redirect }} " />
+{% else %}
+
 {% extends "base.html" %}
+
+{% endif %}


### PR DESCRIPTION
This PR proposes an easy way to create redirects from existing documents to other places (other documents or any URL, really). Which can prove useful when navigation tree reorganisation is needed.

It does so by adding a check for `page.meta.redirect` in `main.html` and then generating a simple js location.href / meta-refresh snippet to redirect the current page to the URL specified in the `redirect:` tag.

So for instance, if a `old_doc.md` document contains this:
```
redirect: /new/doc
```
accessing https://server/old_doc  will redirect to https://server/new/doc