### PR TITLE
Change default CI name in the docs

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -20,13 +20,13 @@ charge and pretty easy to set up.
 
 Using [GitHub Actions][2] you can automate the deployment of your project
 documentation. At the root of your repository, create a new GitHub Actions
-workflow, e.g. `.github/workflows/ci.yml`, and copy and paste the following
+workflow, e.g. `.github/workflows/deploy.yml`, and copy and paste the following
 contents:
 
 === "Material for MkDocs"
 
     ``` yaml
-    name: ci # (1)
+    name: Deploy # (1)
     on:
       push:
         branches: # (2)
@@ -62,7 +62,7 @@ contents:
 === "Insiders"
 
     ``` yaml
-    name: ci
+    name: deploy
     on:
       push:
         branches:


### PR DESCRIPTION
I changed the name `ci` to `Deploy` in the section explaining how to publish the site on GitHub. I think it's a lot clearer. If you prefer lowercase, you can, of course, change it to `deploy`.