### PR TITLE
Reorder nav pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,10 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting started: getting-started.md
+  - Customization: customization.md
+  - Data privacy: data-privacy.md
+  - Contributing: contributing.md
+  - License: license.md
   - Extensions:
     - Admonition: extensions/admonition.md
     - CodeHilite: extensions/codehilite.md
@@ -143,10 +147,6 @@ nav:
     - Upgrading to 5.x: releases/5.md
     - Upgrading to 4.x: releases/4.md
     - Changelog: releases/changelog.md
-  - Customization: customization.md
-  - Data privacy: data-privacy.md
-  - Contributing: contributing.md
-  - License: license.md
 
 # Google Analytics
 google_analytics:


### PR DESCRIPTION
In effect this changes nothing the website, but it better reflects the order of the pages that you see on the website:

![Screenshot 2020-04-29 at 15 48 37](https://user-images.githubusercontent.com/5570380/80603615-f4e60500-8a30-11ea-9851-dccd7bb8dadc.png)

Context before you think I have OCD 😋: I'm developing a plugin where the ordering of pages in `nav` matters and was using this project's website as a test.