### PR TITLE
Translate issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,10 @@
 ---
 name: Bug
 about: Report a bug
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,10 @@
 ---
 name: Feature
 about: Suggest an idea
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,10 @@
 ---
 name: Question
 about: The issue tracker is not for questions. Please ask your question on StackOverflow.
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 __THE ISSUE TRACKER IS NOT FOR QUESTIONS.__  

--- a/.github/ISSUE_TEMPLATE/translate.md
+++ b/.github/ISSUE_TEMPLATE/translate.md
@@ -1,0 +1,42 @@
+---
+name: Translate
+about: 'Help translate Material into more languages '
+title: 'New translation: {Insert language}'
+labels: enhancement
+assignees: ''
+
+---
+
+## Instructions
+
+1. Check, if your language is already available: [here](http://bit.ly/2DCzaL0)
+2. If it isn't, please translate the labels on the right:
+
+``` jinja
+{% macro t(key) %}{{ {
+  "language": "en",
+  "direction": "ltr",
+  "clipboard.copy": "Copy to clipboard",
+  "clipboard.copied": "Copied to clipboard",
+  "edit.link.title": "Edit this page",
+  "footer.previous": "Previous",
+  "footer.next": "Next",
+  "meta.comments": "Comments",
+  "meta.source": "Source",
+  "search.language": "en",
+  "search.pipeline.stopwords": true,
+  "search.pipeline.trimmer": true,
+  "search.placeholder": "Search",
+  "search.result.placeholder": "Type to start searching",
+  "search.result.none": "No matching documents",
+  "search.result.one": "1 matching document",
+  "search.result.other": "# matching documents",
+  "search.tokenizer": "[\s\-]+",
+  "skip.link.title": "Skip to content",
+  "source.link.title": "Go to repository",
+  "source.revision.date": "Last update",
+  "toc.title": "Table of contents"
+}[key] }}{% endmacro %}
+```
+
+Thanks!

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,7 +301,7 @@ theme:
 !!! info "Call for Contributions: Add languages/translations to Material"
 
     Help translate Material into more languages - it's just **one click** and
-    takes approximately **2 minutes**: [click here](http://bit.ly/2EbzFc8)
+    takes approximately **2 minutes**: [click here](https://github.com/squidfunk/mkdocs-material/issues/new?template=translate.md)
 
 #### Localization
 
@@ -380,7 +380,7 @@ translations for all template variables and labels in the following languages:
     </tr>
     <tr>
       <td colspan="4" align="right">
-        <a href="http://bit.ly/2EbzFc8">Submit a new language</a>
+        <a href="https://github.com/squidfunk/mkdocs-material/issues/new?template=translate.md">Submit a new language</a>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Updated new issue for translations, including the new `source.date.revision` and several other missing values. Used github issue template instead of bitly.