### PR TITLE
Update python version requirement to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     packages = find_packages(exclude = ["src", "src.*"]),
     include_package_data = True,
     install_requires = install_requires,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points = {
         "mkdocs.themes": [
             "material = material"


### PR DESCRIPTION
With `pymdown-extensions` required version recently changed to `9.4`, `mkdocs-material` effectively requires at least python 3.7 now

This fixes #3866 