### PR TITLE
Cast all tags as strings to avoid TypeError during highlight

### DIFF
--- a/src/assets/javascripts/integrations/search/_/index.ts
+++ b/src/assets/javascripts/integrations/search/_/index.ts
@@ -266,7 +266,7 @@ export class Search {
                 location,
                 title: highlight(title),
                 text:  highlight(text),
-                ...tags && { tags: tags.map(highlight) },
+                ...tags && { tags: tags.map(tag => highlight(String(tag))) },
                 score: score * (1 + boost),
                 terms
               })


### PR DESCRIPTION
If a tag is specified which is an integer and is unquoted in the source
document, it is parsed as an integer which cannot have .replace() called
on it during the highlight function [1], otherwise it will yield a
TypeError.

For example, in the tags below, the first tag will evaluate as a number,
not a string, and causes a TypeError to occur.

```
...
tags:
  - 9.0
  - some other tags
  - 9.0 with more text
...
```

There is likely a more appropriate way to fix this, but it does seem to
do the job. The error was a bit opaque (just some "Invalid query:
<search string>"), but I'm not sure that's worth addressing, either.

[1] https://github.com/squidfunk/mkdocs-material/blob/9655c3a92471f261533d48b8611a8d24dbfebb13/src/assets/javascripts/integrations/search/highlighter/index.ts#L88