### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     name = "mkdocs-material",
     version = package["version"],
     url = package["homepage"],
+    project_urls = {
+        "Source": "https://github.com/squidfunk/mkdocs-material",
+    },
     license = package["license"],
     description = package["description"],
     long_description = long_description,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)