### PR TITLE
Listen on IPv4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 8000
 
 # Start development server by default
 ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=::0:8000"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
Reverts 02f058bc8212e56eae17bc6141dc1d68eab6eb99

The issue in 1.1.1 was made a warning in 1.1.2, so this can be safely restored. Currently it's not possible to access the dev server.