### PR TITLE
Add mkdocs-redirects when running a dev environment

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -229,6 +229,7 @@ Next, all dependencies need to be installed, which is done with:
 cd mkdocs-material
 pip install -r requirements.txt
 pip install mkdocs-minify-plugin
+pip install mkdocs-redirects
 npm install
 ```
 


### PR DESCRIPTION
`mkdocs-redirects` is not part of `requirements.txt`, yet required when running the development environment. 
Like `mkdocs-minify-plugin`, this PR adds one line in the documentation to install `mkdocs-redirects`.

It is unclear to me why this is not in `requirements.txt`, but this PR will start the discussion!