### PR TITLE
comma was missing before the last item

### DIFF
--- a/src/partials/languages/ru.html
+++ b/src/partials/languages/ru.html
@@ -53,6 +53,6 @@
   "source.file.date.updated": "Последнее обновление",
   "source.file.date.created": "Дата создания",
   "tabs.title": "Вкладки",
-  "toc.title": "Содержание раздела"
+  "toc.title": "Содержание раздела",
   "top.title": "К началу"
 }[key] }}{% endmacro %}


### PR DESCRIPTION
Comma was missing before the last item
This caused a crash during the documentation build
File "..\Python\Python310\lib\site-packages\material\partials\languages\ru.html", line 36, in template jinja2.exceptions.TemplateSyntaxError: expected token ':', got ','