### PR TITLE
Fix links to features in upgrade to 5.x

### DIFF
--- a/docs/releases/5.md
+++ b/docs/releases/5.md
@@ -54,8 +54,8 @@ flags and can be enabled by listing them in `mkdocs.yml` under `theme.features`:
         tabs: true
     ```
 
-  [4]: ../../../getting-started/#tabs
-  [5]: ../../../getting-started/#instant-loading
+  [4]: ../../getting-started/#tabs
+  [5]: ../../getting-started/#instant-loading
 
 #### `theme.logo.icon`
 
@@ -70,7 +70,7 @@ be set to any of the [icons bundled with the theme][6]:
         logo: material/cloud
     ```
 
-  [6]: ../../../getting-started/#icons
+  [6]: ../../getting-started/#icons
 
 === "4.x"
 
@@ -127,7 +127,7 @@ was renamed to `separator`:
         tokenizer: [\s\-\.]+
     ```
 
-  [7]: ../../../plugins/search/#configuration
+  [7]: ../../plugins/search/#configuration
 
 #### `extra.social.*`
 


### PR DESCRIPTION
From (bad link):
https://squidfunk.github.io/getting-started/#tabs

To:
https://squidfunk.github.io/mkdocs-material/getting-started/#tabs