### PR TITLE
reduce number of github requests

### DIFF
--- a/src/assets/javascripts/components/Material/Source/Adapter/GitHub.js
+++ b/src/assets/javascripts/components/Material/Source/Adapter/GitHub.js
@@ -59,8 +59,8 @@ export default class GitHub extends Abstract {
    * @return {Promise<Array<string>>} Promise returning an array of facts
    */
   fetch_() {
-    const paginate = (page = 0) => {
-      return fetch(`${this.base_}?per_page=30&page=${page}`)
+    const paginate = (page = 0) => (
+      fetch(`${this.base_}?per_page=100&sort=updated&page=${page}`)
         .then(response => response.json())
         .then(data => {
           if (!(data instanceof Array))
@@ -87,7 +87,7 @@ export default class GitHub extends Abstract {
             ]
           }
         })
-    }
+    )
 
     /* Paginate through repos */
     return paginate()


### PR DESCRIPTION
Should significantly reduce the number of requests made to github to get forks and stars, by:
* increasing the number of items per page to 100 (the maximum allowed)
* ordering by update timestamp (descending since that's the default) - this is based on the assumption that projects with mkdocs sites are likely to be updated regularly and are therefore likely to be found sooner with this approach.

I found this since for https://pydantic-docs.helpmanual.io/ i noticed:
![image](https://user-images.githubusercontent.com/4039449/66479222-03b89a80-ea94-11e9-89dc-ffff77668b23.png)


This is worthwhile since:
* it should reduce the delay until the stars/forks are shown
* it should use less bandwidth and battery to render the page
* nice to reduce the load on github's servers
