### PR TITLE
remove 'shortcut' from favicon meta tag

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -58,7 +58,7 @@
       {% endif %}
 
       <!-- Favicon -->
-      <link rel="shortcut icon" href="{{ config.theme.favicon | url }}" />
+      <link rel="icon" href="{{ config.theme.favicon | url }}" />
 
       <!-- Generator banner -->
       <meta


### PR DESCRIPTION
This isn't needed and was never part of the spec.
Great article here: https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs#did-we-forget-anyone

Also:
https://mathiasbynens.be/notes/rel-shortcut-icon