### PR TITLE
Update docs for new GitHub Pages deployment method

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -16,12 +16,24 @@ charge and pretty easy to set up.
 
   [GitHub Pages]: https://pages.github.com/
 
-### with GitHub Actions
+GitHub offers two options for configuring a GitHub Pages [publishing source]:
 
-Using [GitHub Actions] you can automate the deployment of your project
-documentation. At the root of your repository, create a new GitHub Actions
-workflow, e.g. `.github/workflows/ci.yml`, and copy and paste the following
-contents:
+1. Publishing from a build artifact with GitHub Actions
+2. Publishing from a branch
+
+### Publishing from a build artifact with GitHub Actions
+
+Using [GitHub Actions], you can automate the deployment of your project
+documentation. Publishing from a build artifact with GitHub Actions is the
+[default GitHub Pages deployment method].
+
+As the GitHub Pages docs on configuring a [publishing source] explain, the
+advantage of publishing a build artifact is that the compiled site files do not
+need to be committed to the repo.
+
+To deploy your documentation with GitHub Actions, create a YAML file in the
+`.github/workflows` directory, e.g. `.github/workflows/ci.yml`, and copy and
+paste the following contents:
 
 === "Material for MkDocs"
 
@@ -32,24 +44,54 @@ contents:
         branches:
           - master # (2)!
           - main
+    permissions: # (3)!
+      contents: read
+      id-token: write
+      pages: write
+    concurrency: # (4)!
+      cancel-in-progress: true
+      group: "pages"
     jobs:
-      deploy:
+      build:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-python@v2
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v3
             with:
