### PR TITLE
Add OkHttp to list of successful OSS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ For other installation methods, configuration options, and a demo, visit
 [Kubernetes](https://kops.sigs.k8s.io/),
 [kSQL](https://docs.ksqldb.io/),
 [Nokogiri](https://nokogiri.org/),
+[OkHttp](https://square.github.io/okhttp/),
 [OpenFaaS](https://docs.openfaas.com/),
 [Pi-Hole](https://docs.pi-hole.net/),
 [Pydantic](https://pydantic-docs.helpmanual.io/),


### PR DESCRIPTION
OkHttp being over 40K stars, and well known among Java and Kotlin
developers, it makes sense to have it in the list.