### PR TITLE
Feature/custom color values

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,6 +165,17 @@ Design color palette. Valid values are: `red`, `pink`, `purple`, `deep purple`,
 `yellow`, `amber`, `orange`, `deep orange`, `brown`, `grey`, `blue grey` and
 `white`. The last four colors can only be used as a primary color.
 
+You may also define custom hex values instead of the names to easily adapt the
+theme to your style. Since this is dynamic and cannot be statically embedded
+into CSS, these values are updated once the page is loaded.
+
+``` yaml
+theme:
+  palette:
+    primary: '#123456'
+    accent: '#789ABC'
+```
+
 If the color is set via this configuration, an additional CSS file that
 defines the color palette is automatically included. If you want to keep things
 lean, clone the repository and recompile the theme with your custom colors set.

--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -84,6 +84,20 @@ function initialize(config) { // eslint-disable-line func-style
       return !!navigator.userAgent.match(/(iPad|iPhone|iPod)/g)
     })
 
+    // TODO bind this to variable?
+    const colorPrimary = document.body.dataset.mdColorPrimary
+    if (colorPrimary.startsWith("#")) {
+      document.body.style.setProperty("--primary-color", colorPrimary)
+      // TODO how to calculate --primary-color-dark
+    }
+
+    // TODO bind this to variable?
+    const colorAccent = document.body.dataset.mdColorAccent
+    if (colorAccent.startsWith("#")) {
+      document.body.style.setProperty("--accent-color", colorAccent)
+      // TODO how to calculate --accent-color-hover
+    }
+
     /* Wrap all data tables for better overflow scrolling */
     const tables = document.querySelectorAll("table:not([class])")              // TODO: this is JSX, we should rename the file
     Array.prototype.forEach.call(tables, table => {

--- a/src/assets/stylesheets/application-palette.scss
+++ b/src/assets/stylesheets/application-palette.scss
@@ -42,6 +42,14 @@
 // ----------------------------------------------------------------------------
 
 // Color tile for presentation in theme documentation
+button[data-md-color-primary] {
+  background-color: var(--primary-color);
+}
+
+button[data-md-color-accent] {
+  background-color: var(--accent-color);
+}
+
 button[data-md-color-primary],
 button[data-md-color-accent] {
   width: px2rem(130px);
@@ -66,88 +74,64 @@ button[data-md-color-accent] {
 // Rules: primary colors
 // ----------------------------------------------------------------------------
 
-// Build primary colors
-@each $name, $color in (
-  "red":         $clr-red-400,
-  "pink":        $clr-pink-500,
-  "purple":      $clr-purple-400,
-  "deep-purple": $clr-deep-purple-400,
-  "indigo":      $clr-indigo-500,
-  "blue":        $clr-blue-500,
-  "light-blue":  $clr-light-blue-500,
-  "cyan":        $clr-cyan-500,
-  "teal":        $clr-teal-500,
-  "green":       $clr-green-500,
-  "light-green": $clr-light-green-600,
-  "lime":        $clr-lime-600,
-  "yellow":      $clr-yellow-800,
-  "amber":       $clr-amber-700,
-  "orange":      $clr-orange-600,
-  "deep-orange": $clr-deep-orange-400,
-  "brown":       $clr-brown-500,
-  "grey":        $clr-grey-600,
-  "blue-grey":   $clr-blue-grey-600
-) {
+@mixin primary-color-variables($color) {
+  --primary-color: #{$color};
+  --primary-color-dark: #{mix($color, $md-color-black, 75%)};
+}
 
-  // Color tile for presentation in theme documentation
-  button[data-md-color-primary="#{$name}"] {
-    background-color: $color;
+[data-md-color-primary] {
+  @include primary-color-variables($md-color-primary);
+
+  // Links in typesetted content
+  .md-typeset a {
+    color: var(--primary-color);
   }
 
-  // Color palette
-  [data-md-color-primary="#{$name}"] {
+  // Application header (stays always on top)
+  .md-header {
+    background-color: var(--primary-color);
+  }
 
-    // Links in typesetted content
-    .md-typeset a {
-      color: $color;
+  // Hero teaser
+  .md-hero {
+    background-color: var(--primary-color);
+  }
+
+  // Current or active link
+  .md-nav__link:active,
+  .md-nav__link--active {
+    color: var(--primary-color);
+  }
+
+  // Reset active color for nested list titles
+  .md-nav__item--nested > .md-nav__link {
+    color: inherit;
+  }
+
+  // [tablet portrait -]: Layered navigation
+  @include break-to-device(tablet portrait) {
+
+    // Repository containing source
+    .md-nav__source {
+      background-color: var(--primary-color-dark);
     }
+  }
 
-    // Application header (stays always on top)
-    .md-header {
-      background-color: $color;
+  // [tablet -]: Layered navigation
+  @include break-to-device(tablet) {
+
+    // Site title in main navigation
+    html & .md-nav--primary .md-nav__title--site {
+      background-color: var(--primary-color);
     }
+  }
 
-    // Hero teaser
-    .md-hero {
-      background-color: $color;
-    }
+  // [screen +]: Set background color for tabs
+  @include break-from-device(screen) {
 
-    // Current or active link
-    .md-nav__link:active,
-    .md-nav__link--active {
-      color: $color;
-    }
-
-    // Reset active color for nested list titles
-    .md-nav__item--nested > .md-nav__link {
-      color: inherit;
-    }
-
-    // [tablet portrait -]: Layered navigation
-    @include break-to-device(tablet portrait) {
-
-      // Repository containing source
-      .md-nav__source {
-        background-color: mix($color, $md-color-black, 75%);
-      }
-    }
-
-    // [tablet -]: Layered navigation
-    @include break-to-device(tablet) {
-
-      // Site title in main navigation
-      html & .md-nav--primary .md-nav__title--site {
-        background-color: $color;
-      }
-    }
-
-    // [screen +]: Set background color for tabs
-    @include break-from-device(screen) {
-
-      // Tabs with outline
-      .md-tabs {
-        background-color: $color;
-      }
+    // Tabs with outline
+    .md-tabs {
+      background-color: var(--primary-color);
     }
   }
 }
@@ -297,6 +281,108 @@ button[data-md-color-primary="black"] {
 // Rules: accent colors
 // ----------------------------------------------------------------------------
 
+@mixin accent-color-variables($color) {
+  --accent-color: #{$color};
+  --accent-color-hover: #{transparentize($color, 0.9)};
+}
+
+[data-md-color-accent] {
+  @include accent-color-variables($md-color-accent);
+
+  // Typesetted content
+  .md-typeset {
+
+    // Hovered and active links
+    a:hover,
+    a:active {
+      color: var(--accent-color);
+    }
+
+    // Hovered scrollbar thumb
+    pre code::-webkit-scrollbar-thumb:hover,
+    .codehilite pre::-webkit-scrollbar-thumb:hover {
+      background-color: var(--accent-color);
+    }
+
+    // Copy to clipboard active icon
+    .md-clipboard:hover::before,
+    .md-clipboard:active::before {
+      color: var(--accent-color);
+    }
+
+    // Active or targeted back reference
+    .footnote li:hover  .footnote-backref:hover,
+    .footnote li:target .footnote-backref {
+      color: var(--accent-color);
+    }
+
+    // Active, targeted or focused permalink
+    [id]:hover  .headerlink:hover,
+    [id]:target .headerlink,
+    [id] .headerlink:focus {
+      color: var(--accent-color);
+    }
+  }
+
+  // Focused or hovered link
+  .md-nav__link:focus,
+  .md-nav__link:hover {
+    color: var(--accent-color);
+  }
+
+  // Search container scrollbar thumb
+  .md-search__scrollwrap::-webkit-scrollbar-thumb:hover {
+    background-color: var(--accent-color);
+  }
+
+  // Search result link
+  .md-search-result__link {
+
+    // Active or hovered link
+    &[data-md-state="active"],
+    &:hover {
+      background-color: var(--accent-color-hover);
+    }
+  }
+
+  // Wrapper for scrolling on overflow
+  .md-sidebar__scrollwrap::-webkit-scrollbar-thumb:hover {
+    background-color: var(--accent-color);
+  }
+
+  // Source file icon
+  .md-source-file:hover::before {
+    background-color: var(--accent-color);
+  }
+}
+
+// Build primary colors
+@each $name, $color in (
+  "red":         $clr-red-400,
+  "pink":        $clr-pink-500,
+  "purple":      $clr-purple-400,
+  "deep-purple": $clr-deep-purple-400,
+  "indigo":      $clr-indigo-500,
+  "blue":        $clr-blue-500,
+  "light-blue":  $clr-light-blue-500,
+  "cyan":        $clr-cyan-500,
+  "teal":        $clr-teal-500,
+  "green":       $clr-green-500,
+  "light-green": $clr-light-green-600,
+  "lime":        $clr-lime-600,
+  "yellow":      $clr-yellow-800,
+  "amber":       $clr-amber-700,
+  "orange":      $clr-orange-600,
+  "deep-orange": $clr-deep-orange-400,
+  "brown":       $clr-brown-500,
+  "grey":        $clr-grey-600,
+  "blue-grey":   $clr-blue-grey-600
+) {
+  [data-md-color-primary="#{$name}"] {
+    @include primary-color-variables($color);
+  }
+}
+
 // Build accent colors
 @each $name, $color in (
   "red":         $clr-red-a400,
@@ -316,79 +402,7 @@ button[data-md-color-primary="black"] {
   "orange":      $clr-orange-a400,
   "deep-orange": $clr-deep-orange-a200
 ) {
-
-  // Color tile for presentation in theme documentation
-  button[data-md-color-accent="#{$name}"] {
-    background-color: $color;
-  }
-
-  // Color palette
   [data-md-color-accent="#{$name}"] {
-
-    // Typesetted content
-    .md-typeset {
-
-      // Hovered and active links
-      a:hover,
-      a:active {
-        color: $color;
-      }
-
-      // Hovered scrollbar thumb
-      pre code::-webkit-scrollbar-thumb:hover,
-      .codehilite pre::-webkit-scrollbar-thumb:hover {
-        background-color: $color;
-      }
-
-      // Copy to clipboard active icon
-      .md-clipboard:hover::before,
-      .md-clipboard:active::before {
-        color: $color;
-      }
-
-      // Active or targeted back reference
-      .footnote li:hover  .footnote-backref:hover,
-      .footnote li:target .footnote-backref {
-        color: $color;
-      }
-
-      // Active, targeted or focused permalink
-      [id]:hover  .headerlink:hover,
-      [id]:target .headerlink,
-      [id] .headerlink:focus {
-        color: $color;
-      }
-    }
-
-    // Focused or hovered link
-    .md-nav__link:focus,
-    .md-nav__link:hover {
-      color: $color;
-    }
-
-    // Search container scrollbar thumb
-    .md-search__scrollwrap::-webkit-scrollbar-thumb:hover {
-      background-color: $color;
-    }
-
-    // Search result link
-    .md-search-result__link {
-
-      // Active or hovered link
-      &[data-md-state="active"],
-      &:hover {
-        background-color: transparentize($color, 0.9);
-      }
-    }
-
-    // Wrapper for scrolling on overflow
-    .md-sidebar__scrollwrap::-webkit-scrollbar-thumb:hover {
-      background-color: $color;
-    }
-
-    // Source file icon
-    .md-source-file:hover::before {
-      background-color: $color;
-    }
+    @include accent-color-variables($color);
   }
 }


### PR DESCRIPTION
This PR should address some issues for custom color values as primary and accent color. Secondly, this also provides a step towards dynamic themes (i.e. dark and light theme) as discussed in #1266.

#### Disclaimer

I know that this is customizable with the Google Material Design Palette, or by compiling your own theme while changing the values in `_config.scss`. However, I think, this is a great effort and needs constant updates to stay up to date with your work (contrary to your [comment](https://github.com/squidfunk/mkdocs-material/issues/73#issuecomment-268190426)).

Secondly, please feel free to improve, remove or discard my changes, as you see fit. I will adjust any comments from your side. If so, I will happily fall back to the existing solutions.

### State of the PR (see commits)

This PR allows the customization for the theme by not just allowing a fixed number of theme colors, but also an arbitrary hex string as color code. This is done with two steps:

1. Use variables to change address the color codes such that they can be changed with one line and at runtime.
    1. Introduce mixins for easy variable generation
    2. Define the base theme which is overwritten by more specialized (i.e color palette themes)
2. Use JavaScript to read, parse the color code and update the variable. _The real magic happens here_.

I also provided a draft to update to the documentation.

#### Things to consider

Since the color code is updated with JavaScript&mdash;which takes a few milliseconds to load&mdash;there is a transition from the default theme to the color code. This could be addressed by following proposals:

1. Use a separate variable, so that one can choose a close color palette and the change is not that drastic.
2. Disable the color transition on initial load, which might be faster initially but potentially more disturbing.

_You might need to format the code with your formatter._

#### Compatibility

This PR uses CSS variables and `var()`, which is [supported](https://developer.mozilla.org/en-US/docs/Web/CSS/var) by almost every browser (except IE).

_However, if you strive for full support (even really old versions), please feel free to dismiss this PR._

#### Future Work

1. I did not provide the updated theme as I am not sure if these are platform dependent.
2. The JavaScript can/has to be improved, as I did not want to spent too much time digging through your code. Thus this is implemented rather rudimentary.
    * Add change listeners to update the values automatically. This would update the theme every time the `data-md-color-primary` and `data-md-color-accent` changes.
    * Derive the rest of the colors from the base color to update the theme. This is still supported through the palette colors, but not possible in CSS as `mix` and `transparentize` or similar Sass-Functions [do not work](https://stackoverflow.com/q/55823860) with variables at the moment.
3. It might be worth to have a input field within the documentation, similar to your palette buttons to change the theme dynamically.

_If needed, I will create an issue to track further work._

#### Build

This PR was built and tested on both Windows and WSL (Debian) with [recheck-web](https://github.com/retest/recheck-web) before and after the build with no changes&mdash;testing major browsers and all specified [resolutions](https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/_config.scss#L38).

_Disclaimer: I am one of the developers of recheck-web._