### PR TITLE
rename tags plugin

### DIFF
--- a/docs/insiders/getting-started.md
+++ b/docs/insiders/getting-started.md
@@ -169,7 +169,7 @@ be mitigated by using [configuration inheritance]:
     plugins:
       - search
       - social
-      - tags
+      - material-tags
     ```
 
 === ":octicons-file-code-16: mkdocs.yml"

--- a/docs/setup/setting-up-tags.md
+++ b/docs/setup/setting-up-tags.md
@@ -25,7 +25,7 @@ the following lines to `mkdocs.yml`:
 
 ``` yaml
 plugins:
-  - tags
+  - material-tags
 ```
 
 The following configuration options are available:
@@ -40,7 +40,7 @@ The following configuration options are available:
 
     ``` yaml
     plugins:
-      - tags:
+      - material-tags:
           tags_file: tags.md
     ```
 
@@ -57,7 +57,7 @@ The following configuration options are available:
 
     ``` yaml
     plugins:
-      - tags:
+      - material-tags:
           tags_extra_files:
             compatibility.md:
               - compat #(1)!
@@ -240,7 +240,7 @@ desirable to hide them for a specific page, which can be achieved by using the
 ``` sh
 ---
 hide:
-  - tags
+  - material-tags
 ---
 
 # Document title

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         ],
         "mkdocs.plugins": [
             "search = material.plugins.search.plugin:SearchPlugin",
-            "tags = material.plugins.tags.plugin:TagsPlugin"
+            "material-tags = material.plugins.tags.plugin:TagsPlugin"
         ]
     },
     zip_safe = False

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -41,7 +41,7 @@
 {% endif %}
 
 <!-- Tags -->
-{% if "tags" in config.plugins %}
+{% if "material-tags" in config.plugins %}
   {% include "partials/tags.html" %}
 {% endif %}
 

--- a/src/partials/content.html
+++ b/src/partials/content.html
@@ -32,7 +32,7 @@
 {% endif %}
 
 <!-- Tags -->
-{% if "tags" in config.plugins %}
+{% if "material-tags" in config.plugins %}
   {% include "partials/tags.html" %}
 {% endif %}
 


### PR DESCRIPTION
to avoid collisions with pre-existing plugins like https://github.com/jldiaz/mkdocs-plugin-tags