### PR TITLE
Add plugins schema

### DIFF
--- a/docs/schema/plugins.json
+++ b/docs/schema/plugins.json
@@ -58,6 +58,12 @@
           "$ref": "plugins/external/git-revision-date.json"
         },
         {
+          "$ref": "plugins/external/literate-nav.json"
+        },
+        {
+          "$ref": "plugins/external/macros.json"
+        },
+        {
           "$ref": "plugins/external/minify.json"
         },
         {

--- a/docs/schema/plugins/external/literate-nav.json
+++ b/docs/schema/plugins/external/literate-nav.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Literate nav plugin",
+  "type": "object",
+  "properties": {
+    "literate-nav": {
+      "markdownDescription": "https://github.com/oprypin/mkdocs-literate-nav",
+      "type": "object",
+      "properties": {
+        "nav_file": {
+          "title": "The name of the file to read to determine the navigation for a particular directory under `docs_dir`",
+          "markdownDescription": "https://oprypin.github.io/mkdocs-literate-nav/reference.html#nav_file",
+          "type": "string",
+          "default": "SUMMARY.md"
+        },
+        "implicit_index": {
+          "title": "If set and a directory has a file named `index.md` or `README.md`, but the literate nav for that directory that never includes it, it will be inserted as the first item of the nav",
+          "markdownDescription": "https://oprypin.github.io/mkdocs-literate-nav/reference.html#implicit_index",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schema/plugins/external/macros.json
+++ b/docs/schema/plugins/external/macros.json
@@ -47,6 +47,12 @@
           "title": "Non-standard Jinja2 marker for end of variable",
           "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#solution-4-altering-the-syntax-of-jinja2-for-mkdocs-macros",
           "type": "string"
+        },
+        "on_error_fail": {
+          "title": "Stop build/serve when macro error happens",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#can-i-make-mkdocs-macros-build-process-to-fail-in-case-of-error-instead-of-displaying-the-error-on-the-page",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/docs/schema/plugins/external/macros.json
+++ b/docs/schema/plugins/external/macros.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Macros plugin",
+  "type": "object",
+  "properties": {
+    "macros": {
+      "markdownDescription": "",
+      "type": "object",
+      "properties": {
+        "module_name":  {
+          "title": "Name of the Python module containing macros, filters and variables.",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/#configuration-of-the-plugin",
+          "type": "string",
+          "default": "main"
+        },
+        "modules": {
+          "title": "List of preinstalled Python modules, i.e. listed by `pip list`.",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/#configuration-of-the-plugin",
+          "type": "array"
+        },
+        "include_dir": {
+          "title": "Directory for including external files",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#changing-the-directory-of-the-includes",
+          "type": "string"
+        },
+        "include_yaml": {
+          "title": "List of yaml files or `key: filename` pairs to be included",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#including-external-yaml-files",
+          "type": "array"
+        },
+        "j2_block_start_string": {
+          "title": "Non-standard Jinja2 marker for start of block",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#solution-4-altering-the-syntax-of-jinja2-for-mkdocs-macros",
+          "type": "string"
+        },
+        "j2_block_end_string": {
+          "title": "Non-standard Jinja2 marker for end of block",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#solution-4-altering-the-syntax-of-jinja2-for-mkdocs-macros",
+          "type": "string"
+        },
+        "j2_variable_start_string": {
+          "title": "Non-standard Jinja2 marker for start of variable",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#solution-4-altering-the-syntax-of-jinja2-for-mkdocs-macros",
+          "type": "string"
+        },
+        "j2_variable_end_string": {
+          "title": "Non-standard Jinja2 marker for end of variable",
+          "markdownDescription": "https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#solution-4-altering-the-syntax-of-jinja2-for-mkdocs-macros",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schema/plugins/external/minify.json
+++ b/docs/schema/plugins/external/minify.json
@@ -24,17 +24,25 @@
         "minify_js": {
           "title": "Minify JavaScript files",
           "markdownDescription": "https://github.com/byrnereese/mkdocs-minify-plugin#options",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "minify_css": {
           "title": "Minify CSS files",
           "markdownDescription": "https://github.com/byrnereese/mkdocs-minify-plugin#options",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "htmlmin_opts": {
           "title": "Options for HTML minifier",
           "markdownDescription": "https://github.com/byrnereese/mkdocs-minify-plugin#options",
           "type": "object"
+        },
+        "cache_safe": {
+          "title": "Add hash to Javascript and CSS file names",
+          "markdownDescription": "https://github.com/byrnereese/mkdocs-minify-plugin#options",
+          "type": "boolean",
+          "default": false
         },
         "js_files": {
           "title": "JavaScript files to minify",


### PR DESCRIPTION
This PR adds schema of these MkDocs plugins:
  * [literate-nav](https://github.com/oprypin/mkdocs-literate-nav)
  * [macros](https://github.com/fralau/mkdocs_macros_plugin)
 
Also this adds missing properties of this MkDocs plugin:
  * [minify](https://github.com/byrnereese/mkdocs-minify-plugin)
      * `cache_safe`

NOTE: Although `macros` plugin supports `!env` at `on_error_fail` property, I couldn't find a way to support both `boolean` and `string` starts with `!env`. 

I tested this with my MkDocs project. No 'error' was printed and VSCode thinks the `mkdocs.yml` is well formed  which is normal.