### PR TITLE
Use Renovate brandname in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For other installation methods, configuration options, and a demo, visit
 [OpenFaaS](https://docs.openfaas.com/),
 [Pi-Hole](https://docs.pi-hole.net/),
 [Pydantic](https://pydantic-docs.helpmanual.io/),
-[Renovatebot](https://docs.renovatebot.com/),
+[Renovate](https://docs.renovatebot.com/),
 [Traefik](https://docs.traefik.io/),
 [Vapor](https://docs.vapor.codes/),
 [ZeroNet](https://zeronet.io/docs/),


### PR DESCRIPTION
## Changes:

- Change `Renovatebot` -> `Renovate`

## Context:

The Renovate project uses `Renovate` as the brand name for the bot. If you want to keep the bot part of the name, then I think it's better to use `Renovate Bot`.

Quote from Renovate documentation homepage: [^homepage]

> Renovate (often referred to as "Renovate Bot") is an Open Source tool designed to automate the process of:

[^homepage]: https://docs.renovatebot.com/