### PR TITLE
 Fix "Changing the color" and "Changing the language" document javascript code

### DIFF
--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -44,7 +44,7 @@ Click on a tile to change the color scheme:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-scheme")
       document.body.setAttribute("data-md-color-scheme", attr)
-      var name = document.querySelector("#__code_1 code span:nth-child(15)")
+      var name = document.querySelector("#__code_1 code span.l")
       name.textContent = attr
     })
   })
@@ -99,7 +99,7 @@ Click on a tile to change the primary color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-primary")
       document.body.setAttribute("data-md-color-primary", attr)
-      var name = document.querySelector("#__code_2 code span:nth-child(15)")
+      var name = document.querySelector("#__code_2 code span.l")
       name.textContent = attr.replace("-", " ")
     })
   })
@@ -156,7 +156,7 @@ Click on a tile to change the accent color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-accent")
       document.body.setAttribute("data-md-color-accent", attr)
-      var name = document.querySelector("#__code_3 code span:nth-child(15)")
+      var name = document.querySelector("#__code_3 code span.l")
       name.textContent = attr.replace("-", " ")
     })
   })

--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -44,7 +44,7 @@ Click on a tile to change the color scheme:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-scheme")
       document.body.setAttribute("data-md-color-scheme", attr)
-      var name = document.querySelector("#__code_1 code span:nth-child(7)")
+      var name = document.querySelector("#__code_1 code span:nth-child(15)")
       name.textContent = attr
     })
   })
@@ -99,7 +99,7 @@ Click on a tile to change the primary color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-primary")
       document.body.setAttribute("data-md-color-primary", attr)
-      var name = document.querySelector("#__code_2 code span:nth-child(7)")
+      var name = document.querySelector("#__code_2 code span:nth-child(15)")
       name.textContent = attr.replace("-", " ")
     })
   })
@@ -156,7 +156,7 @@ Click on a tile to change the accent color:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-color-accent")
       document.body.setAttribute("data-md-color-accent", attr)
-      var name = document.querySelector("#__code_3 code span:nth-child(7)")
+      var name = document.querySelector("#__code_3 code span:nth-child(15)")
       name.textContent = attr.replace("-", " ")
     })
   })

--- a/docs/setup/changing-the-language.md
+++ b/docs/setup/changing-the-language.md
@@ -167,7 +167,7 @@ Click on a tile to change the directionality:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-dir")
       document.body.dir = attr
-      var name = document.querySelector("#__code_3 code span:nth-child(5)")
+      var name = document.querySelector("#__code_3 code span:nth-child(10)")
       name.textContent = attr
     })
   })

--- a/docs/setup/changing-the-language.md
+++ b/docs/setup/changing-the-language.md
@@ -167,7 +167,7 @@ Click on a tile to change the directionality:
     button.addEventListener("click", function() {
       var attr = this.getAttribute("data-md-dir")
       document.body.dir = attr
-      var name = document.querySelector("#__code_3 code span:nth-child(10)")
+      var name = document.querySelector("#__code_3 code span.l")
       name.textContent = attr
     })
   })


### PR DESCRIPTION
Currently the [Color Setup](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/) and [Language Setup](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/) page's button is not working correctly (at least on my Firefox 95.0.2 64-bit Arch Linux browser). When pressing buttons, incorrect text is changed, as illustrated in the screenshot:

![image](https://user-images.githubusercontent.com/95505675/148350944-d8f2960e-22ac-4304-a0f0-efcbeecf63f4.png)

(The "indigo" text in the code box should be changed, but the "palette" text is changed instead).

This is because the "primary" text is the 13th of the element in the code block and the javascript uses a hard-coded 7-element offset instead.