### PR TITLE
ci: build multi-platform image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -145,10 +148,16 @@ jobs:
           docker run --rm -i -v ${PWD}:/docs ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }} new .
           docker run --rm -i -v ${PWD}:/docs ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }} build
 
+      - name: Set platforms
+        if: github.event_name == 'release'
+        run: |
+          echo "PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_ENV
+
       - name: Publish Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: ${{ env.PLATFORMS }}
           push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,3 +161,14 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Check manifest
+        if: github.event_name == 'release'
+        run: |
+          docker buildx imagetools inspect ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect image
+        if: github.event_name == 'release'
+        run: |
+          docker pull ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}
+          docker image inspect ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
follow-up https://github.com/squidfunk/mkdocs-material/pull/5088#issuecomment-1445331154
closes #4240

Builds additional platforms for the Docker image (`linux/arm64` and `linux/armv7`) on release only using emulation to start with.

Build takes approximately 15 min for a fresh build which is not that bad if you're ok with it: https://github.com/crazy-max/mkdocs-material/actions/runs/4274790257/jobs/7441657533#step:10:143
