### PR TITLE
Add support for MkDocs plugin mermaid2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN \
   && \
     if [ "${WITH_PLUGINS}" = "true" ]; then \
       pip install --no-cache-dir \
-        'mkdocs-minify-plugin>=0.3' \
+        'mkdocs-mermaid2-plugin>=0.5' \
         'mkdocs-redirects>=1.0'; \
     fi \
   && apk del .build gcc musl-dev \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,8 +81,7 @@ plugins:
         releases/5.md: upgrading.md #upgrading-from-3x-to-4x
         releases/changelog.md: changelog.md
         sponsorship.md: insiders.md
-  - minify:
-      minify_html: true
+  - mermaid2
 
 # Customization
 extra:
@@ -135,7 +134,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:mermaid2.fence_mermaid
   - pymdownx.tabbed
   - pymdownx.tasklist:
       custom_checkbox: true


### PR DESCRIPTION
Offers the possibility to integrate diagrams based on Mermaid. Unfortunately the plugin is not compatible with Minify:
* https://github.com/fralau/mkdocs-mermaid2-plugin#compatibility

Might be related to #1875.