### PR TITLE
Use comma as thousand separator in documentation

### DIFF
--- a/docs/reference/icons-emojis.md
+++ b/docs/reference/icons-emojis.md
@@ -6,7 +6,7 @@ icon: material/emoticon-happy-outline
 # Icons + Emojis
 
 One of the best features of Material for MkDocs is the possibility to use [more
-than 8.000 icons][icon search] and thousands of emojis in your project 
+than 8,000 icons][icon search] and thousands of emojis in your project 
 documentation with practically zero additional effort. Moreover, custom icons 
 can be added and used in `mkdocs.yml`, documents and templates.
 

--- a/docs/setup/changing-the-logo-and-icons.md
+++ b/docs/setup/changing-the-logo-and-icons.md
@@ -4,7 +4,7 @@ template: overrides/main.html
 
 # Changing the logo and icons
 
-When installing Material for MkDocs, you immediately get access to _over 8.000 
+When installing Material for MkDocs, you immediately get access to _over 8,000 
 icons_ ready to be used for customization of specific parts of the theme and/or 
 when writing your documentation in Markdown. Not enough? You can also add
 [additional icons] with minimal effort.


### PR DESCRIPTION
According to [Wikipedia][1], all major [English-speaking countries][2] use dot as decimal point, instead of comma. This makes it desirable to follow the convention in an English context.

This PR changes two occurrences of dot used as digit *grouping separator* (a.k.a. thousand separator) into comma, so as not to be confused with decimal point.

  [1]: https://en.wikipedia.org/wiki/Decimal_separator#Current_standards
  [2]: https://en.wikipedia.org/wiki/List_of_countries_and_territories_where_English_is_an_official_language