### PR TITLE
Nicer thin scrollbars for pre > code in Firefox

### DIFF
--- a/src/assets/stylesheets/base/_typeset.scss
+++ b/src/assets/stylesheets/base/_typeset.scss
@@ -205,6 +205,7 @@ kbd {
       box-shadow: none;
       box-decoration-break: slice;
       touch-action: auto;
+      scrollbar-width: thin;
 
       // Override native scrollbar styles
       &::-webkit-scrollbar {


### PR DESCRIPTION
Firefox supports `scrollbar-width` styling and `scrollbar-width: thin;` looks much closer to how the custom scrollbars on Chrome look. (REF: https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width)

Note: I haven't tested building the theme with this change, but I have tested using this directly in the browser and it looks great.

Screenshot from Firefox 76 on Windows 10 here with styling applied.
![image](https://user-images.githubusercontent.com/1212885/81579911-b57fc700-93e7-11ea-801c-9e50552406cc.png)
