### PR TITLE
Display page.meta.title in nav bar (if given)

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -22,7 +22,11 @@
               {{ config.site_name }}
             </span>
             <span class="md-header-nav__topic">
-              {{ page.title }}
+              {% if page and page.meta and page.meta.title %}
+                {{ page.meta.title }}
+              {% else %}
+                {{ page.title }}
+              {% endif %}
             </span>
           {% endif %}
         </div>


### PR DESCRIPTION
This PR patches `partials/header.html` to display the `page.meta.title` given in page metadata (using the `meta` extension), if given, otherwise uses the normal `page.title`.