### PR TITLE
Fix outdated fontawesome icon name

### DIFF
--- a/docs/reference/icons-emojis.md
+++ b/docs/reference/icons-emojis.md
@@ -89,12 +89,12 @@ a valid path to any icon bundled with the theme, which are located in the
 [`.icons`][custom icons] directory, and replacing `/` with `-`:
 
 ``` title="Icon"
-:fontawesome-regular-laugh-wink:
+:fontawesome-regular-face-laugh-wink:
 ```
 
 <div class="result" markdown>
 
-:fontawesome-regular-laugh-wink:
+:fontawesome-regular-face-laugh-wink:
 
 </div>
 


### PR DESCRIPTION
So..... apparently `laugh-wink` has changed to `face-laugh-wink` in FA v6... nice.

On another small note, I consider also taking the time to add an info-box regarding Octicons and that their names require the pixel size to be appended too... (Also, are the 12px variants included too? Not really important for me, but just curious.)