### PR TITLE
fix: inline code block inherit link color

### DIFF
--- a/src/assets/stylesheets/main/_typeset.scss
+++ b/src/assets/stylesheets/main/_typeset.scss
@@ -210,7 +210,7 @@ kbd {
   }
 
   // Ensure link color in code blocks
-  a > code {
+  a code {
     color: currentColor;
   }
 


### PR DESCRIPTION
Removes the direct ancestor requirement. Any content wrapped in an anchor tag is within the content boundaries of representing a link.

I had a markdown link with inline code block as part of the link text. It rendered as expected, until I altered presentation with italics or bold, due to the `<code>` block being wrapped by another element, preventing the CSS from applying. I see no reason for an direct child requirement in the selector rule.