### PR TITLE
Add title text for inline examples

### DIFF
--- a/docs/reference/admonitions.md
+++ b/docs/reference/admonitions.md
@@ -229,20 +229,20 @@ Adding a `+` after the `???` token renders the block expanded:
 
 ### Inline blocks
 
-Admonitions can also be rendered as inline blocks (i.e. for sidebars), placing
+Admonitions can also be rendered as inline blocks (e.g., for sidebars), placing
 them to the right using the `inline` + `end` modifiers, or to the left using
 only the `inline` modifier:
 
 === ":octicons-arrow-right-16: inline end"
 
-    !!! info inline end
+    !!! info inline end "Inline End Title Text"
 
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et
         euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo
         purus auctor massa, nec semper lorem quam in massa.
 
     ``` markdown
-    !!! info inline end
+    !!! info inline end "Inline End Title Text"
   
         Lorem ipsum dolor sit amet, consectetur
         adipiscing elit. Nulla et euismod nulla.
@@ -255,14 +255,14 @@ only the `inline` modifier:
 
 === ":octicons-arrow-left-16: inline"
 
-    !!! info inline
+    !!! info inline "Inline Title Text"
 
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et
         euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo
         purus auctor massa, nec semper lorem quam in massa.
 
     ``` markdown
-    !!! info inline
+    !!! info inline "Inline Title Text"
 
         Lorem ipsum dolor sit amet, consectetur
         adipiscing elit. Nulla et euismod nulla.
@@ -276,7 +276,7 @@ only the `inline` modifier:
 __Important__: admonitions that use the `inline` modifiers _must_ be declared
 prior to the content block you want to place them beside. If there's
 insufficient space to render the admonition next to the block, the admonition
-will stretch to the full width of the viewport, e.g. on mobile viewports.
+will stretch to the full width of the viewport, e.g., on mobile viewports.
 
 ### Supported types
 


### PR DESCRIPTION
As per issue #5029.

Also minor grammar fix to replace i.e. with e.g. (for example) and a comma after.