### PR TITLE
Update highlight.js example

### DIFF
--- a/docs/reference/code-blocks.md
+++ b/docs/reference/code-blocks.md
@@ -56,17 +56,17 @@ configuring syntax highlighting of code blocks:
         === "docs/javascripts/config.js"
 
             ``` js
-            hljs.initHighlighting()
+            hljs.highlightAll()
             ```
 
         === "mkdocs.yml"
 
             ``` yaml
             extra_javascript:
-              - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js
+              - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js
               - javascripts/config.js
             extra_css:
-              - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/default.min.css
+              - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/default.min.css
             ```
 
         Note that Highlight.js has no affiliation with the Highlight extension.

--- a/docs/reference/code-blocks.md
+++ b/docs/reference/code-blocks.md
@@ -56,7 +56,9 @@ configuring syntax highlighting of code blocks:
         === "docs/javascripts/config.js"
 
             ``` js
-            hljs.highlightAll()
+            document$.subscribe(() => {
+              hljs.highlightAll()
+            })
             ```
 
         === "mkdocs.yml"


### PR DESCRIPTION
- Use latest `highlight.js` version that now uses `highlightAll()`
- Fix when instant navigation is enabled (see #2569)