### PR TITLE
Fix wrong link in admonitions.md

### DIFF
--- a/docs/reference/admonitions.md
+++ b/docs/reference/admonitions.md
@@ -454,4 +454,5 @@ _Result_:
 
   [13]: https://github.com/squidfunk/mkdocs-material/tree/master/material/.icons
   [14]: ../customization.md#additional-css
-  [15]: https://facelessuser.github.io/pymdown-extensions/extensions/details/
+  [15]: ../icons-emojis.md#with-animations
+  


### PR DESCRIPTION
See #2360 for complete context.

This should link the section about animating icons to the right page.