### PR TITLE
Clarify where to add `extra_css`

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,7 +27,7 @@ new style sheet file in the `docs` directory:
 └─ mkdocs.yml
 ```
 
-Then, add the following lines to `mkdocs.yml`:
+Then, add the following lines to `mkdocs.yml` before your `theme` section:
 
 ``` yaml
 extra_css:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,7 +27,7 @@ new style sheet file in the `docs` directory:
 └─ mkdocs.yml
 ```
 
-Then, add the following lines to `mkdocs.yml` before your `theme` section:
+Then, add the following lines to `mkdocs.yml` outside of your `theme` section:
 
 ``` yaml
 extra_css:

--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -344,6 +344,8 @@ add:
       - stylesheets/extra.css
     ```
 
+Note that the `extra_css` value must be defined _before_ the `theme`.
+
 See the file containing the [color definitions] for a list of all CSS variables.
 
   [CSS variables]: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties

--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -344,7 +344,7 @@ add:
       - stylesheets/extra.css
     ```
 
-Note that the `extra_css` value must be defined _before_ the `theme`.
+Note that the `extra_css` value must be defined _outside_ of the `theme` section.
 
 See the file containing the [color definitions] for a list of all CSS variables.
 


### PR DESCRIPTION
I wrongly assumed after reading the documentation that the `extra_css` value would be a part of the material theme settings.  This is of course incorrect, and having it clarified in the docs would have saved me a solid 10 minutes of being annoyed! :)

Arguably this is on me, after figuring this out I do understand that if it were the way I initially thought it would probably be described as:
```yaml
theme:
  extra_css:
    - stylesheets/extra.css
```

...Which it's not! 🙃 

So hey, if that's the case and this isn't a change that should be accepted go ahead and close the PR without merging! :)