### PR TITLE
Add Python package metadata in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
     "documentation",
     "theme"
   ],
+  "classifiers": [
+      "Development Status :: 5 - Production/Stable",
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: JavaScript",
+      "Programming Language :: Python",
+      "Topic :: Documentation",
+      "Topic :: Text Processing :: Markup :: HTML"
+  ],
   "homepage": "https://squidfunk.github.io/mkdocs-material/",
   "bugs": {
     "url": "https://github.com/squidfunk/mkdocs-material/issues",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     author = package["author"]["name"],
     author_email = package["author"]["email"],
     keywords = package["keywords"],
+    classifiers = package["classifiers"],
     packages = find_packages(),
     include_package_data = True,
     install_requires = install_requires,


### PR DESCRIPTION
Added Classifiers metadata as [shown in the left column of mkdocs package](https://pypi.org/project/mkdocs/).

I felt that you value the convention of declaring and using metadata in `package.json`. So I did the same.

The specified classifiers were selected from the [list_classifiers](https://pypi.org/pypi?%3Aaction=list_classifiers). You can add other classifications as well.

This theme is a great idea and design. Thanks for your maintenance work.