### PR TITLE
Add 'yaml.customTags' to 'settings.json' example

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -58,12 +58,12 @@ theme:
         2.  Add the schema under the `yaml.schemas` key in your user or
             workspace [`settings.json`][settings.json]:
 
-            ``` json
+            ``` { .json .annotate }
             {
               "yaml.schemas": {
                 "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
               },
-              "yaml.customTags": [
+              "yaml.customTags": [ // (1)!
                 "tag:yaml.org,2002:python/name:materialx.emoji.to_svg",
                 "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
                 "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
@@ -71,7 +71,7 @@ theme:
             }
             ```
 
-            `yaml.customTags` part will be needed if you want to use and configure [Emojis](reference/icons-emojis.md).
+            1. `yaml.customTags` part will be needed if you want to use and configure [Emojis](reference/icons-emojis.md).
 
     === "Other"
 

--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -62,9 +62,16 @@ theme:
             {
               "yaml.schemas": {
                 "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
-              }
+              },
+              "yaml.customTags": [
+                "tag:yaml.org,2002:python/name:materialx.emoji.to_svg",
+                "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
+                "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
+              ]
             }
             ```
+
+            `yaml.customTags` would be needed if you want to use and configure [Emojis](reference/icons-emojis.md).
 
     === "Other"
 

--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -71,7 +71,7 @@ theme:
             }
             ```
 
-            `yaml.customTags` would be needed if you want to use and configure [Emojis](reference/icons-emojis.md).
+            `yaml.customTags` part will be needed if you want to use and configure [Emojis](reference/icons-emojis.md).
 
     === "Other"
 


### PR DESCRIPTION
Without `yaml.customTags` in `.vscode/settings.json`, these lines will be marked as error.
``` yaml
markdown_extensions:
  - pymdownx.emoji:
      emoji_index: !!python/name:materialx.emoji.twemoji
      emoji_generator: !!python/name:materialx.emoji.to_svg
```

So I added `yaml.customTags` part in example `settings.json` in the documentation.