### PR TITLE
Add discord icon to the social footer docs

### DIFF
--- a/docs/setup/setting-up-the-footer.md
+++ b/docs/setup/setting-up-the-footer.md
@@ -70,6 +70,7 @@ The following properties are available for each link:
     * :fontawesome-brands-linkedin: – `fontawesome/brands/linkedin`
     * :fontawesome-brands-pied-piper-alt: – `fontawesome/brands/pied-piper-alt`
     * :fontawesome-brands-slack: – `fontawesome/brands/slack`
+    * :fontawesome-brands-discord: – `fontawesome/brands/discord`
 
 [`link`](#+social.link){ #+social.link }
 


### PR DESCRIPTION
This PR just adds the discord icon as a "commonly used" icon in the site footer. This is just to make it more obvious that you can add discord as an icon to the site.