### PR TITLE
Add `dev_addr` property to `schema.json`

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -109,6 +109,12 @@
       "type": "boolean",
       "default": false
     },
+    "dev_addr": {
+      "title": "Development IP Address",
+      "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#dev_addr",
+      "type": "string",
+      "default": "127.0.0.1:8000"
+    },
     "remote_branch": {
       "title": "Remote branch to deploy to",
       "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#remote_branch",


### PR DESCRIPTION
I noticed that VSCode was complaining that `dev_addr` didn't exist

Steps to reproduce

1. Add this to my `settings.json` for VSCode
        2. as instructed here: https://squidfunk.github.io/mkdocs-material/creating-your-site/#minimal-configuration

```json
"yaml.schemas": {
    "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
  },
```

2. Create a file called "mkdocs.yml"
3. Open it in VSCode
4. Add this line `dev_addr: 127.0.0.1:5000`

<img width="806" alt="image" src="https://user-images.githubusercontent.com/11246258/160217104-5f9dfdd4-4099-479b-993f-de8944f50a7d.png">
