### PR TITLE
Fix incorrect info about mathjax blocks

### DIFF
--- a/docs/reference/mathjax.md
+++ b/docs/reference/mathjax.md
@@ -85,20 +85,16 @@ See additional configuration options:
 
 ### Using block syntax
 
-Blocks must be enclosed in `#!latex $$...$$` or `#!latex \[...\]` on separate
-lines:
+Blocks must be enclosed in `#!latex $$...$$` or `#!latex \[...\]` in the
+same line:
 
 ``` latex title="MathJax, block syntax"
-$$
-\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}
-$$
+$$\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}$$
 ```
 
 <div class="result" markdown>
 
-$$
-\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}
-$$
+$$\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}$$
 
 </div>
 


### PR DESCRIPTION
The information about mathjax blocks is (at least from personal testing using the provided javascript) incorrect.

The format actually has to be
```mathjax
$$...$$
```

and not
```mathjax
$$
...
$$
```