### PR TITLE
docs: Better clarify logo setup options

### DIFF
--- a/docs/setup/changing-the-logo-and-icons.md
+++ b/docs/setup/changing-the-logo-and-icons.md
@@ -16,11 +16,19 @@ additional icons][1] with minimal effort.
 ### Logo
 
 [:octicons-file-code-24: Source][2] ·
-:octicons-milestone-24: Default: `material/library`
+:octicons-milestone-24: Default: [`material/library`](https://github.com/squidfunk/mkdocs-material/blob/master/material/.icons/material/library.svg)
 
-There're two ways to specify a _logo_: it must be a valid path to [any icon 
-bundled with the theme][3], or to a user-provided image located in the `docs`
-folder. Both can be set via `mkdocs.yml`:
+Configured in your `mkdocs.yml`; there are two types of _logo_ (choose only one):
+
+- `theme.logo` a user-provided image (_supports SVG_) located in the `docs` folder.
+- `theme.icon.logo` for using [any icon bundled with the theme][3].
+
+=== "Image"
+
+    ``` yaml
+    theme:
+      logo: assets/logo.png
+    ```
 
 === "Icon"
 
@@ -28,13 +36,6 @@ folder. Both can be set via `mkdocs.yml`:
     theme:
       icon:
         logo: material/library
-    ```
-
-=== "Image"
-
-    ``` yaml
-    theme:
-      logo: assets/logo.png
     ```
 
   [2]: https://github.com/squidfunk/mkdocs-material/blob/master/src/partials/logo.html


### PR DESCRIPTION
In response to [troubleshooting an issue that I misunderstood as a bug](https://github.com/squidfunk/mkdocs-material/issues/2370) (but was the fault of reading docs at 3am).

Related, another user ran into a similar problem: https://github.com/squidfunk/mkdocs-material/discussions/2167

---

Better clarifies the distinct path difference (as they share a very similar but slightly different path), which can be accidentally missed triggering either an unhelpful "error" message to the console: `.icons/<logo value>.svg`.

Additionally switches the order of the tabs to the more common implicit use-case of providing a logo resource vs a more explicit decision to use a bundled theme SVG icon for a logo (which is handled differently compared to `theme.logo` such as scaling).