### PR TITLE
Bring back aria-label to search form

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -201,15 +201,19 @@ npm install
 
 ### Development mode
 
-The development server can be started with:
+Start the Webpack watchdog with:
 
 ``` sh
 npm start
 ```
 
-This will also start the MkDocs development server which will monitor changes
-on assets, templates and documentation. Point your browser to
-[localhost:8000][190] and you should see this documentation in front of you.
+Then, in a second session, start the MkDocs server with:
+
+```sh
+mkdocs serve
+```
+
+Point your browser to [localhost:8000][9] and you should see this documentation in front of you.
 
 !!! warning "Automatically generated files"
 

--- a/src/partials/search.html
+++ b/src/partials/search.html
@@ -31,6 +31,7 @@
         type="text"
         class="md-search__input"
         name="query"
+        aria-label="{{ lang.t('search.placeholder') }}"
         placeholder="{{ lang.t('search.placeholder') }}"
         autocapitalize="off"
         autocorrect="off"


### PR DESCRIPTION
As a continuation of https://github.com/squidfunk/mkdocs-material/pull/1516 this PR:

* Bring back aria-label to search form as form elements must have labels, a placeholder is not enough.
* Updates Development server guide.

Related:

https://dequeuniversity.com/rules/axe/3.5/label?application=rocketvalidator