### PR TITLE
Remove unneeded title attribute from text links in nav and sidemenu

### DIFF
--- a/src/partials/tabs-item.html
+++ b/src/partials/tabs-item.html
@@ -24,13 +24,11 @@
 {% if nav_item.is_homepage %}
   <li class="md-tabs__item">
     {% if not page.ancestors | length and nav | selectattr("url", page.url) %}
-      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
-          class="md-tabs__link md-tabs__link--active">
+      <a href="{{ nav_item.url | url }}" class="md-tabs__link md-tabs__link--active">
         {{ nav_item.title }}
       </a>
     {% else %}
-      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
-          class="md-tabs__link">
+      <a href="{{ nav_item.url | url }}" class="md-tabs__link">
         {{ nav_item.title }}
       </a>
     {% endif %}
@@ -50,12 +48,12 @@
     <li class="md-tabs__item">
       {% if nav_item.active %}
         <a href="{{ (nav_item.children | first).url | url }}"
-            title="{{ title }}" class="md-tabs__link md-tabs__link--active">
+            class="md-tabs__link md-tabs__link--active">
           {{ title }}
         </a>
       {% else %}
         <a href="{{ (nav_item.children | first).url | url }}"
-            title="{{ title }}" class="md-tabs__link">
+            class="md-tabs__link">
           {{ title }}
         </a>
       {% endif %}

--- a/src/partials/toc-item.html
+++ b/src/partials/toc-item.html
@@ -22,8 +22,7 @@
 
 <!-- Table of contents item -->
 <li class="md-nav__item">
-  <a href="{{ toc_item.url }}" title="{{ toc_item.title }}"
-      class="md-nav__link">
+  <a href="{{ toc_item.url }}" class="md-nav__link">
     {{ toc_item.title }}
   </a>
 


### PR DESCRIPTION
Fixes: #1207

This PR removes the unneeded title attribute from text links in nav and side-menu. There are a few other instances of title attributes being used, but I left them for the time being. The ones in the footer aren't so annoying and hovering over the 'next page' `>` icon and seeing page title could be helpful to some.