### PR TITLE
Set `tabindex` to `0` for skip to content link

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -228,7 +228,7 @@
 
     <!-- Render "skip to content" link -->
     {% if page.toc | first is defined %}
-      <a href="{{ (page.toc | first).url }}" tabindex="1"
+      <a href="{{ (page.toc | first).url }}" tabindex="0"
           class="md-skip">
         {{ lang.t('skip.link.title') }}
       </a>


### PR DESCRIPTION
I took a look at a few more things and found that the current recommendation for Skip to main content links is to not set tabindex to 1 but to 0 (https://web.dev/control-focus-with-tabindex/) While that is not the ideal solution, it's the one that does not require extra JavaScript. To be 100% correct it would be https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js