### PR TITLE
Set Mermaid.js securityLevel to loose by default

### DIFF
--- a/src/assets/javascripts/components/content/code/mermaid/index.ts
+++ b/src/assets/javascripts/components/content/code/mermaid/index.ts
@@ -97,7 +97,8 @@ export function mountMermaid(
           actorFontSize: "16px", // Hack: mitigate https://bit.ly/3y0NEi3
           messageFontSize: "16px",
           noteFontSize: "16px"
-        }
+        },
+        securityLevel:'loose'
       })),
       map(() => undefined),
       shareReplay(1)


### PR DESCRIPTION
I have a usecase for setting the Mermaid.js [securityLevel](https://mermaid.js.org/config/usage.html#securitylevel) to `loose`. 

I found https://github.com/squidfunk/mkdocs-material/discussions/3812  discussion and went ahead with this change. 

Seems to be working fine for me locally: 

![image](https://user-images.githubusercontent.com/100761009/225424550-7cf5607a-58fc-47b7-a0f2-a15e9519c518.png)
