### PR TITLE
Add forward slash to list of keyboard shortcuts that open search

### DIFF
--- a/src/assets/javascripts/integrations/keyboard/index.ts
+++ b/src/assets/javascripts/integrations/keyboard/index.ts
@@ -166,6 +166,7 @@ export function setupKeyboard(): Observable<Keyboard> {
           /* Open search and select query */
           case "f":
           case "s":
+          case "/":
             setElementFocus(query)
             setElementSelection(query)
             key.claim()


### PR DESCRIPTION
It helps having all nav keys next to each other: `,` `.` `/`

Sites supporting `/`:

- GitHub
- Gmail
- Twitter
- Facebook
- YouTube
- etc.