### PR TITLE
Sequence diagram alt fragment title fix

### DIFF
--- a/src/assets/javascripts/components/content/code/mermaid/index.css
+++ b/src/assets/javascripts/components/content/code/mermaid/index.css
@@ -339,6 +339,7 @@ line {
 
 /* Sequence message, loop and note text */
 .messageText,
+.loopText,
 .loopText > tspan,
 .noteText > tspan {
   font-family: var(--md-mermaid-font-family) !important;


### PR DESCRIPTION
Mermaid diagram alt fragment titles had some styling issues (see #4783) but here is a fix!