### PR TITLE
Enable auto-merge for pull requests from Dependabot

### DIFF
--- a/.github/workflows/dependabotautomerge.yml
+++ b/.github/workflows/dependabotautomerge.yml
@@ -1,0 +1,24 @@
+# Source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot_auto_merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.4
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --rebase --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
For pull requests from Dependabot the [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#enabling-auto-merge) can be enabled. Doing so, a pull request will be merged automatically, once all checks for the pull request succeed (important: the latter has to be configured by protecting the 'master' branch in the [project settings](https://github.com/squidfunk/mkdocs-material/settings), see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches).
The version I am proposing here marks every pull request from Dependabot as auto-mergeable. But it can be reduced to enable auto-merge only for "semver: patch-update", for example. The reduction schema is limited to [Semantic Versioning 2.0.0](https://semver.org)
I am using this approach by myself, see https://github.com/SchulteMarkus/spock-geb-demo