### PR TITLE
add meta data to require python >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     packages = find_packages(exclude = ["src"]),
     include_package_data = True,
     install_requires = install_requires,
+    python_requires='>=3.6',
     entry_points = {
         "mkdocs.themes": [
             "material = material",


### PR DESCRIPTION
[MkDocs has dropped support for Python 3.5 in 1.2](https://www.mkdocs.org/about/release-notes/#other-changes-and-additions-to-version-12)