### PR TITLE
Escape quotes in TOC title attributes

### DIFF
--- a/src/partials/toc-item.html
+++ b/src/partials/toc-item.html
@@ -22,7 +22,7 @@
 
 <!-- Table of contents item -->
 <li class="md-nav__item">
-  <a href="{{ toc_item.url }}" title="{{ toc_item.title }}"
+  <a href="{{ toc_item.url }}" title="{{ toc_item.title | e }}"
       class="md-nav__link">
     {{ toc_item.title }}
   </a>


### PR DESCRIPTION
When there are quotes in a heading, invalid HTML is produced. The item title therefore needs to be escaped in the template.