### PR TITLE
Add multi arch docker build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,11 +63,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -86,7 +90,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ${{ github.event.repository.full_name }}:latest
             ${{ github.event.repository.full_name }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
This PR adds support for building and publishing linux/arm64 and arm/v7 Docker images.

The output works fine on my Macbook M1 and can be found here: https://github.com/afritzler/mkdocs-material/pkgs/container/mkdocs-material

Additionally the arm/v7 images can now be run on a Raspberry Pi (tested on a Raspberry Pi 2 Model B Rev 1.1).

Fixes #2945 