### PR TITLE
Tags Plugin: raise exception when tags.md file doesn't exist

### DIFF
--- a/material/plugins/tags/plugin.py
+++ b/material/plugins/tags/plugin.py
@@ -28,6 +28,9 @@ from mkdocs.plugins import BasePlugin
 # Class
 # -----------------------------------------------------------------------------
 
+class TagsException(Exception):
+    pass
+
 # Tags plugin
 class TagsPlugin(BasePlugin):
 
@@ -58,7 +61,11 @@ class TagsPlugin(BasePlugin):
     def on_nav(self, nav, files, **kwargs):
         file = self.config.get("tags_file")
         if file:
-            self.tags_file = files.get_file_from_path(file)
+            tags_file = files.get_file_from_path(file)
+            if tags_file:
+                self.tags_file = tags_file
+            else:
+                raise TagsException(f"The tags file, {file}, doesn't exist.")
             files.append(self.tags_file)
 
     # Build and render tags index page


### PR DESCRIPTION
I think it would be beneficial to raise an exception when the file for the tags plugin doesn't exist. This would prevent *None* from being added to the `Files` collection in mkdocs, since `get_file_from_path` returns *None* if the `file` isn't in the dict object.

*relevant MkDocs code*
https://github.com/mkdocs/mkdocs/blob/f725e225adf9b6cfab45042e44637f137f56d1bd/mkdocs/structure/files.py#L26-L32