### PR TITLE
Add rss plugin to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN \
         'mkdocs-git-revision-date-localized-plugin>=0.4' \
         'mkdocs-minify-plugin>=0.3' \
         'mkdocs-redirects>=1.0'; \
+        'mkdocs-rss-plugin>=0.6.1'; \
     fi \
   && apk del .build gcc musl-dev \
   && rm -rf /tmp/*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,12 +71,14 @@ The following plugins are bundled with the Docker image:
 * [mkdocs-git-revision-date-localized-plugin][13]
 * [mkdocs-minify-plugin][14]
 * [mkdocs-redirects][15]
+* [mkdocs-rss-plugin][16]
 
   [11]: https://hub.docker.com/r/squidfunk/mkdocs-material/
   [12]: https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
   [13]: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
   [14]: https://github.com/byrnereese/mkdocs-minify-plugin
   [15]: https://github.com/datarobot/mkdocs-redirects
+  [16]: https://github.com/Guts/mkdocs-rss-plugin
 
 ### with git
 


### PR DESCRIPTION
At https://emacs-lsp.github.io/lsp-mode we use the docker image and want to add rss support