### PR TITLE
Use dot notation for Markdown extensions

### DIFF
--- a/docs/reference/abbreviations.md
+++ b/docs/reference/abbreviations.md
@@ -19,7 +19,7 @@ shown on hover__, e.g. for glossaries:
 
 ``` yaml
 markdown_extensions:
-  - abbr
+  - markdown.extensions.abbr
 ```
 
   [1]: https://python-markdown.github.io/extensions/abbreviations/

--- a/docs/reference/admonitions.md
+++ b/docs/reference/admonitions.md
@@ -21,7 +21,7 @@ library, is integrated with Material for MkDocs and can be enabled via
 
 ``` yaml
 markdown_extensions:
-  - admonition
+  - markdown.extensions.admonition
 ```
 
   [1]: https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/extensions/markdown/_admonition.scss

--- a/docs/reference/buttons.md
+++ b/docs/reference/buttons.md
@@ -18,7 +18,7 @@ and can be enabled via `mkdocs.yml`
 
 ``` yaml
 markdown_extensions:
-  - attr_list
+  - markdown.extensions.attr_list
 ```
 
   [1]: https://python-markdown.github.io/extensions/attr_list/

--- a/docs/reference/footnotes.md
+++ b/docs/reference/footnotes.md
@@ -21,7 +21,7 @@ adds the ability to add inline footnotes to a document and can be enabled via
 
 ``` yaml
 markdown_extensions:
-  - footnotes
+  - markdown.extensions.footnotes
 ```
 
   [1]: https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/extensions/markdown/_footnotes.scss

--- a/docs/reference/icons-emojis.md
+++ b/docs/reference/icons-emojis.md
@@ -54,7 +54,7 @@ and can be enabled via `mkdocs.yml`
 
 ``` yaml
 markdown_extensions:
-  - attr_list
+  - markdown.extensions.attr_list
 ```
 
   [10]: https://python-markdown.github.io/extensions/attr_list/

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -20,7 +20,7 @@ and can be enabled via `mkdocs.yml`
 
 ``` yaml
 markdown_extensions:
-  - attr_list
+  - markdown.extensions.attr_list
 ```
 
   [2]: https://python-markdown.github.io/extensions/attr_list/

--- a/docs/reference/lists.md
+++ b/docs/reference/lists.md
@@ -21,7 +21,7 @@ enabled via `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
-  - def_list
+  - markdown.extensions.def_list
 ```
 
   [1]: https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_typeset.scss

--- a/docs/reference/meta-tags.md
+++ b/docs/reference/meta-tags.md
@@ -22,7 +22,7 @@ adds the ability to add [front matter][4] to a document and can be enabled via
 
 ``` yaml
 markdown_extensions:
-  - meta
+  - markdown.extensions.meta
 ```
 
 Front matter is written as a series of key-value pairs at the beginning of the

--- a/docs/setup/adding-a-comment-system.md
+++ b/docs/setup/adding-a-comment-system.md
@@ -41,7 +41,7 @@ adds the ability to add [front matter][6] to a document and can be enabled via
 
 ``` yaml
 markdown_extensions:
-  - meta
+  - markdown.extensions.meta
 ```
 
 Front matter is written as a series of key-value pairs at the beginning of the

--- a/docs/setup/setting-up-navigation.md
+++ b/docs/setup/setting-up-navigation.md
@@ -132,7 +132,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               permalink: true
         ```
 
@@ -140,7 +140,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               permalink: ⚓︎
         ```
 
@@ -155,7 +155,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               slugify: !!python/name:pymdownx.slugs.uslugify
         ```
 
@@ -163,7 +163,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               slugify: !!python/name:pymdownx.slugs.uslugify_cased
         ```
 
@@ -178,7 +178,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               toc_depth: 3
         ```
 
@@ -186,7 +186,7 @@ customize its appearance:
 
         ``` yaml
         markdown_extensions:
-          - toc:
+          - markdown.extensions.toc:
               toc_depth: 0
         ```
 


### PR DESCRIPTION
The documentation should be consistent with your own config, as it is likely to be used as a reference:
* https://github.com/squidfunk/mkdocs-material/blob/master/mkdocs.yml#L104-L112