### PR TITLE
Changing the DOCTYPE case to support Mac build

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -27,7 +27,7 @@
 {% set palette = config.theme.palette %}
 {% set font = config.theme.font %}
 
-<!doctype html>
+<!DOCTYPE html>
 <html lang="{{ lang.t('language') }}" class="no-js">
   <head>
 


### PR DESCRIPTION
We've been experiencing some weird behavior using Azure DevOps and a Mac Agent where if the doctype was lower case, the generated doctype was : 

`<!doctype doctype html>` instead of `<!DOCTYPE html>`.

This fixes it.