-              python-version: 3.x
-          - run: pip install mkdocs-material # (3)!
-          - run: mkdocs gh-deploy --force
+              python-version: "3.x"
+          - name: Install dependencies
+            run: pip install mkdocs-material # (5)!
+          - name: Build site
+            run: mkdocs build
+          - name: Upload build artifact
+            uses: actions/upload-pages-artifact@v1
+            with:
+              path: "site" # (6)!
+      deploy:
+        needs: build # (7)!
+        environment: # (8)!
+          name: github-pages
+          url: ${{ steps.deploy-pages.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+          - name: Deploy site
+            id: deploy-pages
+            uses: actions/deploy-pages@v1 # (9)!
     ```
 
-    1.  You can change the name to your liking. 
+    1.  You can change the name to your liking.
 
     2.  At some point, GitHub renamed `master` to `main`. If your default branch
-        is named `master`, you can safely remove `main`, vice versa.
+        is named `master`, you can safely remove `main`, and vice versa.
 
-    3.  This is the place to install further [MkDocs plugins] or Markdown
+    3.  Settings under the `permissions` key ensure that the [GITHUB_TOKEN]
+        automatically provisioned by GitHub Actions has the necessary permissions
+        to publish the site.
+
+    4.  Settings under the [concurrency key] ensure that only one deployment is
+        going on at a time.
+
+    5.  This is the place to install further [MkDocs plugins] or Markdown
         extensions with `pip` to be used during the build:
 
         ``` sh
@@ -58,6 +100,109 @@ contents:
           mkdocs-awesome-pages-plugin \
           ...
         ```
+
+    6.  MkDocs will save the built site in the `site` directory. This step will
+        upload the `site` directory as a [GitHub Actions build artifact].
+
+    7.  The [needs key] ensures that the site will only deploy if the build
+        was successful.
+
+    8.  Settings under the `environment` key create a [deployment environment]
+        with the GitHub Pages default name `github-pages`. GitHub recommends
+        setting an environment protection rule so that only the default or
+        main branch can trigger deployments.
+
+    9.  [actions/deploy-pages] will deploy the site to GitHub Pages.
+
+=== "Insiders"
+
+    ``` yaml
+    name: ci
+    on:
+      push:
+        branches:
+          - master
+          - main
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    concurrency:
+      cancel-in-progress: true
+      group: "pages"
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }} # (1)!
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v3
+            with:
+              python-version: "3.x"
+          - name: Install dependencies
+          - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+          - name: Build site
+            run: mkdocs build
+          - name: Upload build artifact
+            uses: actions/upload-pages-artifact@v1
+            with:
+              path: "site"
+      deploy:
+        needs: build
+        environment:
+          name: github-pages
+          url: ${{ steps.deploy-pages.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+          - name: Deploy site
+            id: deploy-pages
+            uses: actions/deploy-pages@v1
+    ```
+
+    1.  Remember to set the `GH_TOKEN` environment variable to the value of your
+        [personal access token] when deploying [Insiders], which can be done
+        using [GitHub secrets].
+
+Now, when a new commit is pushed to either the `master` or `main` branches,
+the static site is automatically built and deployed. Push your changes to see
+the workflow in action.
+
+If the GitHub Page doesn't show up after a few minutes, go to the settings of
+your repository and ensure that the [publishing source] for your GitHub
+Page is set to "GitHub Actions."
+
+Your documentation should shortly appear at `<username>.github.io/<repository>`.
+
+### Publishing from a branch with GitHub Actions
+
+To deploy your documentation by publishing from a branch with GitHub Actions,
+create a YAML file in the `.github/workflows` directory, e.g.
+`.github/workflows/ci.yml`, and copy and paste the following contents:
+
+=== "Material for MkDocs"
+
+    ``` yaml
+    name: ci
+    on:
+      push:
+        branches:
+          - master
+          - main
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v3
+            with:
+              python-version: 3.x
+          - run: pip install mkdocs-material
+          - run: mkdocs gh-deploy --force # (1)!
+    ```
+
+    1.  The [`mkdocs gh-deploy --force` command] will build the site, commit the
+        site files to the `gh-pages` branch, and force-push the branch.
 
 === "Insiders"
 
@@ -73,8 +218,8 @@ contents:
         runs-on: ubuntu-latest
         if: github.event.repository.fork == false
         steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-python@v2
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v3
             with:
               python-version: 3.x
           - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
@@ -87,24 +232,26 @@ contents:
         [personal access token] when deploying [Insiders], which can be done
         using [GitHub secrets].
 
-Now, when a new commit is pushed to either the `master` or `main` branches,
-the static site is automatically built and deployed. Push your changes to see
-the workflow in action.
-
 If the GitHub Page doesn't show up after a few minutes, go to the settings of
-your repository and ensure that the [publishing source branch] for your GitHub
-Page is set to `gh-pages`.
-
-Your documentation should shortly appear at `<username>.github.io/<repository>`.
+your repository and ensure that the [publishing source] for your GitHub
+Page is set to the `gh-pages` branch.
 
   [GitHub Actions]: https://github.com/features/actions
   [MkDocs plugins]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins
   [personal access token]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
   [Insiders]: insiders/index.md
   [GitHub secrets]: https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-  [publishing source branch]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+  [publishing source]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+  [`mkdocs gh-deploy --force` command]: https://www.mkdocs.org/user-guide/deploying-your-docs/
+  [default GitHub Pages deployment method]: https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/
+  [GITHUB_TOKEN]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+  [concurrency key]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  [GitHub Actions build artifact]: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
+  [needs key]: https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
+  [deployment environment]: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
+  [actions/deploy-pages]: https://github.com/actions/deploy-pages
 
-### with MkDocs
+### Publishing from a branch manually
 
 If you prefer to deploy your project documentation manually, you can just invoke
 the following command from the directory containing the `mkdocs.yml` file:


### PR DESCRIPTION
## Description

GitHub Pages now supports two different deployment methods:

1. Committing files to a branch like `gh-pages` (the old method using [`mkdocs gh-deploy`](https://www.mkdocs.org/user-guide/deploying-your-docs/) and [`ghp-import`](https://github.com/c-w/ghp-import))
2. Publishing a build artifact (the [new default method](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/)). As the [GitHub docs](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) explain, the advantage of publishing a build artifact is that the compiled site files do not need to be committed to the repo.

Material for MkDocs provides a helpful page on [publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/). It would be great to update this page for the new deployment method, especially because the new method is now the default for GitHub Pages.

## Changes

This PR will update the page on [publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/) to:

- Explain the difference between the two deployment methods
- Provide resources for the new method (publishing a build artifact)

## Related

- [MkDocs: Deploying your docs](https://www.mkdocs.org/user-guide/deploying-your-docs/)
- [Material for MkDocs: Publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/)
- [GitHub Blog 2022-08-10: GitHub Pages now uses Actions by default](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/)
- [GitHub Changelog 2022-08-10: GitHub Pages: Builds with GitHub Actions GA](https://github.blog/changelog/2022-08-10-github-pages-builds-with-github-actions-ga/)
- [GitHub docs: GitHub Pages - Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
- [`actions/deploy-pages`](https://github.com/actions/deploy-pages)
- [Workflow example from `actions/starter-workflows`](https://github.com/actions/starter-workflows/blob/main/pages/static.yml)
- mkdocs/mkdocs#2144
- mhausenblas/mkdocs-deploy-gh-pages#188
