### PR TITLE
Add mkdocstrings JSON schema

### DIFF
--- a/docs/schema/plugins.json
+++ b/docs/schema/plugins.json
@@ -85,6 +85,9 @@
         },
         {
           "$ref": "https://raw.githubusercontent.com/prcr/mkdocs-meta-descriptions-plugin/main/schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/mkdocstrings/mkdocstrings/master/docs/schema.json"
         }
       ]
     }


### PR DESCRIPTION
I've pushed schemas for mkdocstrings, mkdocstrings-python and Griffe (referencing each other in this order).
The tool you mentioned (https://www.jsonschemavalidator.net) validates the schemas, however it seems to have no issue with additional properties that do not exist, while I explicitly added `"additionalProperties": false` to the schemas :thinking: 
It also seems to accept wrong types, so not sure if I did something wrong.

Anyway, that's a first draft.

How would I test if this works as expected?

Reference: https://github.com/mkdocstrings/mkdocstrings/issues/488