### PR TITLE
Added a warning about index file and sections

### DIFF
--- a/docs/setup/setting-up-navigation.md
+++ b/docs/setup/setting-up-navigation.md
@@ -220,6 +220,17 @@ nav:
 
 This feature flag is not compatible with [`toc.integrate`][toc.integrate].
 
+!!! warning
+
+    You cannot have two `index.md` at the same hierarchical level of navigation, as this:
+
+    ```
+    nav:
+      - Section:
+        - section/index.md
+        - Page 1: exampleFolder/index.md
+    ```
+
   [navigation.indexes support]: https://github.com/squidfunk/mkdocs-material/releases/tag/7.3.0
   [navigation.indexes enabled]: ../assets/screenshots/navigation-index-on.png
   [navigation.indexes disabled]: ../assets/screenshots/navigation-index-off.png


### PR DESCRIPTION
Related to:

> Material for MkDocs only supports a single index.md (or README.md which is the same for MkDocs). If you rename the files of those pages they will reappear.

https://github.com/squidfunk/mkdocs-material/issues/3361#issuecomment-997282688