### PR TITLE
Add custom language code to the config schema

### DIFF
--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -46,6 +46,12 @@
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/",
       "oneOf": [
         {
+          "title": "Site language: Custom",
+          "enum": [
+            "custom"
+          ]
+        },
+        {
           "title": "Site language: Afrikaans",
           "enum": [
             "af"


### PR DESCRIPTION
This resolves the `Value is not accepted` warning when [validating mkdocs.yml](https://twitter.com/squidfunk/status/1487746003692400642).

Technically, any `language` value would be valid here as long as user provides the relevant `overrides/partials/languages/{{ language }}.html` file, but `"custom"` is the one [suggested in the docs](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#custom-translations) so it is what most users would probably stick with. 