### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@
 mkdocs>=1
 mkdocs-minify-plugin>=0.2
 Pygments>=2.2
-pymdown-extensions>=4.11
+markdown<3.2
+pymdown-extensions>=6.2,<6.3


### PR DESCRIPTION
- Restrict Markdown to less that 3.2 to prevent CSS breakage as 3.2
  will introduce changes to how code blocks are formatted.
- Use at least version 6.2 of Pymdown Extensions as 6.2 limits EmojiOne
  usage to v2.2.7 which has the most agreeable license for commercial
  and personal use. Additionally, limit the version to to less than 6.3
  as 6.3 will follow Python Markdown 3.2 in code block changes for
  SuperFences.