### PR TITLE
setup.py: minor indent fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,26 +29,26 @@ with open("package.json") as data:
 with open("requirements.txt") as data:
     install_requires = [
         line for line in data.read().split("\n")
-            if line and not line.startswith("#")
+        if line and not line.startswith("#")
     ]
 
 # Load README contents
-with open("README.md", encoding = "utf-8") as data:
+with open("README.md", encoding="utf-8") as data:
     long_description = data.read()
 
 # Package description
 setup(
-    name = "mkdocs-material",
-    version = package["version"],
-    url = package["homepage"],
-    license = package["license"],
-    description = package["description"],
-    long_description = long_description,
-    long_description_content_type = "text/markdown",
-    author = package["author"]["name"],
-    author_email = package["author"]["email"],
-    keywords = package["keywords"],
-    classifiers = [
+    name="mkdocs-material",
+    version=package["version"],
+    url=package["homepage"],
+    license=package["license"],
+    description=package["description"],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author=package["author"]["name"],
+    author_email=package["author"]["email"],
+    keywords=package["keywords"],
+    classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "License :: OSI Approved :: MIT License",
@@ -58,13 +58,13 @@ setup(
         "Topic :: Software Development :: Documentation",
         "Topic :: Text Processing :: Markup :: HTML"
     ],
-    packages = find_packages(exclude = ["src"]),
-    include_package_data = True,
-    install_requires = install_requires,
-    entry_points = {
+    packages=find_packages(exclude=["src"]),
+    include_package_data=True,
+    install_requires=install_requires,
+    entry_points={
         "mkdocs.themes": [
             "material = material",
         ]
     },
-    zip_safe = False
+    zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -33,22 +33,22 @@ with open("requirements.txt") as data:
     ]
 
 # Load README contents
-with open("README.md", encoding="utf-8") as data:
+with open("README.md", encoding = "utf-8") as data:
     long_description = data.read()
 
 # Package description
 setup(
-    name="mkdocs-material",
-    version=package["version"],
-    url=package["homepage"],
-    license=package["license"],
-    description=package["description"],
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author=package["author"]["name"],
-    author_email=package["author"]["email"],
-    keywords=package["keywords"],
-    classifiers=[
+    name = "mkdocs-material",
+    version = package["version"],
+    url = package["homepage"],
+    license = package["license"],
+    description = package["description"],
+    long_description = long_description,
+    long_description_content_type = "text/markdown",
+    author = package["author"]["name"],
+    author_email = package["author"]["email"],
+    keywords = package["keywords"],
+    classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "License :: OSI Approved :: MIT License",
@@ -58,13 +58,13 @@ setup(
         "Topic :: Software Development :: Documentation",
         "Topic :: Text Processing :: Markup :: HTML"
     ],
-    packages=find_packages(exclude=["src"]),
-    include_package_data=True,
-    install_requires=install_requires,
-    entry_points={
+    packages = find_packages(exclude = ["src"]),
+    include_package_data = True,
+    install_requires = install_requires,
+    entry_points = {
         "mkdocs.themes": [
             "material = material",
         ]
     },
-    zip_safe=False
+    zip_safe = False
 )


### PR DESCRIPTION
Makes the setup.py follow PEP8, Python's official style guide.
Yeah sure, it doesn't look as nice, so its your choice if you want to comply here or just leave it as-is.  