### PR TITLE
Add GA4 docs for page helpful

### DIFF
--- a/docs/setup/setting-up-site-analytics.md
+++ b/docs/setup/setting-up-site-analytics.md
@@ -116,18 +116,41 @@ integrated with the [cookie consent][extra.consent] feature[^1].
 
 ??? question "How to visualize the collected feedback ratings?"
 
-    It's quite easy to build a custom report with [Google Analytics] that will
-    quickly show you the worst- and best-rated pages of your project
-    documentation. You can generate a custom report with the following steps:
+    To visualize feedback ratings you'll need to create a custom report with
+    [Google Analytics] that will quickly show you the worst- and best-rated
+    pages of your project documentation.
 
-    1. Go to your Google Analytics __dashboard__
-    2. Open the __customization__ panel on the left and go to __custom reports__
-    3. Create a __new custom report__ and set a custom __title__ and __name__
-    4. Add `Avg. Value` and `Total Events` to __metric group__
-    5. Add `Event Label` to __dimension drilldown__
-    6. Add `Event Category` to __filters__ and filter for the value __feedback__
+    === ":material-google-analytics: Google Analytics 4"
 
-    Now, after you've saved the report and collected some feedback ratings, 
+        1. Go to your Google Analytics __dashboard__
+        2. Go to the __Configure__ page on the left hand menu, then select __Custom Definitions__
+        3. Click the __Custom metrics__ tab and then __Create custom metrics__, enter the following values:
+            * Metric name: Page helpful
+            * Description: Was this page helpful?
+            * Event parameter: data
+            * Unit of measurement: Standard
+        4. Go to the __Explore__ page on the left hand menu, create a new __blank exploration__
+        5. Configure the report as follows:
+            * Dimensions: Add `Event name` and `Page location`
+            * Metrics: Add `Event count` and `Page helpful` (the custom metric created in step 3)
+            * Rows: `Page location`
+            * Values: `Page helpful`
+            * Filters: Add a new filter for `Event name / exactly matches / feedback`
+
+        !!! warning "Delay in data availability"
+
+            The report may take 24 hours or longer to begin displaying data
+
+    === ":material-google-analytics: Universal Analytics"
+
+        1. Go to your Google Analytics __dashboard__
+        2. Open the __customization__ panel on the left and go to __custom reports__
+        3. Create a __new custom report__ and set a custom __title__ and __name__
+        4. Add `Avg. Value` and `Total Events` to __metric group__
+        5. Add `Event Label` to __dimension drilldown__
+        6. Add `Event Category` to __filters__ and filter for the value __feedback__
+
+    Now, after you've saved the report and collected some feedback ratings,
     you'll have a list of all pages with the total number of ratings, and an
     average rating per page. This should help you identify pages that need to
     be improved:


### PR DESCRIPTION
Related: https://github.com/squidfunk/mkdocs-material/issues/3170

Adds docs for setting up a GA4 report to explore feedback data collected via mkdocs-material