### PR TITLE
Escape parentheses separator in docs

### DIFF
--- a/docs/setup/setting-up-site-search.md
+++ b/docs/setup/setting-up-site-search.md
@@ -112,7 +112,7 @@ The following configuration options are supported:
     ``` yaml
     plugins:
       - search:
-          separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+          separator: '[\s\-,:!=\[\]\(\)"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
     ```
 
     Broken into its parts, the separator induces the following behavior:


### PR DESCRIPTION
Without escaping, these parentheses are interpreted as regex operators and the whole separator string then does not work as expected.