### PR TITLE
[_keys.scss] Visualize `arrow-down` as ↓, `arrow-left` as ←, `arrow-right` as →, `arrow-up` as ↑ and `tab` as ⇥

### DIFF
--- a/src/assets/stylesheets/main/extensions/pymdownx/_keys.scss
+++ b/src/assets/stylesheets/main/extensions/pymdownx/_keys.scss
@@ -73,10 +73,10 @@
     "right-windows": "\229E",
 
     // Other keys
-    "arrow-down":    "\25bd",
-    "arrow-left":    "\25c1",
-    "arrow-right":   "\25b7",
-    "arrow-up":      "\25b3",
+    "arrow-down":    "\2193",
+    "arrow-left":    "\2190",
+    "arrow-right":   "\2192",
+    "arrow-up":      "\2191",
     "backspace":     "\232B",
     "backtab":       "\21E4",
     "caps-lock":     "\21EA",
@@ -85,11 +85,11 @@
     "delete":        "\2326",
     "eject":         "\23CF",
     "end":           "\2913",
-    "escape":        "\238b",
+    "escape":        "\238B",
     "home":          "\2912",
     "insert":        "\2380",
-    "page-down":     "\21df",
-    "page-up":       "\21de",
+    "page-down":     "\21DF",
+    "page-up":       "\21DE",
     "print-screen":  "\2399"
   ) {
     .key-#{$name} {
@@ -102,7 +102,7 @@
 
   // Build special keys with right icon
   @each $name, $code in (
-    "tab":           "\21B9",
+    "tab":           "\21E5",
     "num-enter":     "\2324",
     "enter":         "\23CE"
   ) {


### PR DESCRIPTION
Changed key visualization for 

```
    "arrow-down": "\2193", // ↓
    "arrow-left": "\2190", // ←
    "arrow-right": "\2192", // →
    "arrow-up": "\2191", // ↑
    "tab": "\21E5", // ⇥
```

and fixed a few lowercase hex to be uppercase for consistency. This replaces https://github.com/squidfunk/mkdocs-material/pull/1833 which was failed