### PR TITLE
docs/add icon set

### DIFF
--- a/docs/tutorials/icons.md
+++ b/docs/tutorials/icons.md
@@ -1,0 +1,71 @@
+# Icon Sets
+
+With Material 5.0, it is now possible to customize the icons used in the documentation with `.svg` icons. It ships three icon sets, providing over 5k icons:
+
+1. [Material Design icons](https://material.io/resources/icons/)
+2. [FontAwesome icons](https://fontawesome.com/icons?d=gallery&m=free)
+3. [GitHub's Octicons](https://octicons.github.com/)
+
+However, you can add your own custom icons or third party icon sets to your documentation.
+
+!!! tip
+    Because icons are directly inlined into the html, they must be in the `.svg` vector format. If you have a bitmap (e.g. `.png`), you will need to [trace](https://inkscape.org/doc/tutorials/tracing/tutorial-tracing.html) them using [inkscape](https://inkscape.org) or similar tools so that they can be converted to a `.svg` format.
+
+## Goal
+
+With this tutorial, we will add [Bootstrap Icons][bootstrap-icons], a ready-to-use icon set. These icons will be used to customize the icons available in within `mkdocs.yml`, namely `theme.icon` and the social icons `extra.social.icon`.
+
+## Setup
+
+All icons provided by Material are placed within the `.icons` folder. Each icon set provided is placed within its own sub-folder to avoid naming conflicts for the same icon name. They are accessible using the relative file name (without extension): `fontawesome/brands/github`.
+
+In order to add the Bootstrap Icons, we will need to extend the theme to gain access to the `.icons` folder. For that, we create an folder `theme` (or any other name) within the project root and specify it as `custom_dir`.
+
+```yaml
+theme:
+    name: material
+    custom_dir: theme
+```
+
+!!! warning
+    Theme extension may be used for the following use cases:
+
+    1. Overwrite assets locally provided by Material by specifying the exact relative file name (e.g. `.icons/logo.svg`). 
+    2. Add custom assets to be discoverable by Material.
+
+    When adding custom assets, please make sure that you do not accidentally overwrite other assets of Material by choosing a unique name for them. A list of provided assets can be found [here](https://github.com/squidfunk/mkdocs-material/tree/master/material).
+
+In order to avoid accidentally overwriting any provided icons, it is recommended to create a unique folder (e.g. `bootstrap`) and place it in the `theme/.icons` folder, so that Material can find the icons.
+
+A fully functional project structure should look like this:
+
+```
+docs
+    index.md
+theme
+    .icons
+        bootstrap
+            *.svg
+mkdocs.yml
+```
+
+## Usage
+
+You can now place any `.svg` icon within your folder `theme/.icons/bootstrap` to make them accessible (e.g. copy over all downloaded [Bootstrap Icons][bootstrap-icons]). They are referenced similar to the provided icon sets.
+
+```yaml
+theme:
+    name: material
+    custom_dir: theme
+
+    icon:
+        logo: bootstrap/bootstrap
+        repo: bootstrap/archive
+
+extra:
+    social:
+        - icon: bootstrap/bootstrap-fill
+          link: https://getbootstrap.com/
+```
+
+[bootstrap-icons]: https://icons.getbootstrap.com/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
   - Tutorials:
     - Notice: tutorials/index.md
     - GitHub Pages: tutorials/github-pages.md
+    - Icons Sets: tutorials/icons.md
   - Releases:
     - Upgrading to 5.x: releases/5.md
     - Upgrading to 4.x: releases/4.md


### PR DESCRIPTION
# Description

This describes the steps to perform to add the your own `.svg` icons that can be referenced within `mkdocs.yml` as `theme.icon`.

A rendered version can be found [here](https://diba1013.github.io/mkdocs-material-playground/customization/icons/) (small changes done within this PR, but gives an overall overview) 

## State of this PR

I have built the documentation and verified the rendered result. As per discussion on #1585, I specified `docs/tutorials` as base branch (which is slightly outdated, thus this PR contains a half broken link to `../extensions/pymdown.md#icons`).

### Questions

1. How do you want this to be setup? For now I have gone for a style: "All necessary steps are already described in the main documentation, so this will only guide you through without explaining them in detail". Thus I have only linked to the more detailed references.
2. How do you do your links? For now I have used inline-style relative markdown links.

### mkdocs-material-extensions

I have tested this with [mkdocs-material-extensions](https://github.com/facelessuser/mkdocs-material-extensions) (since it is now referenced on the production site) and it does not pick up on your custom icon sets (a setup can be found [here](https://github.com/diba1013/mkdocs-material-playground/blob/master/mkdocs.yml), note the `:bootstrap-circle-square:` within the bug notice). @facelessuser I know [this was not intended in the first place](https://github.com/squidfunk/mkdocs-material/issues/1498#issuecomment-597678171) and I am happy to file an issue for that. I understand that it is a [pre-release](https://github.com/facelessuser/mkdocs-material-extensions/issues/2) and will be shipped with mkdocs-material eventually.

If this is intentional or not possible, I am happy to remove this notice.