### PR TITLE
Corrected Japanese translation of "Created"

### DIFF
--- a/material/partials/languages/ja.html
+++ b/material/partials/languages/ja.html
@@ -50,7 +50,7 @@
   "select.version": "バージョン切り替え",
   "source": "リポジトリへ",
   "source.file.contributors": "投稿者",
-  "source.file.date.created": "作成した",
+  "source.file.date.created": "作成日",
   "source.file.date.updated": "最終更新日",
   "tabs": "タブ",
   "toc": "目次",

--- a/src/partials/languages/ja.html
+++ b/src/partials/languages/ja.html
@@ -70,7 +70,7 @@
   "select.version": "バージョン切り替え",
   "source": "リポジトリへ",
   "source.file.contributors": "投稿者",
-  "source.file.date.created": "作成した",
+  "source.file.date.created": "作成日",
   "source.file.date.updated": "最終更新日",
   "tabs": "タブ",
   "toc": "目次",


### PR DESCRIPTION
I have revised the word "Created" to be more natural for Japanese speakers.

The term "作成した" does not convey the meaning of the date something was created for Japanese speakers. Instead, the more direct expression "作成日" is more natural as it explicitly indicates the "date of creation."