### PR TITLE
Replace deprecated -webkit-details-marker

### DIFF
--- a/src/assets/stylesheets/main/extensions/pymdownx/_details.scss
+++ b/src/assets/stylesheets/main/extensions/pymdownx/_details.scss
@@ -114,7 +114,7 @@
     }
 
     // Hide native details marker
-    &::-webkit-details-marker {
+    &::marker {
       display: none;
     }
   }

--- a/src/assets/stylesheets/main/layout/_search.scss
+++ b/src/assets/stylesheets/main/layout/_search.scss
@@ -595,7 +595,7 @@
     }
 
     // Hide native details marker
-    &::-webkit-details-marker {
+    &::marker {
       display: none;
     }
 


### PR DESCRIPTION
[Deprecation] ::-webkit-details-marker pseudo element selector is deprecated. Please use ::marker instead. See https://chromestatus.com/feature/6730096436051968 for more details.