### PR TITLE
Update _keys.scss

### DIFF
--- a/docs/reference/lists.md
+++ b/docs/reference/lists.md
@@ -97,7 +97,7 @@ _Result_:
 
 An ordered list must start with a number immediately followed by a dot. The 
 numbers do not need to be consecutive and can be all set to `1.`, as they will
-be re-numbered when renderer.
+be re-numbered when rendered.
 
 _Example_:
 


### PR DESCRIPTION
The symbols in the current version are OK, except for

```
    "arrow-down": "\2193", // ↓
    "arrow-left": "\2190", // ←
    "arrow-right": "\2192", // →
    "arrow-up": "\2191", // ↑
    "tab": "\21E5", // ⇥
```

The symbols above are better than the ones used today. 

The bloody autoformatter in VSCode has reformatted the SCSS :/ 