### PR TITLE
Minimal configuration is not enough for a build

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -62,6 +62,7 @@ slightly different:
 === ":fontawesome-brands-git-alt: git"
 
     ``` yaml
+    site_name: Example-Name
     theme:
       name: null
       custom_dir: mkdocs-material/material


### PR DESCRIPTION
The build fails due to the lack of `site_name`