### PR TITLE
Use Twemoji by default and document how to use Twemoji

### DIFF
--- a/docs/extensions/pymdown.md
+++ b/docs/extensions/pymdown.md
@@ -183,69 +183,89 @@ all Admonition qualifiers can be used, e.g. `note`, `question`, `warning` etc.:
 ### Emoji
 
 [Emoji][13] adds the ability to insert a :shit:-load of emojis that we use in
-our daily lives. See the [EmojiOne demo][14] for a list of all available
-emojis. Happy scrolling :tada:
+our daily lives.
+
+By default, [Emoji][13] uses JoyPixles' emoji under the former name EmojiOne.
+Recent versions of the extension lock support to an older version (2.2.7) due
+to JoyPixels' newer, less permissible licenses included in later releases. This
+restricts support to Unicode 9. To get the latest support for the current
+Unicode version, you can use Twemoji instead which has a much more permissable
+license. Simply override the default emoji index being used:
+
+```yml
+markdown_extensions:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:pymdownx.emoji.twemoji
+      emoji_generator: !!python/name:pymdownx.emoji.to_svg
+```
+
+To view all the available short names and emoji available, see [Emoji's documentation][18]
+on your chosen index which includes links to the files containing the short names
+and emoji associated with each supported index. Happy scrolling :tada:.
 
 !!! warning "Legal disclaimer"
 
-    Material has no affiliation with [EmojiOne][15] which is released under
-    [CC BY 4.0][16]. When including EmojiOne images or CSS, please read the
-    [EmojiOne license][17] to ensure proper usage and attribution.
+    Material has no affiliation with [JoyPixles][15] or [Twemoji][14], both
+    of which use releases that are under [CC BY 4.0][16]. When including
+    images or CSS from either provider, please read the the respective
+    licenses: [EmojiOne][17] or [Twemoji][14] to ensure proper usage and
+    attribution.
 
   [13]: https://facelessuser.github.io/pymdown-extensions/extensions/emoji/
-  [14]: https://emoji.codes/
+  [14]: https://twemoji.twitter.com/
   [15]: https://www.joypixels.com/
   [16]: https://creativecommons.org/licenses/by/4.0/legalcode
-  [17]: http://emojione.com/licensing/
+  [17]: https://github.com/joypixels/emojione#emojione-version-2
+  [18]: https://facelessuser.github.io/pymdown-extensions/extensions/emoji/#default-emoji-indexes
 
 ### InlineHilite
 
-[InlineHilite][18] adds support for inline code highlighting. It's useful for
+[InlineHilite][19] adds support for inline code highlighting. It's useful for
 short snippets included within body copy, e.g. `#!js var test = 0;` and can be
 achieved by prefixing inline code with a shebang and language identifier,
 e.g. `#!js`.
 
-  [18]: https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/
+  [19]: https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/
 
 ### MagicLink
 
-[MagicLink][19] detects links in Markdown and auto-generates the necessary
+[MagicLink][20] detects links in Markdown and auto-generates the necessary
 markup, so no special syntax is required. It auto-links `http[s]://` and
 `ftp://` links, as well as references to email addresses.
 
-  [19]: https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
+  [20]: https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
 
 ### Mark
 
-[Mark][20] adds the ability to ==highlight text== like it was marked with a
+[Mark][21] adds the ability to ==highlight text== like it was marked with a
 ==text marker==. The portion of text that should be highlighted must be
 enclosed in two equal signs `==...==`.
 
-  [20]: https://facelessuser.github.io/pymdown-extensions/extensions/mark/
+  [21]: https://facelessuser.github.io/pymdown-extensions/extensions/mark/
 
 ### SmartSymbols
 
-[SmartSymbols][21] converts markup for special characters into their
+[SmartSymbols][22] converts markup for special characters into their
 corresponding symbols, e.g. arrows (<--, -->, <-->), trademark and copyright
 symbols ((c), (tm), (r)) and fractions (1/2, 1/4, ...).
 
-  [21]: https://facelessuser.github.io/pymdown-extensions/extensions/smartsymbols/
+  [22]: https://facelessuser.github.io/pymdown-extensions/extensions/smartsymbols/
 
 ### SuperFences
 
-[SuperFences][22] provides the ability to nest code blocks under blockquotes,
-lists and other block elements, which the [Fenced Code Blocks][23] extension
+[SuperFences][23] provides the ability to nest code blocks under blockquotes,
+lists and other block elements, which the [Fenced Code Blocks][24] extension
 from the standard Markdown library doesn't parse correctly.
 
-SuperFences does also allow [grouping code blocks with tabs][24].
+SuperFences does also allow [grouping code blocks with tabs][25].
 
-  [22]: https://facelessuser.github.io/pymdown-extensions/extensions/superfences/
-  [23]: https://python-markdown.github.io/extensions/fenced_code_blocks/
-  [24]: codehilite.md#grouping-code-blocks
+  [23]: https://facelessuser.github.io/pymdown-extensions/extensions/superfences/
+  [24]: https://python-markdown.github.io/extensions/fenced_code_blocks/
+  [25]: codehilite.md#grouping-code-blocks
 
 ### Tasklist
 
-[Tasklist][25] adds support for styled checkbox lists. This is useful for
+[Tasklist][26] adds support for styled checkbox lists. This is useful for
 keeping track of tasks and showing what has been done and has yet to be done.
 Checkbox lists are like regular lists, but prefixed with `[ ]` for empty or
 `[x]` for filled checkboxes.
@@ -278,12 +298,12 @@ Result:
 * [ ] Aenean pretium efficitur erat, donec pharetra, ligula non scelerisque
 * [ ] Nulla vel eros venenatis, imperdiet enim id, faucibus nisi
 
-[25]: https://facelessuser.github.io/pymdown-extensions/extensions/tasklist/
+[26]: https://facelessuser.github.io/pymdown-extensions/extensions/tasklist/
 
 ### Tilde
 
-[Tilde][26] provides an easy way to ~~strike through~~ cross out text.
+[Tilde][27] provides an easy way to ~~strike through~~ cross out text.
 The portion of text that should be erased must be enclosed in two tildes
 `~~...~~` and the extension will take care of the rest.
 
-  [26]: https://facelessuser.github.io/pymdown-extensions/extensions/tilde/
+  [27]: https://facelessuser.github.io/pymdown-extensions/extensions/tilde/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
+      emoji_index: !!python/name:pymdownx.emoji.twemoji
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.keys

--- a/src/assets/stylesheets/extensions/pymdown/_emoji.scss
+++ b/src/assets/stylesheets/extensions/pymdown/_emoji.scss
@@ -28,7 +28,9 @@
 .md-typeset {
 
   // Correct alignment of emojis
-  .emojione {
+  .emojione,
+  .twemoji,
+  .gemoji {
     width: px2rem(20px);
     vertical-align: text-top;
   }


### PR DESCRIPTION
- Document how to use Twemoji and explain why it may be a better choice than the current default EmojiOne (now JoyPixels).
- Fix links links that are no longer relevant or unhelpful adding new , more helpful links.
- Have MkDocs Material use Twemoji in its documentation by default.
