### PR TITLE
Fix EmojiOne URL to prevent a HTTP redirect

### DIFF
--- a/docs/extensions/pymdown.md
+++ b/docs/extensions/pymdown.md
@@ -194,7 +194,7 @@ emojis. Happy scrolling :tada:
 
   [13]: https://facelessuser.github.io/pymdown-extensions/extensions/emoji/
   [14]: https://emoji.codes/
-  [15]: http://emojione.com
+  [15]: https://www.joypixels.com/
   [16]: https://creativecommons.org/licenses/by/4.0/legalcode
   [17]: http://emojione.com/licensing/
 


### PR DESCRIPTION
EmojiOne is now JoyPixels
https://blog.joypixels.com/emojione-is-now-joypixels/