### PR TITLE
feat: multi platform docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm/v8
           tags: |
             ${{ github.event.repository.full_name }}:latest
             ${{ github.event.repository.full_name }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
The original image is really slow on m1 macs, for example.

This will build for arm64 as well, which should improve things.

You can test it: https://hub.docker.com/r/caarlos0/material-mkdocs/tags