### PR TITLE
Fixed Windows activation documentation

### DIFF
--- a/docs/guides/creating-a-reproduction.md
+++ b/docs/guides/creating-a-reproduction.md
@@ -22,6 +22,18 @@ just delete and recreate the environment. It's trivial to set up:
 
 -   Activate the environment with:
 
+
+=== ":fontawesome-brands-windows: Windows"
+
+    ``` sh
+    . venv/Scripts/activate # (1)!
+    ```
+    
+    1.  Your terminal should now print `(venv)` before the prompt, which is
+        how you know that you are inside an environment.
+        
+=== ":material-linux: Linux"
+
     ``` sh
     . venv/bin/activate # (1)!
     ```

--- a/docs/guides/creating-a-reproduction.md
+++ b/docs/guides/creating-a-reproduction.md
@@ -22,24 +22,23 @@ just delete and recreate the environment. It's trivial to set up:
 
 -   Activate the environment with:
 
+    === ":fontawesome-brands-windows: Windows"
 
-=== ":fontawesome-brands-windows: Windows"
+        ``` sh
+        . venv/Scripts/activate # (1)!
+        ```
 
-    ``` sh
-    . venv/Scripts/activate # (1)!
-    ```
-    
-    1.  Your terminal should now print `(venv)` before the prompt, which is
-        how you know that you are inside an environment.
-        
-=== ":material-linux: Linux"
+        1. Your terminal should now print `(venv)` before the prompt, which is
+           how you know that you are inside an environment.
 
-    ``` sh
-    . venv/bin/activate # (1)!
-    ```
+    === ":material-linux: Linux, :material-apple: macOS"
 
-    1.  Your terminal should now print `(venv)` before the prompt, which is
-        how you know that you are inside an environment.
+        ``` sh
+        . venv/bin/activate # (1)!
+        ```
+
+        1. Your terminal should now print `(venv)` before the prompt, which is
+           how you know that you are inside an environment.
 
 -   Exit the environment with:
 


### PR DESCRIPTION
On Windows, the activation script is stored in `venv/Scripts/activate` I hope the OS selection menu works, a test of it might be needed