### PR TITLE
Fix documentation

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -98,7 +98,7 @@ templates can be shared among multiple pages:
 
     ``` markdown
     ---
-    template: overrides/hero.html
+    template: hero.html
     ---
     ```
 


### PR DESCRIPTION
I had to delete the `overrides` directory from the template declaration inside the page front matter for the site to build correctly.

In my case that directory didn't had the default name and maybe that was the cause of the error.

However, skipping the directory and leaving only the template file fixed the build of my site (`hexagonkt/hexagon`).