### PR TITLE
Add DockerHub credentials instructions

### DIFF
--- a/docs/insiders/getting-started.md
+++ b/docs/insiders/getting-started.md
@@ -59,9 +59,10 @@ comfortable self-hosting:
     2. Click on [Generate a new token][5]
     3. Enter a name and select the [`write:packages`][10] scope
     4. Generate the token and store it in a safe place
-4. Add a [GitHub Actions secret][11] on your fork
-    1. Set the name to `GHCR_TOKEN`
-    2. Set the value to the personal access token created in the previous step
+4. Add [GitHub Actions secrets][11] on your fork
+    1. Set the name to `GHCR_TOKEN`. Set the value to the personal access token created in the previous step
+    2. Set the name to `DOCKER_USERNAME`. Set the value to your Docker ID from hub.docker.com.
+    3. Set the name to `DOCKER_PASSWORD`. Set the value to your Docker Access Token that you can create at https://hub.docker.com/settings/security.
 5. [Create a new release][12] to build and publish the Docker image
 6. Install [Pull App][13] on your fork to stay in-sync with upstream
 


### PR DESCRIPTION
This is needed because of lines 46-50 in the `.github/workflows/publish.yml` file

```
      - name: Login to DockerHub
        uses: docker/login-action@v1
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
```

Another option is to remove those lines. I tried both options and they worked. I'm not really sure why it is necessary to log into DockerHub if we are only using GHCR, but I assume that those steps are there for a reason.