### PR TITLE
Added missing step to create a new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ Material for MkDocs can be installed with `pip`:
 pip install mkdocs-material
 ```
 
+Create new site:
+```
+mkdocs new .
+```
+
 Add the following lines to `mkdocs.yml`:
 
 ``` yaml


### PR DESCRIPTION
Quick start instruction jumps to editing `mkdocs.yml` file before creating a new site. Install doesn't create the file so the instruction seems missing. 

I've added the step to create a new site to the quick start as in the [official documentation](https://squidfunk.github.io/mkdocs-material/creating-your-site/).