### PR TITLE
Remove zero width space U+200B in from code snippets

### DIFF
--- a/docs/reference/abbreviations.md
+++ b/docs/reference/abbreviations.md
@@ -81,7 +81,7 @@ _Example_:
     ```` markdown
     The HTML specification is maintained by the W3C.
     
-    --8<--​ "includes/abbreviations.md"
+    --8<-- "includes/abbreviations.md"
     ````
 
 === "includes/abbreviations.md"

--- a/docs/reference/code-blocks.md
+++ b/docs/reference/code-blocks.md
@@ -311,7 +311,7 @@ _Example_:
 
 ```` markdown
 ```
---8<--​ ".browserslistrc"
+--8<-- ".browserslistrc"
 ```
 ````
 


### PR DESCRIPTION
When I tried to use `pymdownx.snippets`, and copied the code from the [adding-a-glossary](https://squidfunk.github.io/mkdocs-material/reference/abbreviations/#adding-a-glossary), the abbreviation docs wasn't included.
Instead after serving the site locally I got no abbreviation underlines in the text followed by

```
--8<--​ "includes/abbreviation.md"
```

I then realized that there is a "zero width space" character (U+200B) after the `--8<--` which prevented the snippets extension from correctly parsing the include. 

Notice the red dot after `--8<--` in the following screenshot:

![mkdocs-char](https://user-images.githubusercontent.com/1286618/104247672-86cf5a00-5468-11eb-8a7a-2561a07a2d5d.png)

To see the hidden character I also used: https://www.soscisurvey.de/tools/view-chars.php

![image](https://user-images.githubusercontent.com/1286618/104247626-7323f380-5468-11eb-8383-bfbc7cf9088d.png)


This PR removes those "zero width space" characters.