### PR TITLE
Fix "Changing the color" and "Changing the language" document javascript code

### DIFF
--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -44,7 +44,14 @@ Click on a tile to change the color scheme:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-scheme")
       document.body.setAttribute("data-md-color-scheme", attr)
-      var name = document.querySelector("#__code_1 code span:nth-child(7)")
+      var nodes = document.querySelector("#__code_1 code").childNodes
+      var name
+      for (var i = 0; i < nodes.length; ++i) {
+        var node = nodes[i]
+        if (node.innerText == "scheme") {
+          name = nodes[i + 3]
+        }
+      }
       name.textContent = attr
     })
   })
@@ -99,8 +106,15 @@ Click on a tile to change the primary color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-primary")
       document.body.setAttribute("data-md-color-primary", attr)
-      var name = document.querySelector("#__code_2 code span:nth-child(7)")
-      name.textContent = attr.replace("-", " ")
+      var nodes = document.querySelector("#__code_2 code").childNodes
+      var name
+      for (var i = 0; i < nodes.length; ++i) {
+        var node = nodes[i]
+        if (node.innerText == "primary") {
+          name = nodes[i + 3]
+        }
+      }
+      name.textContent = attr
     })
   })
 </script>
@@ -156,8 +170,15 @@ Click on a tile to change the accent color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-accent")
       document.body.setAttribute("data-md-color-accent", attr)
-      var name = document.querySelector("#__code_3 code span:nth-child(7)")
-      name.textContent = attr.replace("-", " ")
+      var nodes = document.querySelector("#__code_3 code").childNodes
+      var name
+      for (var i = 0; i < nodes.length; ++i) {
+        var node = nodes[i]
+        if (node.innerText == "accent") {
+          name = nodes[i + 3]
+        }
+      }
+      name.textContent = attr
     })
   })
 </script>

--- a/docs/setup/changing-the-language.md
+++ b/docs/setup/changing-the-language.md
@@ -167,7 +167,14 @@ Click on a tile to change the directionality:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-dir")
       document.body.dir = attr
-      var name = document.querySelector("#__code_3 code span:nth-child(5)")
+      var nodes = document.querySelector("#__code_3 code").childNodes
+      var name
+      for (var i = 0; i < nodes.length; ++i) {
+        var node = nodes[i]
+        if (node.innerText == "direction") {
+          name = nodes[i + 3]
+        }
+      }
       name.textContent = attr
     })
   })


### PR DESCRIPTION
Currently the [Color Setup](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/) and [Language Setup](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/) page's button is not working correctly (at least on my Firefox 95.0.2 64-bit Arch Linux browser). When pressing buttons, incorrect text is changed, as illustrated in the screenshot:

![image](https://user-images.githubusercontent.com/95505675/148350944-d8f2960e-22ac-4304-a0f0-efcbeecf63f4.png)

(The "indigo" text in the code box should be changed, but the "palette" text is changed instead).

This is because the "primary" text is the 13th of the element in the code block and the javascript uses a hard-coded 7-element offset instead.

In this PR, I attempted to loop over the elements in code block to find the text that we need to modify in order to provide better compatibility over the hard-coded offset.