### PR TITLE
Missing repo_url results in "/", not a falsy value

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -40,7 +40,7 @@
           {% include "partials/search.html" %}
         {% endif %}
       </div>
-      {% if config.repo_url %}
+      {% if config.repo_url != "/" %}
         <div class="md-flex__cell md-flex__cell--shrink">
           <div class="md-header-nav__source">
             {% include "partials/source.html" %}

--- a/material/partials/nav.html
+++ b/material/partials/nav.html
@@ -12,7 +12,7 @@
     </a>
     {{ config.site_name }}
   </label>
-  {% if config.repo_url %}
+  {% if config.repo_url != "/" %}
     <div class="md-nav__source">
       {% include "partials/source.html" %}
     </div>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -79,7 +79,7 @@
       </div>
 
       <!-- Repository containing source -->
-      {% if config.repo_url %}
+      {% if config.repo_url != "/" %}
         <div class="md-flex__cell md-flex__cell--shrink">
           <div class="md-header-nav__source">
             {% include "partials/source.html" %}

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -37,7 +37,7 @@
   </label>
 
   <!-- Repository containing source -->
-  {% if config.repo_url %}
+  {% if config.repo_url != "/" %}
     <div class="md-nav__source">
       {% include "partials/source.html" %}
     </div>


### PR DESCRIPTION
Ran into a bit of a config edge case with mkdocs-material.

Looking at the readme, it seems like we should be able to omit `repo_url` from the `mkdocs.yml` to hide the link to a source repository. This does work, but only partially, the `div` that contains this link is not removed, and still takes up space in the navigation bar. See below image for an example, there is a lot of white space to the right of the search bar:

![before](https://user-images.githubusercontent.com/568079/66017065-3288ac80-e4a7-11e9-8887-d1987d0332e6.PNG)

After a bit of investigating, I found that simply omitting the `repo_url` from the `mkdocs.yml` config results in `repo_url` being `"/"`, not `None` or `""`.

This seems strange, and I'll admit my Python-fu isn't the strongest, so maybe there is a way to explicitly set `repo_url` to a falsy value instead of `"/"`.

This PR simply modifies the templates to check for `"/"` instead of a falsy value to hide this section from the page.

This does fix the issue, see below image:
![after](https://user-images.githubusercontent.com/568079/66017145-8abfae80-e4a7-11e9-836c-a9717e8ed8da.PNG)


I am definitely open to suggestions to my approach! Fixing the config to actually set `repo_url` to a falsy value feels like the proper approach for this, but I can't figure out where to do that. Maybe in mkdocs upstream?