### PR TITLE
Fix for Homepage background image gradient on Edge Legacy

### DIFF
--- a/src/overrides/home.html
+++ b/src/overrides/home.html
@@ -52,7 +52,7 @@
         linear-gradient(
           to bottom,
           var(--md-primary-fg-color),
-          hsla(280deg, 67%, 55%, 1) 99%,
+          hsla(280, 67%, 55%, 1) 99%,
           white 99%
         );
     }


### PR DESCRIPTION
note the text in the 'Get Started' button is hidden still - but it was completely hidden before anyway (as the whole top was white) - this is still a good improvement.

Screenshots:

Current:
![image](https://user-images.githubusercontent.com/1212885/85270700-adba4480-b4b4-11ea-897b-4554834feef2.png)

With the fix in this PR:
![image](https://user-images.githubusercontent.com/1212885/85270613-89f6fe80-b4b4-11ea-9a26-845380d25e0a.png)
