### PR TITLE
Add namespace for icons

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -527,9 +527,9 @@ theme:
 All icons are directly inlined as `*.svg` files, so no further requests will be
 made. Icon sets which are bundled with Material for MkDocs:
 
-* [Material Design icons][16]: 3.8k icons
-* [FontAwesome icons][17]: 1.5k icons
-* [GitHub's Octicons][18]: 200 icons
+* [Material Design icons][16] (material): 3.8k icons
+* [FontAwesome icons][17] (fontawesome): 1.5k icons
+* [GitHub's Octicons][18] (octicons): 200 icons
 
 __You can use all those icons [directly from :fontawesome-brands-markdown:
 Markdown][19]!__

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -527,9 +527,9 @@ theme:
 All icons are directly inlined as `*.svg` files, so no further requests will be
 made. Icon sets which are bundled with Material for MkDocs:
 
-* [Material Design icons][16] (material): 3.8k icons
-* [FontAwesome icons][17] (fontawesome): 1.5k icons
-* [GitHub's Octicons][18] (octicons): 200 icons
+* [Material Design icons][16] (`material`): 3.8k icons
+* [FontAwesome icons][17] (`fontawesome`): 1.5k icons
+* [GitHub's Octicons][18] (`octicons`): 200 icons
 
 __You can use all those icons [directly from :fontawesome-brands-markdown:
 Markdown][19]!__


### PR DESCRIPTION
I added the actually used name for the icons to the list of supported icons (i.e. Fontawesome (fontawesome): 1.5k icons)

This should prevent future confusion, where it isn't 100% clear, which "prefix" the icon of your choice has. Trust me... this will happen.