### PR TITLE
*try* to add giscus tutorial

### DIFF
--- a/docs/setup/adding-a-comment-system.md
+++ b/docs/setup/adding-a-comment-system.md
@@ -5,22 +5,22 @@ template: overrides/main.html
 # Adding a comment system
 
 Material for MkDocs allows to easily add the third-party comment system of your
-choice to the footer of every page by using [theme extension]. As an example,
-we'll be integrating [Disqus] a wildly popular comment provider, but others
-can be integrate with the same principles
+choice to the footer of every page by using [theme extension]. On this page do
+we show two examples using [Disqus] and [Giscus] respectively.
 
   [Disqus]: https://disqus.com/
+  [Giscus]: https://giscus.app/
 
 ## Customization
 
-### Disqus integration
+### Extending the theme
 
 In order to integrate a third-party comment provider offering a JavaScript-based
 solution, follow the guide on [theme extension], copy the contents from the
 [`content.html`][content partial] partial and create a file at the same location
 in the `overrides` folder:
 
-=== ":octicons-file-code-16: overrides/partials/content.html"
+=== ":octicons-file-code-16: Disqus integration"
 
     ``` html
     <!-- Add copied contents from original content.html here -->
@@ -65,7 +65,77 @@ in the `overrides` folder:
 
     1.  Ensure you've set [`site_url`][site_url] in `mkdocs.yml`.
 
-=== ":octicons-file-code-16: mkdocs.yml"
+=== ":octicons-file-code-16: Giscus integration"
+    
+    Please make sure to follow all required steps for Giscus to
+    work, including adding the Giscus app to your repository and
+    enabling the Discussion feature for it.
+
+    ``` html
+    <!-- Add copied contents from original content.html here -->
+
+    <!-- Get setting from mkdocs.yml, but allow page-level overrides -->
+    {% set disqus = config.extra.giscus %}
+    {% if page and page.meta and page.meta.disqus is string %}
+      {% set disqus = page.meta.giscus %}
+    {% endif %}
+
+    <!-- Inject Disqus into current page -->
+    {% if not page.is_homepage and giscus %}
+      <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+      <div class="giscus"></div> <!-- (1) -->
+      <script>
+        var giscus_config = function() {
+          this.page.url = "{{ page.canonical_url }}"
+          this.page.identifier =
+            "{{ page.canonical_url | replace(config.site_url, '') }}" // (2)
+        }
+
+        /* Set up for the first time */
+        if (typeof GISCUS === "undefined") {
+          var script = document.createElement("script")
+          script.async = true
+          script.src = "https://{{ disqus }}.disqus.com/embed.js"
+          script.setAttribute("data-repo", "squidfunk/mkdocs-material") // (3)
+          script.setAttribute("data-repo-id", "eyxxxxx=")
+          script.setAttribute("data-category", "discussion")
+          script.setAttribute("data-category-id", "abc123")
+          script.setAttribute("data-mapping", "pathname")
+          script.setAttribute("data-reactions-enabled", "1")
+          script.setAttribute("data-emit-metadata", "0")
+          script.setAttribute("data-theme", "light")
+          script.setAttribute("data-lang", "en")
+          script.setAttribute("crossorigin", "anonymous")
+
+          /* Inject script tag */
+          document.body.appendChild(script)
+
+        /* Set up on navigation (instant loading) */
+        } else {
+          GISCUS.reset({
+            reload: true,
+            config: giscus_config
+          })
+        }
+      </script>
+    {% endif %}
+    ```
+    
+    1.  The div needs to be called `giscus` as that sets where the comment system should be located at
+    2.  Ensure you've set [`site_url`][site_url] in `mkdocs.yml`.
+    3.  Please see the [Giscus site][Giscus] what each `data-x` attribute is used for.
+
+  [site_url]: https://www.mkdocs.org/user-guide/configuration/#site_url
+
+### mkdocs.yml
+
+All you have to do now is set the right value inside the `mkdocs.yml` under the
+`extra` section.
+
+Note that the version with Disqus is used as identifier for what comment system
+to load while on Giscus it is only used to enable/disable it by default.
+
+=== ":octicons-file-code-16: Disqus"
 
     ``` yaml
     extra:
