### PR TITLE
override noteText color with mermaid default

### DIFF
--- a/src/assets/javascripts/components/content/code/mermaid/index.css
+++ b/src/assets/javascripts/components/content/code/mermaid/index.css
@@ -346,6 +346,11 @@ line {
   stroke: none;
 }
 
+/* make statically colored note nodes use a statically color text */
+.noteText > tspan {
+  fill: #000;
+}
+
 /* Sequence arrow head */
 #arrowhead path {
   fill: var(--md-mermaid-edge-color);


### PR DESCRIPTION
fixes #4517 

As requested, I went through and inspected all the demo graphs in the doc (using both light and dark schemes). Everything looks as expected now.