### PR TITLE
fix(Version Selector): Current version should be consistent with drop-down listed version

### DIFF
--- a/src/assets/javascripts/templates/version/index.tsx
+++ b/src/assets/javascripts/templates/version/index.tsx
@@ -61,7 +61,7 @@ export function renderVersionSelector(versions: Version[]): HTMLElement {
   return (
     <div class="md-version">
       <span class="md-version__current">
-        {active.version}
+        {active.title}
       </span>
       <ul class="md-version__list">
         {versions.map(version => (


### PR DESCRIPTION
Use the presentational `title` value like the drop-down does; not the `version` value used to match the URL (version subdirectory).