### PR TITLE
fixed the water formula typo

### DIFF
--- a/docs/reference/formatting.md
+++ b/docs/reference/formatting.md
@@ -108,13 +108,13 @@ superscripted with a simple syntax, which is more convenient that directly
 using the corresponding [`sub`][sub] and [`sup`][sup] HTML tags:
 
 ``` markdown title="Text with sub- und superscripts"
-- H~2~0
+- H~2~O
 - A^T^A
 ```
 
 <div class="result" markdown>
 
-- H~2~0
+- H~2~O
 - A^T^A
 
 </div>


### PR DESCRIPTION
Found a small typo in formatting.md about the super and subscript. The formula for water should be H2O not H20. 

This is the first time ever I have done a PR, I don't know I am doing this correctly or not.