### PR TITLE
Fix typo in mkdocs_macros_plugin schema

### DIFF
--- a/docs/schema/plugins/external/macros.json
+++ b/docs/schema/plugins/external/macros.json
@@ -3,9 +3,9 @@
   "title": "Macros plugin",
   "oneOf": [
     {
-      "markdownDescription": "https://github.com/oprypin/mkdocs-literate-nav",
+      "markdownDescription": "https://github.com/fralau/mkdocs_macros_plugin",
       "enum": [
-        "literate-nav"
+        "macros"
       ]
     },
     {


### PR DESCRIPTION
Fixing small typos in the external plugin mkdocs_macros_plugin schema.

This was preventing the correct validation of `mkdocs.yml` without the mkdocs_macros_plugin specific optional sub properties:

``` yaml
plugins:
  - macros
```