### PR TITLE
Fix too many github requests exceed rate limit

### DIFF
--- a/src/assets/javascripts/components/Material/Source/Adapter/GitHub.js
+++ b/src/assets/javascripts/components/Material/Source/Adapter/GitHub.js
@@ -64,7 +64,7 @@ export default class GitHub extends Abstract {
         .then(response => response.json())
         .then(data => {
           if (!(data instanceof Array))
-            throw new TypeError
+            return []
 
           /* Display number of stars and forks, if repository is given */
           if (this.name_) {


### PR DESCRIPTION
> TL;DR
    This fixes that an error is thrown, if Github reports an exceeded rate limit due to many concurrent sessions, thus allowing the UI to initialize properly (i.e. set an `data-md-state=done` on the Github source facts))

# Problem

When opening multiple browser sessions and opening the MkDocs website with a Github repository enabled, you eventually will receive a 403 (i.e. exceeded rate limit). While that itself is not visible inside the application, it still recognizes inside the HTML, thus leaving behind an inconsistent state. Let me explain ...

I am currently writing tests for a [documentation](https://docs.retest.de/) that incorporates your material theme. 

1. Each test creates a new browser (i.e. fresh session) that accesses the website.
2. It waits until the site is stable, which is important to achieve consistent test states (using [`ExpectedConditions`](https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)). That means it waits until all animations have been played. The most consistent test for different resolutions and Browsers is to wait for `md-data-state=done` to be set in the Github facts. Other methods e.g. waiting for visible elements are inconsistent between resolutions and waiting a fixed time firstly slows down the test and secondly does not work reliable.
3. It executes some actions (e.g. perform clicks, enter searches, etc)

However, together they easily overflow the [default limit](https://developer.github.com/v3/#rate-limiting) of 60 requests/hour.

## Cause

1. I looked at `Github.js` which executes does pagination ([inefficiently](https://developer.github.com/v3/guides/traversing-with-pagination/)) and writes the result into a cookie which is queried instead. This, however, is pointless with separate browser instances.
2. Once Github rejects the REST call, a 403 is returned, which is no Array, thus an [error](https://github.com/squidfunk/mkdocs-material/blob/1127db13b06326d2eecff365254215959d1628a1/src/assets/javascripts/components/Material/Source/Adapter/GitHub.js#L67) it thrown.
    ```
    {
        "message": "API rate limit exceeded for XX.XXX.XXX.XX. (But here's the good news: Authenticated 
        requests get a higher rate limit. Check out the documentation for more details.)",
        "documentation_url": "https://developer.github.com/v3/#rate-limiting"
    }
    ```
3. The [UI](https://github.com/squidfunk/mkdocs-material/blob/1127db13b06326d2eecff365254215959d1628a1/src/assets/javascripts/application.js#L503) code does not check for errors and thus does not update the `data-md-state` to `done`.
4. Timeout in my tests (thus failing tests, since the `data-md-state` is never set.

## Solutions

Short term (i.e. on my end):

1. Set Cookies inside tests: You generate a hash `salt_` and write the result in it. While this would seem like the preferred solution to mock the test behavior, it is of course not designed to be used as such, as the key with the value is generated (seemingly) random: `2128506368.cache-source: [%222.7k%20Stars%22%2C%22724%20Forks%22]`
2. Checking incomplete state: While I am able to ignore some differences, I would prefer to have a stable baseline for the tests to minimize occurring differences.

Long term (i.e. on your end), which may be worked into your rewrite to TypeScript:

1. Do proper error handling (i.e. check response status codes).
2. Silently ignore the warning (as done in this PR).