### PR TITLE
Update _codehilite.scss

### DIFF
--- a/src/assets/stylesheets/extensions/_codehilite.scss
+++ b/src/assets/stylesheets/extensions/_codehilite.scss
@@ -233,7 +233,6 @@ $codehilite-whitespace: transparent;
       padding: px2rem(10.5px) px2rem(12px);
       background-color: transparent;
       overflow: auto;
-      vertical-align: top;
 
       // Override native scrollbar styles
       &::-webkit-scrollbar {


### PR DESCRIPTION
Property is ignored due to the display. With 'display: block', vertical-align should not be used.