### PR TITLE
Fix deprecations links (second try)

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,8 +30,8 @@ pip show mkdocs-material
 * Removed hero partial in favor of [custom implementation][1]
 * Removed [deprecated front matter features][2]
 
-  [1]: deprecations/#hero
-  [2]: deprecations/#front-matter
+  [1]: deprecations.md/#hero
+  [2]: deprecations.md/#front-matter
 
 ### Changes to `mkdocs.yml`
 


### PR DESCRIPTION
I messed up #1947 and the links now point to `upgrading/deprecations/#hero` this should hopefully fix it for real. Sorry about that.