### PR TITLE
Support for Referrer-Policy metadata

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -35,6 +35,11 @@
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width,initial-scale=1" />
 
+      <!-- Referrer policy -->
+      {% if config.extra.referrer %}
+        <meta name="referrer" content="{{ config.extra.referrer }}" />
+      {% endif %}
+
       <!-- Page description -->
       {% if page and page.meta and page.meta.description %}
         <meta name="description" content="{{ page.meta.description }}" />


### PR DESCRIPTION
Provide a means of setting `referrerpolicy` attribute via metadata.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

_mkdocs.yml_:
```
extra:
  referrer: same-origin
```