### PR TITLE
Add tip about setting use_directory_urls: false for offline docs

### DIFF
--- a/docs/setup/setting-up-site-search.md
+++ b/docs/setup/setting-up-site-search.md
@@ -255,6 +255,12 @@ For setup instructions, refer to the [official documentation][18].
   [17]: https://github.com/squidfunk/iframe-worker
   [18]: https://github.com/wilhelmer/mkdocs-localsearch#installation-material-v5
 
+!!! tip
+
+    When distributing documentation as HTML files to be opened from the file
+    system, you will also want to set `use_directory_urls: false` in
+    `mkdocs.yml` to make page links function correctly.
+
 ## Customization
 
 The search implementation of Material for MkDocs is probably its most


### PR DESCRIPTION
When packaging up a Material for MkDocs project for offline HTML file system distribution, I initially had trouble finding a reference to solve this issue: https://github.com/mkdocs/mkdocs/issues/526#issuecomment-102064019

The Offline Search is currently the only place I could find that Material for MkDocs discusses this concept, so I added a `tip` to help other users that come across this in the future.