### PR TITLE
Fix for GitLab stars

### DIFF
--- a/src/assets/javascripts/patches/source/index.ts
+++ b/src/assets/javascripts/patches/source/index.ts
@@ -74,7 +74,7 @@ function fetchSourceFacts(
 
     /* GitLab repository */
     case "gitlab":
-      const [, base, project] = url.match(/^.+?([^\/]*gitlab[^\/]+)\/(.+)/i)
+      const [, base, project] = url.match(/^.+?([^\/]*gitlab[^\/]+)\/([A-Za-z0-9\-\_]+\/[A-Za-z0-9\-\_]+)/i)
       return fetchSourceFactsFromGitLab(base, project)
 
     /* Everything else */


### PR DESCRIPTION
The current regex grabs the trailing / on the repo name like `squidfunk/mkdocs-material/` but GitLab doesn't expect that and will 404 with the trailing /.

This new regex does not grab the trailing slash, and should fix GitLab stars not rendering.