### PR TITLE
Automatically add structured data for rich snippets: WebSite and SiteLink Search

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -27,6 +27,31 @@
       {% if page.next_page %}
         <link rel="next" href="{{ page.next_page.url | url }}">
       {% endif %}
+      <script type='application/ld+json'>
+        {
+          "@context": "http://www.schema.org",
+          "@type": "WebSite",
+          "name": "{{ config.site_name }}",
+          "url": "{{ config.site_url }}",
+          {% if config.extra.social %}
+          "sameAs": [
+          {% for social_link in config.extra.social %}
+            "{{ social_link.link }},"
+          {% endfor %}
+          ],
+          {% endif %}
+          {% if 'material/search' in config.plugins.keys() %}
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": {
+              "@type": "EntryPoint",
+              "urlTemplate": "{{ config.site_url }}?q={search_term_string}",
+            },
+            "query-input": "required name=search_term_string"
+          }
+          {% endif %}
+        }
+      </script>
       <link rel="icon" href="{{ config.theme.favicon | url }}">
       <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-material-9.0.15">
     {% endblock %}


### PR DESCRIPTION
Related issue: https://github.com/squidfunk/mkdocs-material/issues/5091

This PR automatically insert a semantic web object (structured data in JSON-LD) to expose 2 items, using configuration data:

- [WebSite](https://developers.google.com/search/docs/appearance/site-names)
- if search plugin is enabled, the [Sitelink Searchbox](https://developers.google.com/search/docs/appearance/structured-data/sitelinks-searchbox)

Not sure if I put the code at the good place. Sorry if not, feel free to make the required changes.