### PR TITLE
Align "edit this page" icon with the one from mkdocs-material

### DIFF
--- a/material/partials/content.html
+++ b/material/partials/content.html
@@ -3,7 +3,7 @@
 -#}
 {% if page.edit_url %}
   <a href="{{ page.edit_url }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
-    {% include ".icons/material/pencil.svg" %}
+    {% include ".icons/material/file-edit-outline.svg" %}
   </a>
 {% endif %}
 {% if "tags" in config.plugins %}


### PR DESCRIPTION
Make the "edit this page" icon the same as the one from the mkdocs-material documentation site.

As one can see from [the commit](https://github.com/squidfunk/mkdocs-material/commit/d926bb4c2791300548634bbd5f7d2ca23d997367) which adds "edit this page" and "view source of this page", the icon to edit the page has changed for the mkdocs-material documentation site. But not for any site made with mkdocs-material.

This fixes it.

Before: 

![image](https://user-images.githubusercontent.com/5385290/181219097-fef95131-f324-43e5-92cf-7bea6d1a1849.png)

After:

![image](https://user-images.githubusercontent.com/5385290/181219181-aaa62fe5-16d3-4e5e-98fa-30999e7865c9.png)
