### PR TITLE
Include revision-date(*) plugins in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ RUN \
     pip install --no-cache-dir \
       "mkdocs-minify-plugin>=0.3" \
       "mkdocs-redirects>=1.0"; \
+      "mkdocs-git-revision-date-plugin>=1.0"; \
+      "git-revision-date-localized>=1.0"; \
   fi \
 && \
   apk del .build \


### PR DESCRIPTION
These are supported plugins, mentioned in the documentation, it'd be rather convenient to have them included in the Docker image without having to build your own derived image.

I am aware of #1455 but altough you seemed keen on accepting these 2 plugins. However the discussion derived into another one on improving the Dockerfile structure, which was merged, but inclusion of these 2 plugins was "lost in translation".

This PR is about bringing them back.
