### PR TITLE
Output minified JavaScript and CSS files with the '.min.js' or '.min.css' file extension

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,7 +138,7 @@ module.exports = (_env, args) => { // eslint-disable-line complexity
     /* Output */
     output: {
       path: path.resolve(__dirname, "material"),
-      filename: `[name]${args.mode === "production" ? ".[chunkhash]" : ""}.js`,
+      filename: `[name]${args.mode === "production" ? ".[chunkhash]" : ""}.min.js`,
       hashDigestLength: 8,
       libraryTarget: "window"
     },
@@ -160,7 +160,8 @@ module.exports = (_env, args) => { // eslint-disable-line complexity
            plugins will complain about. For this reason we only minify */
         {
           context: path.resolve(__dirname, "node_modules/lunr-languages"),
-          to: "assets/javascripts/lunr",
+          to: "assets/javascripts/lunr/[name].min.js",
+          toType: "template",
           from: "*.js",
           transform: content => {
             return uglify.minify(content.toString()).code

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,7 @@ module.exports = (_env, args) => { // eslint-disable-line complexity
               options: {
                 name: `[name]${
                   args.mode === "production" ? ".[md5:hash:hex:8]" : ""
-                }.css`,
+                }.min.css`,
                 outputPath: "assets/stylesheets",
                 publicPath: path.resolve(__dirname, "material")
               }
@@ -178,6 +178,8 @@ module.exports = (_env, args) => { // eslint-disable-line complexity
         /* Copy and minify web font stylesheets */
         {
           context: "src",
+          to: "assets/fonts/[name].min.css",
+          toType: "template",
           from: "assets/fonts/*.css",
           transform: content => cssmin(content.toString())
         },


### PR DESCRIPTION
These patches modify webpack.config.js to output JavaScript and CSS files with the minified file extension.

It fixes #1247 and #1248.