### PR TITLE
Update MathJaX Config file in mkdocs, compatible with Promises, in case of instant loading

### DIFF
--- a/docs/reference/mathjax.md
+++ b/docs/reference/mathjax.md
@@ -38,7 +38,9 @@ lines to `mkdocs.yml`:
     };
 
     document$.subscribe(() => { // (1)!
-      MathJax.typesetPromise()
+    MathJax.startup.promise
+      .then(() => MathJax.typesetPromise())
+      .then(() => { /* other actions once MathJax is done */ })
     })
     ```
 

--- a/docs/reference/mathjax.md
+++ b/docs/reference/mathjax.md
@@ -38,9 +38,9 @@ lines to `mkdocs.yml`:
     };
 
     document$.subscribe(() => { // (1)!
-    MathJax.startup.promise
-      .then(() => MathJax.typesetPromise())
-      .then(() => { /* other actions once MathJax is done */ })
+      MathJax.startup.promise
+        .then(() => MathJax.typesetPromise())
+        .then(() => { /* other actions once MathJax is done */ })
     })
     ```
 


### PR DESCRIPTION
FYI, I am using the latest MathJaX@3.2.2, so my mkdocs.yml file contains the following, but that has nothing to do.

```yaml
markdown_extensions:
  - pymdownx.arithmatex:
      generic: true

extra_javascript:
  - javascripts/mathjax.js
  - https://polyfill.io/v3/polyfill.js?features=es5,es6,es7,es8&flags=gated
  - https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js
```

Just update the `MathJax.startup.promise` part of the docs, that's all there is to it.
Thanks !