### PR TITLE
Add ability to override homepage title (config.extra.homepage_title)

### DIFF
--- a/docs/setup/changing-the-logo-and-icons.md
+++ b/docs/setup/changing-the-logo-and-icons.md
@@ -48,6 +48,7 @@ with the following configuration:
 ``` yaml
 extra:
   homepage: https://example.com
+  homepage_title: Example
 ```
 
 ### Favicon

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -30,9 +30,9 @@
     <!-- Link to home -->
     <a
       href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
-      title="{{ config.site_name | e }}"
+      title="{{ config.extra.homepage_title | d(config.site_name, true) | e }}"
       class="md-header__button md-logo"
-      aria-label="{{ config.site_name }}"
+      aria-label="{{ config.extra.homepage_title | d(config.site_name, true) }}"
       data-md-component="logo"
     >
       {% include "partials/logo.html" %}


### PR DESCRIPTION
While you can change homepage URL, I was wondering if it made sense to also allow for the hompage title to be changed. Allowing this will prevent you from having to override the header.html partial and goes along with the homepage URL.