### PR TITLE
Updated Dockerfile to Python 3.11 on Alpine 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,13 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-FROM python:3.9.2-alpine3.13
+FROM python:3.11.0-alpine3.17
 
 # Build-time flags
 ARG WITH_PLUGINS=true
 
 # Environment variables
-ENV PACKAGES=/usr/local/lib/python3.9/site-packages
+ENV PACKAGES=/usr/local/lib/python3.11/site-packages
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Set build directory


### PR DESCRIPTION
Fixes #4711.

Tested using [gaseri/website](https://github.com/gaseri/website).

Running emits:

```
INFO     -  DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead
File "/usr/local/lib/python3.11/site-packages/cairosvg/features.py", line 9, in <module>
LOCALE = locale.getdefaultlocale()[0] or ''
File "/usr/local/lib/python3.11/locale.py", line 559, in getdefaultlocale
warnings.warn(
```

This should likely be fixed by upgrading CairoSVG later.