### PR TITLE
Add missing gitlab pages in nav and mention GitHub template

### DIFF
--- a/docs/tutorials/github-pages.md
+++ b/docs/tutorials/github-pages.md
@@ -75,3 +75,9 @@ Running this command will build the site in the `site` directory.
 If you want a different folder to be used, set the `site_dir` setting in the mkdocs.yml.
 
 After the site is built, you can push these pages to your GitHub repository.
+
+## Template
+A template to use with GitHub Actions can be found at https://github.com/Andre601/mkdocs-template  
+Just click the `Use this template`, choose a name and start with a pre-made repository.
+
+For more information read the `README.md` of the aforementioned repository.

--- a/docs/tutorials/github-pages.md
+++ b/docs/tutorials/github-pages.md
@@ -75,9 +75,3 @@ Running this command will build the site in the `site` directory.
 If you want a different folder to be used, set the `site_dir` setting in the mkdocs.yml.
 
 After the site is built, you can push these pages to your GitHub repository.
-
-## Template
-A template to use with GitHub Actions can be found at https://github.com/Andre601/mkdocs-template  
-Just click the `Use this template`, choose a name and start with a pre-made repository.
-
-For more information read the `README.md` of the aforementioned repository.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
   - Tutorials:
     - Notice: tutorials/index.md
     - GitHub Pages: tutorials/github-pages.md
+    - GitLab Pages: tutorials/gitlab-pages.md
     - Icons Sets: tutorials/icons.md
   - Releases:
     - Upgrading to 5.x: releases/5.md


### PR DESCRIPTION
Adds the GitLab pages tutorial to the nav in the mkdocs.yml (Was missing) and also mentions the template I made for using MkDocs with GitHub pages.