### PR TITLE
Fix link to discussion board

### DIFF
--- a/docs/bug-report/index.md
+++ b/docs/bug-report/index.md
@@ -66,7 +66,7 @@ problems.__
   [theme.hooks]: https://www.mkdocs.org/user-guide/configuration/#hooks
   [extra_css]: https://www.mkdocs.org/user-guide/configuration/#extra_css
   [extra_javascript]: https://www.mkdocs.org/user-guide/configuration/#extra_javascript
-  [discussion board]: https://github.com/squidfunk/mkdocs-material/issues
+  [discussion board]: https://github.com/squidfunk/mkdocs-material/discussions
   [StackOverflow]: https://stackoverflow.com
   [that our documentation explicitly mentions]: ?q="extends+base"
 


### PR DESCRIPTION
Noticed this on https://squidfunk.github.io/mkdocs-material/bug-report/#related-links, where
> Additionally, since you have searched our [issue tracker](https://github.com/squidfunk/mkdocs-material/issues) and [discussion board](https://github.com/squidfunk/mkdocs-material/issues) before reporting an issue, and have possibly found several issues or discussions, include those as well.

has both links pointing to the same page.

The `bug` issue template does use the right URLs: https://github.com/squidfunk/mkdocs-material/blob/c8fb426d988e9cdf75054347e4152ac0063528e1/.github/ISSUE_TEMPLATE/bug.yml#L37-L38