### PR TITLE
Fix infinite loop

### DIFF
--- a/src/assets/javascripts/index.ts
+++ b/src/assets/javascripts/index.ts
@@ -383,7 +383,7 @@ export function initialize(config: unknown) {
 
             /* Determine common prefix */
             let index = 0
-            while (a.charAt(index) === b.charAt(index))
+            while (a.charAt(index) === b.charAt(index) && index < a.length && index < b.length)
               index++
 
             /* Replace common prefix (i.e. base) with effective base */


### PR DESCRIPTION
If the URLs being compared were identical, this loop would never finish.

This bounds the loop on the length of the shortest string.

Fixes #1696  