### PR TITLE
Source branch for GitHub Pages has to be set

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -91,6 +91,9 @@ Now, when a new commit is pushed to either the `master` or `main` branches,
 the static site is automatically built and deployed. Push your changes to see
 the workflow in action.
 
+After the first successful build, visit `github.com/<username>/<repository>/settings/pages`
+and set `Source (branch)` to `gh-pages`.
+
 Your documentation should shortly appear at `<username>.github.io/<repository>`.
 
   [GitHub Actions]: https://github.com/features/actions

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -91,8 +91,9 @@ Now, when a new commit is pushed to either the `master` or `main` branches,
 the static site is automatically built and deployed. Push your changes to see
 the workflow in action.
 
-After the first successful build, visit `github.com/<username>/<repository>/settings/pages`
-and set `Source (branch)` to `gh-pages`.
+If the GitHub Page doesn't show up after a few minutes, ensure the source branch
+for your GitHub Page is set to `gh-pages` in your repository settings 
+`github.com/<username>/<repository>/settings/pages`.
 
 Your documentation should shortly appear at `<username>.github.io/<repository>`.
 


### PR DESCRIPTION
Using your awesome workflow, a branch gh-pages is being created, which serves as GitHub Pages source. This has to be set once in the repository settings.