### PR TITLE
Fix improperly calculated Sidebar height

### DIFF
--- a/src/assets/javascripts/components/Material/Sidebar/Position.js
+++ b/src/assets/javascripts/components/Material/Sidebar/Position.js
@@ -106,7 +106,6 @@ export default class Position {
 
     /* Calculate new offset and height */
     const height = visible - bounds.top
-                 - Math.max(0, this.offset_ - offset)
                  - Math.max(0, offset + visible - bounds.bottom)
 
     /* If height changed, update element */


### PR DESCRIPTION
I think this line got duplicated during a merge or a rebase and should not be there.
It hides a part of the TOC on wired conditions.

<img width="287" alt="Screen Shot 2020-01-20 at 14 42 25" src="https://user-images.githubusercontent.com/1387855/72753565-40b42300-3b93-11ea-8b1a-c99268d990e2.png">

