### PR TITLE
Fix header link when use_directory_urls is unset

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -3,7 +3,7 @@
 -#}
 <header class="md-header" data-md-component="header">
   <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
-    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
+    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}{% if not config.use_directory_urls %}index.html{% endif %}" title="{{ config.site_name }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
       {% include "partials/logo.html" %}
     </a>
     <label class="md-header-nav__button md-icon" for="__drawer">

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -28,7 +28,7 @@
 
     <!-- Link to home -->
     <a
-      href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
+      href="{{ config.site_url | default(nav.homepage.url, true) | url }}{% if not config.use_directory_urls %}index.html{% endif %}"
       title="{{ config.site_name }}"
       class="md-header-nav__button md-logo"
       aria-label="{{ config.site_name }}"


### PR DESCRIPTION
By default use_directory_urls is set to True. But when set to False, the header
link should be "/index.html" and not "/".