### PR TITLE
Show external links in the tab nav

### DIFF
--- a/src/partials/tabs-item.html
+++ b/src/partials/tabs-item.html
@@ -66,4 +66,13 @@
       {% endif %}
     </li>
   {% endif %}
+
+<!-- Navigation item with an external link -->
+{% elif (config.site_url not in nav_item.url) and ("http" in nav_item.url) %}
+  <li class="md-tabs__item">
+    <a href="{{ nav_item.url | url }}" class="md-tabs__link">
+      {{ nav_item.title }}
+    </a>
+  </li>
+
 {% endif %}


### PR DESCRIPTION
Add another check for nav items that don't contain the current site url (In case the links are absolute) and if the url contains at least http. This is not the most elegant way of knowing if it's an external absolute url :/ 

I tested with a configuration like this:

```YAML
nav:
  - ALM:
      - ALM Wiki:
          - index: index.md
          - ALM:
              - ALM: ALM.md
              - Access to the Wiki: ALM/Access-to-the-Wiki.md
              - InnerSource: ALM/InnerSource.md
  - Bühler Insights: 'https://docs.buhlergroup.io'
  - Bühler Outsight: 'Outsight.md'
site_dir: ../site-output/
site_name: ALM Docs
site_url: 'https://docs.alm.buhlergroup.com/'
theme:
  name: material
  custom_dir: overrides
  include_search_page: false
  search_index_only: true
  language: en
  features:
    - tabs
```
And I added the new tabs-item.html in the /overrides/partial folder.
Is there also another way to test properly? 