### PR TITLE
Add role=main to main element for accessibility improvement for IE users

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -255,7 +255,7 @@
       {% endif %}
 
       <!-- Main container -->
-      <main class="md-main">
+      <main class="md-main" role="main">
         <div class="md-main__inner md-grid" data-md-component="container">
 
           <!-- Navigation -->


### PR DESCRIPTION
> The `<main>` element is widely supported. For Internet Explorer 11 and lower, it's suggested that an ARIA role of "main" be added to the `<main>` element to ensure it is accessible (screen readers like JAWS, used in combination with older versions of Internet Explorer, understand the semantic meaning of the `<main>` element when this role attribute is included).

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main#Browser_compatibility