### PR TITLE
Add site_logo block for site logo customization

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -159,6 +159,7 @@ The Material theme provides the following template blocks:
 | `scripts`    | Wraps the JavaScript application logic          |
 | `source`     | Wraps the linked source files                   |
 | `search_box` | Wraps the search form in the header bar         |
+| `site_logo`  | Wraps the logo element in the header bar        |
 | `site_meta`  | Wraps the meta tags in the document head        |
 | `site_name`  | Wraps the site name in the header bar           |
 | `site_nav`   | Wraps the site navigation and table of contents |

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -32,11 +32,13 @@
         <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
             title="{{ config.site_name }}"
             class="md-header-nav__button md-logo">
-          {% if config.theme.logo.icon %}
-            <i class="md-icon">{{ config.theme.logo.icon }}</i>
-          {% else %}
-            <img src="{{ config.theme.logo | url }}" width="24" height="24" />
-          {% endif %}
+          {% block site_logo %}
+            {% if config.theme.logo.icon %}
+              <i class="md-icon">{{ config.theme.logo.icon }}</i>
+            {% else %}
+              <img src="{{ config.theme.logo | url }}" width="24" height="24" />
+            {% endif %}
+          {% endblock %}
         </a>
       </div>
 


### PR DESCRIPTION
Allow custom block for the logo, which will allow manual adjustments for that area.
Example use case - fixing broken logo images like this:
![Wrong svg size](https://i.imgur.com/iL2j4wa.png)