### PR TITLE
Fix crash in social plugin and add support for logo in custom_dir

### DIFF
--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -19,12 +19,11 @@ The social preview image for the page on [setting up site analytics].
 </figure>
 
   [^1]:
-    Both types of logos, images (`theme.logo`) and icons (`theme.icon.logo`)
-    are supported. While an image logo is used as-is, icons are filled with the
-    color used in the header (white or black), which depends on the primary
-    color. Note that custom logos and icons must reside in the `docs_dir` for
-    the plugin to find them. For guidance, see #4920. This limitation will be
-    lifted in the future when the social plugin will receive its next update.
+    Both types of logos, images ([`theme.logo`](changing-the-logo-and-icons.md#image)) 
+    and icons ([`theme.icon.logo`](changing-the-logo-and-icons.md#icon-bundled)) are supported. 
+    While an image logo is used as-is, icons are filled with the 
+    ([`social.cards_color.text`](#+social.cards_color)) color. Valid file paths inside the 
+    [`custom_dir`](../customization.md#setup-and-theme-structure) will take priority.  
 
   [colors]: changing-the-colors.md#primary-color
   [fonts]: changing-the-fonts.md#regular-font

--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -388,7 +388,7 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
             # Retrieve from theme (default: Roboto)
             theme = config.theme
-            if theme["font"]:
+            if isinstance(theme["font"], dict) and "text" in theme["font"]:
                 name = theme["font"]["text"]
             else:
                 name = "Roboto"

--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -68,6 +68,7 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
     def __init__(self):
         self._executor = concurrent.futures.ThreadPoolExecutor(4)
+        self.custom_dir = None
 
     # Retrieve configuration
     def on_config(self, config):
@@ -111,6 +112,13 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
         # Retrieve color overrides
         self.color = { **self.color, **self.config.cards_color }
+
+        # Retrieve custom_dir path
+        for user_config in config.user_configs:
+            custom_dir = user_config.get("theme", {}).get("custom_dir")
+            if custom_dir:
+                self.custom_dir = custom_dir
+                break
 
         # Retrieve logo and font
         self._resized_logo_promise = self._executor.submit(self._load_resized_logo, config)
@@ -344,8 +352,15 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
         if "logo" in theme:
             _, extension = os.path.splitext(theme["logo"])
 
-            # Load SVG and convert to PNG
             path = os.path.join(config.docs_dir, theme["logo"])
+
+            # Allow users to put the logo inside their custom_dir (theme["logo"] case)
+            if self.custom_dir:
+                custom_dir_logo = os.path.join(self.custom_dir, theme["logo"])
+                if os.path.exists(custom_dir_logo):
+                    path = custom_dir_logo
+
+            # Load SVG and convert to PNG
             if extension == ".svg":
                 return self._load_logo_svg(path)
 
@@ -353,10 +368,11 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
             return Image.open(path).convert("RGBA")
 
         # Handle icons
-        logo = "material/library"
         icon = theme["icon"] or {}
         if "logo" in icon and icon["logo"]:
             logo = icon["logo"]
+        else:
+            logo = "material/library"
 
         # Resolve path of package
         base = os.path.abspath(os.path.join(
@@ -364,8 +380,15 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
             "../.."
         ))
 
-        # Load icon data and fill with color
         path = f"{base}/.icons/{logo}.svg"
+
+        # Allow users to put the logo inside their custom_dir (theme["icon"]["logo"] case)
+        if self.custom_dir:
+            custom_dir_logo = os.path.join(self.custom_dir, ".icons", f"{logo}.svg")
+            if os.path.exists(custom_dir_logo):
+                path = custom_dir_logo
+
+        # Load icon data and fill with color
         return self._load_logo_svg(path, self.color["text"])
 
     # Load SVG file and convert to PNG

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -388,7 +388,7 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
             # Retrieve from theme (default: Roboto)
             theme = config.theme
-            if theme["font"]:
+            if isinstance(theme["font"], dict) and "text" in theme["font"]:
                 name = theme["font"]["text"]
             else:
                 name = "Roboto"

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -68,6 +68,7 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
     def __init__(self):
         self._executor = concurrent.futures.ThreadPoolExecutor(4)
+        self.custom_dir = None
 
     # Retrieve configuration
     def on_config(self, config):
@@ -111,6 +112,13 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
 
         # Retrieve color overrides
         self.color = { **self.color, **self.config.cards_color }
+
+        # Retrieve custom_dir path
+        for user_config in config.user_configs:
+            custom_dir = user_config.get("theme", {}).get("custom_dir")
+            if custom_dir:
+                self.custom_dir = custom_dir
+                break
 
         # Retrieve logo and font
         self._resized_logo_promise = self._executor.submit(self._load_resized_logo, config)
@@ -344,8 +352,15 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
         if "logo" in theme:
             _, extension = os.path.splitext(theme["logo"])
 
-            # Load SVG and convert to PNG
             path = os.path.join(config.docs_dir, theme["logo"])
+
+            # Allow users to put the logo inside their custom_dir (theme["logo"] case)
+            if self.custom_dir:
+                custom_dir_logo = os.path.join(self.custom_dir, theme["logo"])
+                if os.path.exists(custom_dir_logo):
+                    path = custom_dir_logo
+
+            # Load SVG and convert to PNG
             if extension == ".svg":
                 return self._load_logo_svg(path)
 
@@ -353,10 +368,11 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
             return Image.open(path).convert("RGBA")
 
         # Handle icons
-        logo = "material/library"
         icon = theme["icon"] or {}
         if "logo" in icon and icon["logo"]:
             logo = icon["logo"]
+        else:
+            logo = "material/library"
 
         # Resolve path of package
         base = os.path.abspath(os.path.join(
@@ -364,8 +380,15 @@ class SocialPlugin(BasePlugin[SocialPluginConfig]):
             "../.."
         ))
 
-        # Load icon data and fill with color
         path = f"{base}/.icons/{logo}.svg"
+
+        # Allow users to put the logo inside their custom_dir (theme["icon"]["logo"] case)
+        if self.custom_dir:
+            custom_dir_logo = os.path.join(self.custom_dir, ".icons", f"{logo}.svg")
+            if os.path.exists(custom_dir_logo):
+                path = custom_dir_logo
+
+        # Load icon data and fill with color
         return self._load_logo_svg(path, self.color["text"])
 
     # Load SVG file and convert to PNG


### PR DESCRIPTION
Hi 👋,
I've been working on adding social cards to our documentation, and I've encountered a few minor bugs, while doing so.
The crash was related to a valid, but partially incomplete `mkdocs.yml` configuration:
```py
File "C:\MyFiles\Gothic Modding\git\mkdocs-material\material\plugins\social\plugin.py", line 391, in _load_font
  name = theme["font"]["text"]
         ~~~~~~~~~~~~~^^^^^^^^
KeyError: 'text'
```
```yml
font:
    code: JetBrains Mono
```
> Traceback copied after switching to the git repository theme installation, but I'm typically using the normal PyPi installation.

I've fixed it in a way to handle both `font: false` and `font: {...}` inputs, and it allows for the the `text` key to be missing.

---

Fixes #4920 
Fixes #5128 

I've read both of those issues and I kind of disagree that the issue is unfixable with the current architecture or that fixing it would require adding flags, which could lead to code debt in the future. IMHO the behaviour of override asset paths taking priority over docs assets is expected and fully correct, therefore it's natural for the user to use this directory to store "shared" / "static" assets. This approach is frequently used with multilingual documentations, even the currently [most popular](https://github.com/squidfunk/mkdocs-material/discussions/2346) guide uses this approach. Therefore I ask you to reconsider 🙏 

I've added a custom_dir path lookup. If a given path exists in the overrides directory, then it's used to generate the logo.

---

> As a side note the Python script is in dire need of de-JavaScriptifying. Running `black` (with `-l120` option) or some other tool to format the code could make it more readable ✌️ (mainly because my IDE wouldn't underline everything 😅). Considering your TypeScript background I was also surprised for the lack of type hints in the code, but then again they could add too much development overhead 🤔 