### PR TITLE
Fixed typo in docs/customization.md

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -12,7 +12,7 @@ necessary to preserve your brand's style.
 ## Adding assets
 
 [MkDocs] provides several ways to customize a theme. In order to make a few
-small tweaks to Material for MkDocs, you can just CSS and JavaScript files to
+small tweaks to Material for MkDocs, you can just add CSS and JavaScript files to
 the `docs` directory.
 
   [MkDocs]: https://www.mkdocs.org


### PR DESCRIPTION
There was a minor typo in the following line:

```
...Material for MkDocs, you can just CSS and JavaScript files to...
```

Added "add".
```
...Material for MkDocs, you can just add CSS and JavaScript files to...
```