### PR TITLE
Fix cache: pip Example

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -37,11 +37,8 @@ contents:
           - uses: actions/checkout@v3
           - uses: actions/setup-python@v4
             with:
-              python-version: 3.x
-          - uses: actions/cache@v2
-            with:
-              key: ${{ github.ref }}
-              path: .cache
+              python-version: 3.9
+              cache: 'pip' # caching pip dependencies
           - run: pip install mkdocs-material # (3)!
           - run: mkdocs gh-deploy --force
     ```


### PR DESCRIPTION
It shows this error

example: https://github.com/RammusXu/toolkit/blob/69612a431d5f0aa7ae85a7ed7d66850e67494a7e/.github/workflows/publish.yaml
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.Show more
```

<img width="1370" alt="image" src="https://user-images.githubusercontent.com/4367069/219347398-cc936285-e04e-4719-b47e-8b96ad461f26.png">

After this change, it will fix.

example: https://github.com/RammusXu/toolkit/actions/runs/4193199747


ref: https://github.com/actions/setup-python#caching-packages-dependencies
