### PR TITLE
Support TOC anchor targets vertical order differing from TOC order.

### DIFF
--- a/src/assets/javascripts/components/toc/index.ts
+++ b/src/assets/javascripts/components/toc/index.ts
@@ -161,6 +161,13 @@ export function watchTableOfContents(
         }, new Map<HTMLAnchorElement[], number>())
       }),
 
+      /* Sort index by vertical offset */
+      map(index => (
+        new Map<HTMLAnchorElement[], number>(
+          [...index].sort(([, offsetA], [, offsetB]) => offsetA - offsetB)
+        )
+      )),
+
       /* Re-compute partition when viewport offset changes */
       switchMap(index => combineLatest([adjust$, viewport$])
         .pipe(


### PR DESCRIPTION
Prior to this PR, if the TOC anchor targets' vertical page offsets did not match the order of the TOC anchors themselves, then blur would not work correctly.

All this PR does is sort the anchors by their target's offset so that computation of the current partition (driven by the viewport) remains accurate.

The primary motivation for this change is that I've created a Python-Markdown plugin which allows you to manually insert entries into TOC: https://github.com/Benjamin-Dobell/pymdown-toc-ext.

`pymdown-toc-ext` aside, if a user was particularly adventurous, they could also run into the vertical offset issue with CSS that reorders the anchor targets / headers vertically.

P.S. pymdown-toc-ext can be used as an alternate mechanism to address #1408 #313 #974 (probably others too).

P.P.S. I read the CONTRIBUTING doc re: including build artefacts. However, I'm seeing a [_lot_ of unrelated changes](https://github.com/Benjamin-Dobell/mkdocs-material/commit/ca28879c1f1720b6c2edd7aee29f6cb141869db1) when I build. For example, > 100 SVGs have changed for some reason 🤷‍♂️