### PR TITLE
Add mkdocs-glightbox as lightbox recommended plugin

### DIFF
--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -152,3 +152,18 @@ hash fragment to the image URL:
   [color palette toggle]: ../setup/changing-the-colors.md#color-palette-toggle
   [Zelda light world]: ../assets/images/zelda-light-world.png#only-light
   [Zelda dark world]: ../assets/images/zelda-dark-world.png#only-dark
+
+## Lightbox
+
+The [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox) plugin supports adding the lightbox(zoom) effect on all image in each page with [GLightbox](https://github.com/biati-digital/glightbox). As always, it can be installed with pip:
+
+```bash
+pip install mkdocs-glightbox
+```
+
+Then, add the following lines to mkdocs.yml:
+
+```mk
+plugins:
+  - glightbox
+```


### PR DESCRIPTION
Add [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox) as lightbox recommended plugin mentioned in https://github.com/squidfunk/mkdocs-material/issues/4096.

The header and sidebar vanishing bug has been fixed in [mkdocs-glightbox v0.1.5](https://github.com/blueswen/mkdocs-glightbox/releases/tag/v0.1.5). Also fix a content shrinking bug and use [document$.subscribe](https://github.com/blueswen/mkdocs-glightbox/blob/v0.1.5/mkdocs_glightbox/plugin.py#L58) to make sure the compatibility with Instant loading feature. All plugin options have been tested the compatibility with Material for MkDocs, and all options looks working fine without breaking Material for MkDocs.

Feel free to edit these contents. Not sure these information for user is enough or not.