### PR TITLE
Add a helpful error message when attempting to call `mike install-extras`

### DIFF
--- a/material/mike.py
+++ b/material/mike.py
@@ -1,0 +1,5 @@
+raise ValueError(
+    'install-extras not required to use mike with material theme; '
+    'for more information, see https://squidfunk.github.io/mkdocs-material/' +
+    'setup/setting-up-versioning/#versioning'
+)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ setup(
     entry_points = {
         "mkdocs.themes": [
             "material = material",
+        ],
+        "mike.themes": [
+            "material = material.mike",
         ]
     },
     zip_safe = False


### PR DESCRIPTION
Now that the Material theme has built-in support for mike (thanks for the work, by the way!), I thought it'd be helpful for `mike install-extras` to report an error directing them to Material's documentation if a user attempts to install extras for their Material-themed docs. This patch causes `mike` to report the following error (assuming you're using the just-released v0.6):

```
$ mike install-extras
mike: install-extras not required to use mike with material theme; for more info
rmation, see https://squidfunk.github.io/mkdocs-material/setup/setting-up-versio
ning/#versioning
```