### PR TITLE
Fix navigation.instant to correctly handle version dropdown

### DIFF
--- a/src/assets/javascripts/integrations/instant/index.ts
+++ b/src/assets/javascripts/integrations/instant/index.ts
@@ -276,7 +276,9 @@ export function setupInstantLoading(
 
           /* Components */
           "[data-md-component=announce]",
-          "[data-md-component=header-topic]",
+          // Replace header-title rather than header-topic in order to avoid problem with
+          // versioning.
+          "[data-md-component=header-title]",
           "[data-md-component=container]",
           "[data-md-component=skip]"
         ]) {


### PR DESCRIPTION
Without this change, on each instant navigation, an additional version
dropdown is added but the old one also remains in the header, leading
to multiple version dropdowns.