### PR TITLE
Update FontAwesome icon names

### DIFF
--- a/docs/reference/admonitions.md
+++ b/docs/reference/admonitions.md
@@ -89,13 +89,13 @@ theme:
         theme:
           icon:
             admonition:
-              note: fontawesome/solid/sticky-note
+              note: fontawesome/solid/note-sticky
               abstract: fontawesome/solid/book
-              info: fontawesome/solid/info-circle
+              info: fontawesome/solid/circle-info
               tip: fontawesome/solid/bullhorn
               success: fontawesome/solid/check
-              question: fontawesome/solid/question-circle
-              warning: fontawesome/solid/exclamation-triangle
+              question: fontawesome/solid/circle-question
+              warning: fontawesome/solid/triangle-exclamation
               failure: fontawesome/solid/bomb
               danger: fontawesome/solid/skull
               bug: fontawesome/solid/robot


### PR DESCRIPTION
I recently ran into errors when building locally. The last line of the error mentioned the following:

`jinja2.exceptions.TemplateNotFound: .icons/fontawesome/solid/sticky-note.svg`

After a bit of research, I found that some of the FontAwesome icons had recently changed: [What's changed - Version 6 | FontAwesome](https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6)

After updating the names of the changed icons in my local mkdocs.yml file, I was able to build successfully without errors.

So that others can avoid this issue (seems sporadic since I was able to build without issues until recently), I've updated the documentation.