### PR TITLE
Use edit in edit_uri example

### DIFF
--- a/docs/setup/adding-a-git-repository.md
+++ b/docs/setup/adding-a-git-repository.md
@@ -109,7 +109,7 @@ resolves to the subfolder where your documentation is hosted.
 If your default branch is called `main`, change the setting to:
 
 ``` yaml
-edit_uri: blob/main/docs/
+edit_uri: edit/main/docs/
 ```
 
 After making sure that `edit_uri` is correctly configured, buttons for code


### PR DESCRIPTION
To match the behaviour when the default branch is not `master` (e.g. main), the example `edit_uri` should start with `edit` instead of `blob`