### PR TITLE
Support the Google analytics 4

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -71,8 +71,12 @@
       <link rel="stylesheet" href="{{ path | url }}">
     {% endfor %}
     {% block analytics %}
-      {% if config.google_analytics %}
-        {% include "partials/integrations/analytics.html" %}
+      {% if config.google_analytics_4 %}
+        {% include "partials/integrations/analytics-4.html" %}
+      {% else %}
+        {% if config.google_analytics %}
+          {% include "partials/integrations/analytics.html" %}
+        {% endif %}
       {% endif %}
     {% endblock %}
     {% block extrahead %}{% endblock %}

--- a/material/partials/integrations/analytics-4.html
+++ b/material/partials/integrations/analytics-4.html
@@ -1,0 +1,6 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% set analytics_4 = config.google_analytics_4 %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_4[0] }}"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);} gtag('js',new Date());gtag('config','{{ analytics_4[0] }}');</script>

--- a/src/base.html
+++ b/src/base.html
@@ -143,8 +143,12 @@
 
     <!-- Analytics -->
     {% block analytics %}
-      {% if config.google_analytics %}
-        {% include "partials/integrations/analytics.html" %}
+      {% if config.google_analytics_4 %}
+        {% include "partials/integrations/analytics-4.html" %}
+      {% else %}
+        {% if config.google_analytics %}
+          {% include "partials/integrations/analytics.html" %}
+        {% endif %}
       {% endif %}
     {% endblock %}
 

--- a/src/partials/integrations/analytics-4.html
+++ b/src/partials/integrations/analytics-4.html
@@ -1,0 +1,32 @@
+<!--
+  Copyright (c) 2016-2021 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+{% set analytics_4 = config.google_analytics_4 %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_4[0] }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ analytics_4[0] }}');
+</script>


### PR DESCRIPTION
Currently, the theme does not support the newest Google analytics 4 API. I provide an option for enabling it in the config file. In `mkdocs.yml`, add the following line:

```yaml
# Google Analytics
google_analytics_4:
  - <your-google-analytics-4-ID>
```

When setting `google_analytics_4`, the original configs `google_analytics` would not be used.
