### PR TITLE
Update css for custom admonition example

### DIFF
--- a/docs/reference/admonitions.md
+++ b/docs/reference/admonitions.md
@@ -402,6 +402,7 @@ following CSS to an [additional stylesheet][14]:
 .md-typeset .pied-piper > .admonition-title,
 .md-typeset .pied-piper > summary {
   background-color: rgba(43, 155, 70, 0.1);
+  border-color: rgb(43, 155, 70);
 }
 .md-typeset .pied-piper > .admonition-title::before,
 .md-typeset .pied-piper > summary::before {
@@ -426,6 +427,7 @@ colors. [You can even add animations][15].
   .md-typeset .pied-piper > .admonition-title,
   .md-typeset .pied-piper > summary {
     background-color: rgba(43, 155, 70, 0.1);
+    border-color: rgb(43, 155, 70);
   }
   .md-typeset .pied-piper > .admonition-title::before,
   .md-typeset .pied-piper > summary::before {


### PR DESCRIPTION
It seems to be required to set a `border-color: <color>;` for `.md-typeset .<class> > .adminition-title, .md-typeset .<class> > summary` to make it work with details or it will otherwise display the primary fg color for the left border.

If there is a better way to this, let me know and I'll update this PR.