### PR TITLE
Call code font "monospace" instead of "proportional"

### DIFF
--- a/docs/setup/changing-the-fonts.md
+++ b/docs/setup/changing-the-fonts.md
@@ -19,7 +19,7 @@ or another destination should be used.
 :octicons-milestone-24: Default: [`Roboto`][3]
 
 The _regular font_ is used for all body copy, headlines, and essentially
-everything that does not need to be proportionally spaced. It can be set to any
+everything that does not need to be monospaced. It can be set to any
 valid [Google Font][1] with:
 
 ``` yaml
@@ -33,12 +33,12 @@ The typeface will be loaded in 300, 400, _400i_ and __700__.
   [2]: https://github.com/squidfunk/mkdocs-material/blob/master/src/base.html
   [3]: https://fonts.google.com/specimen/Roboto
 
-### Proportional font
+### Monospaced font
 
 [:octicons-file-code-24: Source][2] ·
 :octicons-milestone-24: Default: [`Roboto Mono`][4]
 
-The _proportional font_ is used for code blocks and can be configured separately.
+The _monospaced font_ is used for code blocks and can be configured separately.
 Just like the regular font, it can be set to any valid [Google Font][1] via
 `mkdocs.yml` with:
 
@@ -88,7 +88,7 @@ corresponding `@font-face` definition:
 ```
 
 The font can then be applied to specific elements, e.g. only headlines, or 
-globally to be used as the site-wide regular or proportional font:
+globally to be used as the site-wide regular or monospaced font:
 
 === "Regular font"
 
@@ -98,7 +98,7 @@ globally to be used as the site-wide regular or proportional font:
     }
     ```
 
-=== "Proportional font"
+=== "Monospaced font"
 
     ``` css
     pre, code, kbd {

--- a/src/assets/stylesheets/main/_typeset.scss
+++ b/src/assets/stylesheets/main/_typeset.scss
@@ -40,7 +40,7 @@ input {
     -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif;
 }
 
-// Define proportionally spaced fonts
+// Define monospaced fonts
 code,
 pre,
 kbd {


### PR DESCRIPTION
Implements the conclusion reached in #2309.