### PR TITLE
Update fontawesome URL

### DIFF
--- a/docs/reference/icons-emojis.md
+++ b/docs/reference/icons-emojis.md
@@ -56,7 +56,7 @@ See additional configuration options:
 - [Emoji with custom icons]
 
   [Material Design]: https://materialdesignicons.com/
-  [FontAwesome]: https://fontawesome.com/icons?d=gallery&m=free
+  [FontAwesome]: https://fontawesome.com/search?m=free
   [Octicons]: https://octicons.github.com/
   [Emoji]: ../setup/extensions/python-markdown-extensions.md#emoji
   [Emoji with custom icons]: ../setup/extensions/python-markdown-extensions.md#custom-icons


### PR DESCRIPTION
Fontawesome seems to have shipped their next version which comes with a new website.

Ignoring the god awful way to find anything (And the fact that clicking the button to see all icons is extremely unreliable) does it seem like the URL has slightly changed as the current one is no longer really usable.

This PR updates it from https://fontawesome.com/icons?d=gallery&m=free to https://fontawesome.com/search?m=free which works.