### PR TITLE
Fix example for hero deprecation

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -98,13 +98,15 @@ templates can be shared among multiple pages:
 
     ``` markdown
     ---
-    template: overrides/hero.html
+    template: hero.html
     ---
     ```
 
 === "Template"
 
     ``` html
+    {% extends "base.html" %}
+
     {% block hero %}
       <!-- Add custom hero here -->
     {% endblock %}


### PR DESCRIPTION
- If  the `custom_dir` is `overrides` (as specified  in the documentation) it shouldn't be specified in the template path
- `{% extends "base.html" %}` is needed in the template