### PR TITLE
Add trailing slash to version selector URL's

### DIFF
--- a/src/assets/javascripts/templates/version/index.tsx
+++ b/src/assets/javascripts/templates/version/index.tsx
@@ -68,7 +68,7 @@ export function renderVersionSelector(versions: Version[]): HTMLElement {
           <li class="md-version__item">
             <a
               class="md-version__link"
-              href={`${new URL(version.version, config.base)}`}
+              href={`${new URL(version.version + "/", config.base)}`}
             >
               {version.title}
             </a>


### PR DESCRIPTION
Add trailing slash to URL's in version selector in order to be in line with other links in generated docs. This ensures that the relative paths to js / css always work. For me they did not work when deploying to Azure blob storage, hosted as "static website".

You can observe the behavior in the example: https://squidfunk.github.io/mkdocs-material-example-versioning/latest/
- hover over version selector -> no trailing slash
- hover over other link -> trailing slash

Note: I did build the theme, but got a lot of build artifacts, so was not sure whether to include them.