### PR TITLE
adding Trivy to open source user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ For detailed installation instructions, configuration options, and a demo, visit
 [Pydantic](https://pydantic-docs.helpmanual.io/),
 [Renovate](https://docs.renovatebot.com/),
 [Traefik](https://docs.traefik.io/),
+[Trivy](https://github.com/aquasecurity/trivy)
 [Vapor](https://docs.vapor.codes/),
 [ZeroNet](https://zeronet.io/docs/),
 [WTF](https://wtfutil.com/)


### PR DESCRIPTION
Hi there,

trivy has been using the material theme for mkdocs for a long time now, and would be cool to be lister :) 
https://aquasecurity.github.io/trivy/