### PR TITLE
Reimplement `<h1>` headline detection in content partial

### DIFF
--- a/material/partials/content.html
+++ b/material/partials/content.html
@@ -5,8 +5,7 @@
   {% include "partials/tags.html" %}
 {% endif %}
 {% include "partials/actions.html" %}
-{% set first = page.toc | first %}
-{% if first and first.level != 1 %}
+{% if "\x3ch1" not in page.content %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}
 {{ page.content }}

--- a/src/partials/content.html
+++ b/src/partials/content.html
@@ -29,11 +29,10 @@
 {% include "partials/actions.html" %}
 
 <!--
-  Check whether the content starts with a level 1 headline. If it doesn't, the
+  Hack: check whether the content contains a h1 headline. If it doesn't, the
   page title (or respectively site name) is used as the main headline.
 -->
-{% set first = page.toc | first %}
-{% if first and first.level != 1 %}
+{% if "\x3ch1" not in page.content %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}
 


### PR DESCRIPTION
### Summary
* See discussion: https://github.com/squidfunk/mkdocs-material/discussions/5053
* Partially reverts https://github.com/squidfunk/mkdocs-material/commit/b95dffa5cd7c32a443ab2c46d63252bc828409ec by re-adding `<h1>` headline detection in content partial.
* This provides more flexibility, allowing the user to provide their own `<h1>` tag without a headline being automatically added.