### PR TITLE
Add support for multiple architectures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -80,6 +86,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ${{ github.event.repository.full_name }}:latest
             ${{ github.event.repository.full_name }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
I just stumbled across the following GitHub action:
* https://github.com/mhausenblas/mkdocs-deploy-gh-pages

Unfortunately, your Docker image is only built for the linux/adm64 architecture. 

This pull request ensures that your Docker image is also built for the linux/arm64 and linux/arm/v7 architectures. This makes it possible, to run a self-hosted runner on a Raspberry PI. 
* https://github.com/docker/build-push-action#multi-platform-image

In conjunction with the GitHub action mentioned above, this would automatically generate the docs and make them available via GitHub Pages.