### PR TITLE
Update `name` info in config docs

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -56,7 +56,7 @@ slightly different:
 
     ``` yaml
     theme:
-      name: null
+      name: material
       custom_dir: mkdocs-material/material
 
       # 404 page


### PR DESCRIPTION
This can actually stay as `material` and does not have to be `null`. Benefit is that even when using a fork/material as submodule, plugins can rely on the name from the config for feature detection.