### PR TITLE
Fix incorrect escaping of site_name, remove some title attributes

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -306,7 +306,7 @@
                   as the main headline.
                 -->
                 {%- if not "\x3ch1" in page.content -%}
-                  <h1>{{ page.title | default(e(config.site_name), true)}}</h1>
+                  <h1>{{ page.title | default(config.site_name | e, true)}}</h1>
                 {%- endif -%}
 
                 <!-- Content -->

--- a/src/base.html
+++ b/src/base.html
@@ -42,16 +42,16 @@
       <!-- Page description -->
       {%- if page and page.meta and page.meta.description -%}
         <meta name="description"
-            content="{{ page.meta.description }}" />
+            content="{{ page.meta.description | e }}" />
       {%- elif config.site_description -%}
-        <meta name="description" content="{{ config.site_description }}" />
+        <meta name="description" content="{{ config.site_description | e }}" />
       {%- endif -%}
 
       <!-- Redirect -->
       {%- if page and page.meta and page.meta.redirect -%}
         <script>
           var anchor = window.location.hash.substr(1)
-          location.href = '{{ page.meta.redirect }}' +
+          location.href = {{ page.meta.redirect | tojson | safe }} +
             (anchor ? '#' + anchor : '')
         </script>
 
@@ -67,9 +67,9 @@
 
       <!-- Page author -->
       {%- if page and page.meta and page.meta.author -%}
-        <meta name="author" content="{{ page.meta.author | first }}" />
+        <meta name="author" content="{{ page.meta.author | e }}" />
       {%- elif config.site_author -%}
-        <meta name="author" content="{{ config.site_author }}" />
+        <meta name="author" content="{{ config.site_author | e }}" />
       {%- endif -%}
 
       <!-- Localization -->

--- a/src/base.html
+++ b/src/base.html
@@ -99,11 +99,11 @@
     <!-- Site title -->
     {%- block htmltitle -%}
       {%- if page and page.meta and page.meta.title -%}
-        <title>{{ page.meta.title }}</title>
+        <title>{{ page.meta.title | e }}</title>
       {%- elif page and page.title and not page.is_homepage -%}
-        <title>{{ page.title }} - {{ config.site_name }}</title>
+        <title>{{ page.title }} - {{ config.site_name | e }}</title>
       {%- else -%}
-        <title>{{ config.site_name }}</title>
+        <title>{{ config.site_name | e }}</title>
       {%- endif -%}
     {%- endblock -%}
 

--- a/src/base.html
+++ b/src/base.html
@@ -306,7 +306,7 @@
                   as the main headline.
                 -->
                 {%- if not "\x3ch1" in page.content -%}
-                  <h1>{{ page.title | default(config.site_name, true)}}</h1>
+                  <h1>{{ page.title | default(e(config.site_name), true)}}</h1>
                 {%- endif -%}
 
                 <!-- Content -->
@@ -323,7 +323,7 @@
                     {%- set path = page.meta.path | default([""]) -%}
                     {%- set file = page.meta.source -%}
                     <a href="{{ [repo, path, file] | join('/') }}"
-                        title="{{ file }}" class="md-source-file">
+                        class="md-source-file">
                       {{ file }}
                     </a>
                   {%- endif -%}

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -30,7 +30,7 @@
       <!-- Link to home -->
       <div class="md-flex__cell md-flex__cell--shrink">
         <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
-            title="{{ config.site_name }}"
+            title="{{ config.site_name | e }}"
             class="md-header-nav__button md-logo">
           {%- if config.theme.logo.icon -%}
             <i class="md-icon">{{- config.theme.logo.icon -}}</i>
@@ -51,10 +51,10 @@
         <div class="md-flex__ellipsis md-header-nav__title"
             data-md-component="title">
           {%- if config.site_name == page.title -%}
-            {{ config.site_name }}
+            {{ config.site_name | e }}
           {%- else -%}
             <span class="md-header-nav__topic">
-              {{- config.site_name -}}
+              {{- config.site_name | e -}}
             </span>
             <span class="md-header-nav__topic">
               {%- if page and page.meta and page.meta.title -%}

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -58,7 +58,7 @@
             </span>
             <span class="md-header-nav__topic">
               {%- if page and page.meta and page.meta.title -%}
-                {{- page.meta.title -}}
+                {{- page.meta.title | e -}}
               {%- else -%}
                 {{- page.title -}}
               {%- endif -%}

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -26,14 +26,14 @@
   <!-- Site title -->
   <label class="md-nav__title md-nav__title--site" for="__drawer">
     <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
-        title="{{ config.site_name }}" class="md-nav__button md-logo">
+        title="{{ config.site_name | e }}" class="md-nav__button md-logo">
       {%- if config.theme.logo.icon -%}
         <i class="md-icon">{{- config.theme.logo.icon -}}</i>
       {%- else -%}
         <img src="{{ config.theme.logo | url }}" width="48" height="48" />
       {%- endif -%}
     </a>
-    {{- config.site_name -}}
+    {{- config.site_name | e -}}
   </label>
 
   <!-- Repository containing source -->

--- a/src/partials/tabs-item.html
+++ b/src/partials/tabs-item.html
@@ -24,12 +24,12 @@
 {%- if nav_item.is_homepage -%}
   <li class="md-tabs__item">
     {%- if not page.ancestors | length and nav | selectattr("url", page.url) -%}
-      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
+      <a href="{{ nav_item.url | url }}"
           class="md-tabs__link md-tabs__link--active">
         {{- nav_item.title -}}
       </a>
     {%- else -%}
-      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
+      <a href="{{ nav_item.url | url }}"
           class="md-tabs__link">
         {{- nav_item.title -}}
       </a>
@@ -50,12 +50,12 @@
     <li class="md-tabs__item">
       {%- if nav_item.active -%}
         <a href="{{ (nav_item.children | first).url | url }}"
-            title="{{ title }}" class="md-tabs__link md-tabs__link--active">
+            class="md-tabs__link md-tabs__link--active">
           {{- title -}}
         </a>
       {%- else -%}
         <a href="{{ (nav_item.children | first).url | url }}"
-            title="{{ title }}" class="md-tabs__link">
+            class="md-tabs__link">
           {{- title -}}
         </a>
       {%- endif -%}

--- a/src/partials/toc-item.html
+++ b/src/partials/toc-item.html
@@ -22,7 +22,7 @@
 
 <!-- Table of contents item -->
 <li class="md-nav__item">
-  <a href="{{ toc_item.url }}" title="{{ toc_item.title }}"
+  <a href="{{ toc_item.url }}"
       class="md-nav__link">
     {{- toc_item.title -}}
   </a>


### PR DESCRIPTION
This ensures that config.site_name is escaped correctly in all places, while also removing the title attributes discussed in #1100.