### PR TITLE
Update extracopyright in footer (fixes issue 2508)

### DIFF
--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -94,7 +94,7 @@
         >
           Material for MkDocs
         </a>
-        {% block extracopyright %}{% endblock %}
+        {{ extracopyright }}
       </div>
 
       <!-- Social links -->


### PR DESCRIPTION
Replace the extracopyright block,which doesnt' work, by a variable `{{ extracopyright }}` that can be set e.g from `overrides/main.html` with `{% set extracopyright %} ... {% set %}`; see issue #2508.