### PR TITLE
Point `keys` reference to `keys`, not `snippets`

### DIFF
--- a/docs/reference/code-blocks.md
+++ b/docs/reference/code-blocks.md
@@ -382,7 +382,7 @@ The `#!python range()` function is used to generate a sequence of numbers.
 ### Adding keyboard keys
 
 When [Keys][22] is enabled, keyboard keys can be rendered with a simple syntax.
-Consult the [Python Markdown Extensions][16] documentation to learn about all
+Consult the [Python Markdown Extensions][14] documentation to learn about all
 available key codes.
 
 _Example_:


### PR DESCRIPTION
I noticed in the docs that the link to browse the key codes actually links to the snippets extension.

I believe this was due to an accidental switch of the numbers used as link references.

Might I suggest at some point converting this page to use textual keys (e.g. `[keys-extension]` instead of `[14]`) to prevent such inadvertent swaps in the future?