### PR TITLE
Fix: Update schema json for linking section header in redirect

### DIFF
--- a/docs/schema/plugins/external/redirects.json
+++ b/docs/schema/plugins/external/redirects.json
@@ -17,7 +17,7 @@
                 {
                   "title": "Internal redirect",
                   "markdownDescription": "https://github.com/datarobot/mkdocs-redirects#using",
-                  "pattern": "\\.md$"
+                  "pattern": "\\.md(#\\S+)?$"
                 },
                 {
                   "title": "External redirect",


### PR DESCRIPTION
Addressing https://github.com/squidfunk/mkdocs-material/issues/4690

Tested by setting
`# yaml-language-server: $schema=https://raw.githubusercontent.com/squidfunk/mkdocs-material/7a1676b5fc57ccd73cbe1d5e84c6147a3b4e95ae/docs/schema.json`

In my `mkdocs.yml`