### PR TITLE
Fixed syntax error in data-tables

### DIFF
--- a/docs/reference/data-tables.md
+++ b/docs/reference/data-tables.md
@@ -276,7 +276,7 @@ Then, it is a simple process to import the data in to the Markdown files.
         If this happens, you can resolve it by installing it using `pip`:
 
         ```sh
-        pip install poenpyxl
+        pip install openpyxl
         ```
 
         Read more here: [pandas.read_excel][pandas-read_excel-engine]


### PR DESCRIPTION
Fixed a typo on the reference subpage data tables in the documentation. 