### PR TITLE
update min MkDocs version in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,19 +10,19 @@ good to go with the following commands:
 
 ``` sh
 python --version
-# Python 2.7.13
+# Python 3.8.0
 pip --version
-# pip 9.0.1
+# pip 19.3.1
 ```
 
 Installing and verifying MkDocs is as simple as:
 
 ``` sh
 pip install mkdocs && mkdocs --version
-# mkdocs, version 0.17.1
+# mkdocs, version 1.0.4
 ```
 
-Material requires MkDocs >= 0.17.1.
+Material requires MkDocs >= 1.0.0.
 
   [1]: https://www.mkdocs.org
 


### PR DESCRIPTION
MkDocs Material has required MkDocs v1.x since version 3 so I think it'd be right to update the minimum version here now.
MkDocs v1 was released more than a year ago and older versions are unsupported.
I also bumped the versions of Python and PIP just for good measure as those (although they are just example output) are really old versions too.

(minor nitpicky thing is that the first release of MkDocs v1 release on https://github.com/mkdocs/mkdocs/releases is actually 1.0, but I put it above as 1.0.0 for consistency... feel free to change :-D