### PR TITLE
Add support for Plausible Analytics

### DIFF
--- a/src/partials/integrations/analytics/plausible.html
+++ b/src/partials/integrations/analytics/plausible.html
@@ -1,0 +1,38 @@
+<script
+  defer
+  data-domain="{{ config.extra.analytics.domain }}"
+  src="{{ config.extra.analytics.src | default("https://plausible.io/js/plausible.js", true) }}"
+></script>
+
+<script>
+  window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments) };
+
+  /* Register event handlers after documented loaded */
+  document.addEventListener("DOMContentLoaded", function () {
+    /* Set up feedback, i.e. "Was this page helpful?" */
+    document$.subscribe(function () {
+      var feedback = document.forms.feedback;
+      if (typeof feedback === "undefined") return;
+
+      /* Send feedback to Plausible */
+      for (var button of feedback.querySelectorAll("[type=submit]")) {
+        button.addEventListener("click", function (ev) {
+          ev.preventDefault();
+
+          var page = document.location.pathname;
+          var value = this.getAttribute("data-md-value");
+          console.log("[feedback] User clicked", { value });
+          plausible(`Feedback: ${value}`);
+
+          /* Disable form and show note, if given */
+          feedback.firstElementChild.disabled = true;
+          var note = feedback.querySelector(".md-feedback__note [data-md-value='" + data + "']");
+          if (note) note.hidden = false;
+        })
+
+        /* Show feedback */
+        feedback.hidden = false;
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
I've implemented [Plausible](https://plausible.io/) support. Usage:

1. Add configuration to mkdocs.yml:

    ```yml
    extra:
      analytics:
        provider: plausible
        domain: example.com

        # If using custom domain proxy or self-hosting Plausible, specify script path:
        # src: "https://plausible.example.com/js/plausible.js"

        feedback:
          title: Was this page helpful?
          ratings:
            - icon: tabler/thumb-up
              name: This page was helpful
              data: good
              note: "Thanks for your feedback!"
            - icon: tabler/thumb-down
              name: This page could be improved
              data: bad
              note: "Thanks for your feedback! Help us improve this page by..."
    ```

2. In your Plausible account, go to your website's settings and visit the **"Goals"** section. For each rating defined, click on the **"+ Add goal"** button, select **Custom event** as the goal trigger and enter `Feedback: {rating data value}`.

    For example, if you have two ratings – `good` and `bad`, add `Feedback: good` and `Feedback: bad` goals.

Ratings will be shown in the **Goal Conversions** section at the very bottom of the page, as soon as any are available:

<img width="449" alt="image" src="https://user-images.githubusercontent.com/1298948/211634195-b0131d54-cd5f-49d6-9a3d-85bdb4c493fc.png">

You can click on a specific “goal” to filter your dashboard by it. For example, if you filter by the `Feedback: bad` goal, you can see which pages need the most attention in the **Top Pages** section.

Let me know if you have any questions!