### PR TITLE
Bump Pygments to 2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ jinja2>=2.11.1
 markdown>=3.2
 mkdocs>=1.2.3
 mkdocs-material-extensions>=1.0
-pygments>=2.10
+pygments>=2.11
 pymdown-extensions>=9.0


### PR DESCRIPTION
Bumps the Pygments dependency to version 2.11.0.
See [changelogs](https://github.com/pygments/pygments/releases/tag/2.11.0) for more information.