### PR TITLE
Fix splitChunks on Windows

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -333,7 +333,7 @@ export default (_env: never, args: Configuration): Configuration[] => {
         splitChunks: {
           cacheGroups: {
             vendor: {
-              test: /\/node_modules\//,
+              test: /[\\/]node_modules[\\/]/,
               name: "assets/javascripts/vendor",
               chunks: "all"
             }


### PR DESCRIPTION
https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks

>When files paths are processed by webpack, they always contain / on Unix systems and \ on Windows. That's why using [\\/] in {cacheGroup}.test fields is necessary to represent a path separator. / or \ in {cacheGroup}.test will cause issues when used cross-platform.

And here's the patch from my Windows dev VM: https://github.com/squidfunk/mkdocs-material/compare/master...XhmikosR:build