### PR TITLE
Avoid content shining through clipboard icon

### DIFF
--- a/src/assets/stylesheets/main/layout/_clipboard.scss
+++ b/src/assets/stylesheets/main/layout/_clipboard.scss
@@ -27,12 +27,14 @@
 // Copy to clipboard
 .md-clipboard {
   position: absolute;
-  top: px2rem(8px);
-  right: px2em(8px, 16px);
+  top: 0;
+  right: 0;
   z-index: 1;
-  width: px2em(24px, 16px);
-  height: px2em(24px, 16px);
+  padding: px2em(8px);
+  width: px2em(32px, 24px);
+  height: px2em(32px, 24px);
   color: var(--md-default-fg-color--lightest);
+  background-color: var(--md-code-bg-color);
   border-radius: px2rem(2px);
   cursor: pointer;
   transition: color 125ms;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8647429/88477446-5f2f1880-cf40-11ea-9c2c-b5723a904805.png)
instead of:
![image](https://user-images.githubusercontent.com/8647429/88477430-3eff5980-cf40-11ea-8ba6-5cf1c611eac7.png)
