### PR TITLE
Fix example of plugins.search.separator

### DIFF
--- a/docs/releases/5.md
+++ b/docs/releases/5.md
@@ -111,7 +111,7 @@ was renamed to `separator`:
     ``` yaml
     plugins:
       - search:
-          separator: [\s\-\.]+
+          separator: '[\s\-\.]+'
           lang:
             - en
             - de


### PR DESCRIPTION
Fixed the example of `plugins.search.separator` on the v5 release note.