### PR TITLE
Fix lint

### DIFF
--- a/src/assets/javascripts/integrations/instant/index.ts
+++ b/src/assets/javascripts/integrations/instant/index.ts
@@ -316,7 +316,7 @@ export function setupInstantLoading(
 
         /* Complete immediately */
         } else {
-          script.textContent = el.textContent!
+          script.textContent = el.textContent
           replaceElement(el, script)
           return EMPTY
         }


### PR DESCRIPTION
This assertion is unnecessary since the receiver accepts the original type of the expression  @typescript-eslint/no-unnecessary-type-assertion

Unblocks #2446