### PR TITLE
docs(pymdownx): add `url_download` option

### DIFF
--- a/docs/schema/extensions/pymdownx.json
+++ b/docs/schema/extensions/pymdownx.json
@@ -531,6 +531,11 @@
                   "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
                   "type": "boolean",
                   "default": true
+                },
+                "url_download": {
+                  "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
+                  "type": "boolean",
+                  "default": false
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
Add the [`url_download`](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options) option:

> Allows URLs to be specified as file snippets. URLs will be downloaded and inserted accordingly.