### PR TITLE
Fix links to deprecations

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,8 +30,8 @@ pip show mkdocs-material
 * Removed hero partial in favor of [custom implementation][1]
 * Removed [deprecated front matter features][2]
 
-  [1]: http://localhost:8000/deprecations/#hero
-  [2]: http://localhost:8000/deprecations/#front-matter
+  [1]: deprecations/#hero
+  [2]: deprecations/#front-matter
 
 ### Changes to `mkdocs.yml`
 


### PR DESCRIPTION
The docs currently link to localhost which breaks the links on the deployed version. This PR removes the prefix to fix the links.