@@ -73,6 +143,13 @@ in the `overrides` folder:
     ```
 
     1.  Add your Disqus [shortname] here.
+    
+=== ":octicons-file-code-16: Giscus"
+
+    ``` yaml
+    extra:
+      giscus: 'yes'
+    ```
 
   [theme extension]: ../customization.md#extending-the-theme
   [content partial]: https://github.com/squidfunk/mkdocs-material/blob/master/src/partials/content.html
@@ -80,29 +157,34 @@ in the `overrides` folder:
 
 #### on a single page
 
-When [Metadata] is enabled, Disqus can be enabled or disabled for a single page
+When [Metadata] is enabled, Disqus/Giscus can be enabled or disabled for a single page
 with custom front matter. Add the following lines at the top of a Markdown file:
 
 === ":octicons-check-circle-fill-16: Enabled"
 
     ``` bash
     ---
-    disqus: <shortname>
+    disqus: <shortname> # (1)
     ---
 
     # Document title
     ...
     ```
+    
+    1.  Change this to `giscus: yes` for Giscus.
 
 === ":octicons-skip-16: Disabled"
 
     ``` bash
     ---
-    disqus: ""
+    disqus: "" # (1)
     ---
 
     # Document title
     ...
     ```
+    
+    1.  Change this to `giscus: ""` for Giscus.
 
   [Metadata]: extensions/python-markdown.md#metadata
+

--- a/docs/setup/adding-a-comment-system.md
+++ b/docs/setup/adding-a-comment-system.md
@@ -13,14 +13,13 @@ we show two examples using [Disqus] and [Giscus] respectively.
 
 ## Customization
 
-### Extending the theme
+### Disqus
 
-In order to integrate a third-party comment provider offering a JavaScript-based
-solution, follow the guide on [theme extension], copy the contents from the
-[`content.html`][content partial] partial and create a file at the same location
-in the `overrides` folder:
+In order to integrate [Disqus] into your site, follow the guide on [theme extension],
+copy the contents from the [`contents.html`][content partials] partial and create a
+file at the same location the `overrides` folder:
 
-=== ":octicons-file-code-16: Disqus integration"
+=== ":octicons-file-code-16: overrides/partials/content.html"
 
     ``` html
     <!-- Add copied contents from original content.html here -->
@@ -65,91 +64,14 @@ in the `overrides` folder:
 
     1.  Ensure you've set [`site_url`][site_url] in `mkdocs.yml`.
 
-=== ":octicons-file-code-16: Giscus integration"
+=== ":octicons-file-code-16: mkdocs.yml"
     
-    Please make sure to follow all required steps for Giscus to
-    work, including adding the Giscus app to your repository and
-    enabling the Discussion feature for it.
-
-    ``` html
-    <!-- Add copied contents from original content.html here -->
-
-    <!-- Get setting from mkdocs.yml, but allow page-level overrides -->
-    {% set disqus = config.extra.giscus %}
-    {% if page and page.meta and page.meta.disqus is string %}
-      {% set disqus = page.meta.giscus %}
-    {% endif %}
-
-    <!-- Inject Disqus into current page -->
-    {% if not page.is_homepage and giscus %}
-      <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
-      <div class="giscus"></div> <!-- (1) -->
-      <script>
-        var giscus_config = function() {
-          this.page.url = "{{ page.canonical_url }}"
-          this.page.identifier =
-            "{{ page.canonical_url | replace(config.site_url, '') }}" // (2)
-        }
-
-        /* Set up for the first time */
-        if (typeof GISCUS === "undefined") {
-          var script = document.createElement("script")
-          script.async = true
-          script.src = "https://{{ disqus }}.disqus.com/embed.js"
-          script.setAttribute("data-repo", "squidfunk/mkdocs-material") // (3)
-          script.setAttribute("data-repo-id", "eyxxxxx=")
-          script.setAttribute("data-category", "discussion")
-          script.setAttribute("data-category-id", "abc123")
-          script.setAttribute("data-mapping", "pathname")
-          script.setAttribute("data-reactions-enabled", "1")
-          script.setAttribute("data-emit-metadata", "0")
-          script.setAttribute("data-theme", "light")
-          script.setAttribute("data-lang", "en")
-          script.setAttribute("crossorigin", "anonymous")
-
-          /* Inject script tag */
-          document.body.appendChild(script)
-
-        /* Set up on navigation (instant loading) */
-        } else {
-          GISCUS.reset({
-            reload: true,
-            config: giscus_config
-          })
-        }
-      </script>
-    {% endif %}
-    ```
-    
-    1.  The div needs to be called `giscus` as that sets where the comment system should be located at
-    2.  Ensure you've set [`site_url`][site_url] in `mkdocs.yml`.
-    3.  Please see the [Giscus site][Giscus] what each `data-x` attribute is used for.
-
-  [site_url]: https://www.mkdocs.org/user-guide/configuration/#site_url
-
-### mkdocs.yml
-
-All you have to do now is set the right value inside the `mkdocs.yml` under the
-`extra` section.
-
-Note that the version with Disqus is used as identifier for what comment system
-to load while on Giscus it is only used to enable/disable it by default.
-
-=== ":octicons-file-code-16: Disqus"
-
     ``` yaml
     extra:
       disqus: <shortname> # (1)
     ```
 
     1.  Add your Disqus [shortname] here.
