### PR TITLE
Add title to prev/next footer links

### DIFF
--- a/material/partials/footer.html
+++ b/material/partials/footer.html
@@ -6,7 +6,7 @@
   {% if page.previous_page or page.next_page %}
     <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer.title') }}">
       {% if page.previous_page %}
-        <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" rel="prev">
+        <a href="{{ page.previous_page.url | url }}" title="{{ lang.t('footer.previous') }}" class="md-footer__link md-footer__link--prev" rel="prev">
           <div class="md-footer__button md-icon">
             {% include ".icons/material/arrow-left.svg" %}
           </div>
@@ -21,7 +21,7 @@
         </a>
       {% endif %}
       {% if page.next_page %}
-        <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" rel="next">
+        <a href="{{ page.next_page.url | url }}" title="{{ lang.t('footer.next') }}" class="md-footer__link md-footer__link--next" rel="next">
           <div class="md-footer__title">
             <div class="md-ellipsis">
               <span class="md-footer__direction">

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -36,6 +36,7 @@
       {% if page.previous_page %}
         <a
           href="{{ page.previous_page.url | url }}"
+          title="{{ lang.t('footer.previous') }}"
           class="md-footer__link md-footer__link--prev"
           rel="prev"
         >
@@ -57,6 +58,7 @@
       {% if page.next_page %}
         <a
           href="{{ page.next_page.url | url }}"
+          title="{{ lang.t('footer.next') }}"
           class="md-footer__link md-footer__link--next"
           rel="next"
         >


### PR DESCRIPTION
Adds a title to the pre/next footer links to satisfy accessibility requirements. On mobile only the icon is shown so the text is not providing the needed context for screen readers.