### PR TITLE
Dockerfile: add README.md because setup.py requires

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY MANIFEST.in MANIFEST.in
 COPY package.json package.json
 COPY requirements.txt requirements.txt
 COPY setup.py setup.py
+COPY README.md README.md
 
 # Perform build and cleanup artifacts
 RUN \


### PR DESCRIPTION
Simple enough, `python setup.py install 2>/dev/null` was silenced.
On debugging seen that it seeks for `README.md`.

`setup.py` now uses `README.md`:
https://github.com/squidfunk/mkdocs-material/blob/62ca75e27d7d2f0aa7071eef2f684c0a64fd2862/setup.py#L35-L38

Closes: https://github.com/squidfunk/mkdocs-material/issues/1051