-    
-=== ":octicons-file-code-16: Giscus"
-
-    ``` yaml
-    extra:
-      giscus: 'yes'
-    ```
 
   [theme extension]: ../customization.md#extending-the-theme
   [content partial]: https://github.com/squidfunk/mkdocs-material/blob/master/src/partials/content.html
@@ -157,34 +79,67 @@ to load while on Giscus it is only used to enable/disable it by default.
 
 #### on a single page
 
-When [Metadata] is enabled, Disqus/Giscus can be enabled or disabled for a single page
+When [Metadata] is enabled, Disqus can be enabled or disabled for a single page
 with custom front matter. Add the following lines at the top of a Markdown file:
 
 === ":octicons-check-circle-fill-16: Enabled"
+    
+    ``` bash
+    ---
+    disqus: <shortname>
+    ---
+    
+    # Document title
+    ```
+
+=== ":octicons-skip-16: "Disabled"
 
     ``` bash
     ---
-    disqus: <shortname> # (1)
+    disqus: ""
     ---
-
-    # Document title
-    ...
-    ```
     
-    1.  Change this to `giscus: yes` for Giscus.
-
-=== ":octicons-skip-16: Disabled"
-
-    ``` bash
-    ---
-    disqus: "" # (1)
-    ---
-
     # Document title
-    ...
     ```
-    
-    1.  Change this to `giscus: ""` for Giscus.
 
-  [Metadata]: extensions/python-markdown.md#metadata
+### Giscus
 
+Before you can add Giscus into your site, make sure to follow their guide on setting
+it up, including adding their bot to the GitHub Repository and enabling the Discussions
+feature for it.
+
+To integrate [Giscus] into your site, follow the guide on [theme extension] and create
+a new HTML file, which doesn't match any of the already existing files in Material for MkDocs.
+You will then need to add the following content to it:
+
+``` html
+{% extends "overrides/main.html" %} // (1)
+
+<!-- Content -->
+{% block content %}
+  {{ super() }}
+  
+  <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+  <!-- Paste your generated <script> from Giscus here --> // (2)
+```
+
+1.  Make sure to use [`main.html`][main html] as the base file to extend.
+2.  You can find an example on the [GitHub Repository] of Material for MkDocs.
+
+  [main html]: https://github.com/squidfunk/mkdocs-material/blob/master/src/main.html
+  [GitHub Repository]: https://github.com/squidfunk/mkdocs-material/blob/master/src/overrides/blog.html
+
+#### enabling/disabling on a specific site
+
+Giscus won't be displayed on pages by default. To change this, make sure to have the
+[Metadata] extension added and add the following frontmatter to your Markdown file:
+
+``` bash
+---
+template: overrides/blog.html # (1)
+---
+
+# Document title
+```
+
+1.  Change `blog.html` with the name of your created HTML file.


### PR DESCRIPTION
This is a - in my personal opinion really bad - approach at adding a tutorial for how to Integrate Giscus into Material for MkDocs.

The main issues I have with this is, that you still heavily rely on the Giscus site itself to get values such as a Repo and Discussion ID, which I feel like isn't really an optimal approach.

I also don't think that it is well made in terms of structure and readability, so any help on improving this further is greatly appreciated.

Related discussion: #3266