### PR TITLE
Account for empty versions

### DIFF
--- a/src/assets/javascripts/templates/version/index.tsx
+++ b/src/assets/javascripts/templates/version/index.tsx
@@ -76,10 +76,12 @@ export function renderVersionSelector(versions: Version[]): HTMLElement {
   const config = configuration()
 
   /* Determine active version */
-  const [, current] = config.base.match(/([^/]*)\/?$/)!
+  const [, current] = config.base.match(/([^/]+)\/?$/)!
   const active =
     versions.find(({ version, aliases }) => (
       version === current || aliases.includes(current)
+    )) || versions.find(({ version }) => (
+      version === ""
     )) || versions[0]
 
   /* Render version selector */

--- a/src/assets/javascripts/templates/version/index.tsx
+++ b/src/assets/javascripts/templates/version/index.tsx
@@ -76,7 +76,7 @@ export function renderVersionSelector(versions: Version[]): HTMLElement {
   const config = configuration()
 
   /* Determine active version */
-  const [, current] = config.base.match(/([^/]+)\/?$/)!
+  const [, current] = config.base.match(/([^/]*)\/?$/)!
   const active =
     versions.find(({ version, aliases }) => (
       version === current || aliases.includes(current)


### PR DESCRIPTION
Essentially, I really want the default version to be at the root and the versioned docs to live alongside it.

I'd manage `versions.json` myself so it (and dropdown) would look like:

```json
[
    {"version": "dev", "title": "dev", "aliases": []},
    {"version": "", "title": "1.1", "aliases": []},
    {"version": "1.0", "title": "1.0", "aliases": []}
]
```

Then when `1.2` is released:

```json
[
    {"version": "dev", "title": "dev", "aliases": []},
    {"version": "", "title": "1.2", "aliases": []},
    {"version": "1.1", "title": "1.1", "aliases": []},
    {"version": "1.0", "title": "1.0", "aliases": []}
]
```