### PR TITLE
Check for GitHub Action updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
   schedule:
     interval: weekly
     time: "04:00"
+- package-ecosystem: github-actions
+  open-pull-requests-limit: 10
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"


### PR DESCRIPTION
## Changes:

- Check for GitHub Action updates with Dependabot

## Context:

I checked your GitHub Action workflow files and saw you're using some old runners.
Dependabot can update the workflow runners for you automatically. [^gh-docs]

I've kept the schedule you already use for the other updates.

[^gh-docs]: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates