### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ on:
 env:
   NODE_VERSION: 14.x
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build project

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,9 @@ on:
 env:
   PYTHON_VERSION: 3.x
 
+permissions:
+  contents: read
+
 jobs:
   documentation:
     name: Build documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ on:
 env:
   PYTHON_VERSION: 3.x
 
+permissions:
+  contents: read
+
 jobs:
   publish_pypi:
     name: Build and push Python package


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
