### PR TITLE
Use el ISO 639-1 code for Greek language

### DIFF
--- a/docs/setup/changing-the-language.md
+++ b/docs/setup/changing-the-language.md
@@ -35,6 +35,7 @@ The following languages are supported:
 - `cs` – Czech
 - `da` – Danish
 - `de` – German
+- `el` – Greek
 - `en` – English
 - `eo` – Esperanto
 - `es` – Spanish
@@ -43,7 +44,6 @@ The following languages are supported:
 - `fi` – Finnish
 - `fr` – French
 - `gl` – Galician
-- `gr` – Greek
 - `he` – Hebrew
 - `hi` – Hindi
 - `hr` – Croatian

--- a/material/partials/languages/el.html
+++ b/material/partials/languages/el.html
@@ -2,7 +2,7 @@
   This file was automatically generated - do not edit
 -#}
 {% macro t(key) %}{{ {
-  "language": "gr",
+  "language": "el",
   "clipboard.copy": "Αντιγραφή",
   "clipboard.copied": "Αντιγράφηκε",
   "edit.link.title": "Επεξεργασία αυτής της σελίδας",

--- a/src/partials/languages/el.html
+++ b/src/partials/languages/el.html
@@ -22,7 +22,7 @@
 
 <!-- Translations: Greek -->
 {% macro t(key) %}{{ {
-  "language": "gr",
+  "language": "el",
   "clipboard.copy": "Αντιγραφή",
   "clipboard.copied": "Αντιγράφηκε",
   "edit.link.title": "Επεξεργασία αυτής της σελίδας",


### PR DESCRIPTION
Hi, this PR renames the Greek language code from "gr" to "el", as defined in https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes.

The code "gr" is for the country (Greece, e.g. DNS TLD), while "el" is for the language (Greek, H**el**lenic), which is also spoken in Cyprus.

Relevant issue: #3182