### PR TITLE
lowercase doctype in HTML template

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -2,7 +2,7 @@
 {% set feature = config.theme.feature %}
 {% set palette = config.theme.palette %}
 {% set font = config.theme.font %}
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ lang.t('language') }}" class="no-js">
   <head>
     {% block site_meta %}

--- a/src/base.html
+++ b/src/base.html
@@ -27,7 +27,7 @@
 {% set palette = config.theme.palette %}
 {% set font = config.theme.font %}
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ lang.t('language') }}" class="no-js">
   <head>
 


### PR DESCRIPTION
This gzip compresses slightly better (can save 2 bytes!)

REF:
https://encode.ru/threads/1889-gzthermal-pseudo-thermal-view-of-Gzip-Deflate-compression-efficiency

https://github.com/h5bp/html5-boilerplate/blob/master/dist/index.html
https://getbootstrap.com/docs/4.1/getting-started/introduction/#starter-template