### PR TITLE
Remove ToC setup instructions

### DIFF
--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -214,13 +214,7 @@ No configuration options are available. See reference for usage:
 
 The [Table of Contents] extension automatically generates a table of contents
 from a document, which Material for MkDocs will render as part of the resulting 
-page. Enable it via `mkdocs.yml`:
-
-``` yaml
-markdown_extensions:
-  - toc:
-      permalink: true
-```
+page.
 
 The following configuration options are supported:
 


### PR DESCRIPTION
The ToC appears to be enabled by default. Also, the instructions are for enabling permalinks, which are a distinct feature already listed further below.