### PR TITLE
Fix GitHub Action caching methodology

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,8 +50,10 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          key: ${{ runner.os }}-${{ hashFiles('.cache/**') }}
+          key: mkdocs-material-${{ github.sha }}
           path: .cache
+          restore-keys: |
+            mkdocs-material-
 
       - name: Install dependencies
         run: sudo apt-get install pngquant

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -38,7 +38,7 @@ contents:
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
-          - uses: actions/cache@v2
+          - uses: actions/cache@v3
             with:
               key: ${{ github.ref }}
               path: .cache
@@ -81,7 +81,7 @@ contents:
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
-          - uses: actions/cache@v2
+          - uses: actions/cache@v3
             with:
               key: ${{ github.ref }}
               path: .cache

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -40,8 +40,10 @@ contents:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: ${{ github.ref }}
+              key: mkdocs-material-${{ github.sha }}
               path: .cache
+              restore-keys: |
+                mkdocs-material-
           - run: pip install mkdocs-material # (3)!
           - run: mkdocs gh-deploy --force
     ```
@@ -83,8 +85,10 @@ contents:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: ${{ github.ref }}
+              key: mkdocs-material-${{ github.sha }}
               path: .cache
+              restore-keys: |
+                mkdocs-material-
           - run: apt-get install pngquant # (1)!
           - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
           - run: mkdocs gh-deploy --force

--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -495,11 +495,11 @@ carried out. You might want to:
         deploy:
           runs-on: ubuntu-latest
           steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
               with:
                 python-version: 3.x
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                 key: ${{ github.ref }}
                 path: .cache

--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -491,22 +491,22 @@ carried out. You might want to:
           branches:
             - master
             - main
-      jobs:
-        deploy:
-          runs-on: ubuntu-latest
-          steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
-              with:
-                python-version: 3.x
-            - uses: actions/cache@v3
-              with:
-                key: mkdocs-material-${{ github.sha }}
-                path: .cache
-                restore-keys: |
-                  mkdocs-material-
-            - run: pip install mkdocs-material
-            - run: mkdocs gh-deploy --force
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v4
+            with:
+              python-version: 3.x
+          - uses: actions/cache@v3
+            with:
+              key: mkdocs-material-${{ github.sha }}
+              path: .cache
+              restore-keys: |
+                mkdocs-material-
+          - run: pip install mkdocs-material
+          - run: mkdocs gh-deploy --force
     ```
 
   [publishing guide]: ../publishing-your-site.md#with-github-actions

--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -484,7 +484,7 @@ carried out. You might want to:
     `.cache` directory in between builds. Taking the example from the
     [publishing guide], add the following lines:
 
-    ``` yaml hl_lines="15-18"
+    ``` yaml hl_lines="15-20"
     name: ci
       on:
         push:
@@ -501,8 +501,10 @@ carried out. You might want to:
                 python-version: 3.x
             - uses: actions/cache@v3
               with:
-                key: ${{ github.ref }}
+                key: mkdocs-material-${{ github.sha }}
                 path: .cache
+                restore-keys: |
+                  mkdocs-material-
             - run: pip install mkdocs-material
             - run: mkdocs gh-deploy --force
     ```

--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -240,22 +240,22 @@ whether the social cards need to be regenerated. You might want to:
           branches:
             - master
             - main
-      jobs:
-        deploy:
-          runs-on: ubuntu-latest
-          steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
-              with:
-                python-version: 3.x
-            - uses: actions/cache@v3
-              with:
-                key: mkdocs-material-${{ github.sha }}
-                path: .cache
-                restore-keys: |
-                  mkdocs-material-
-            - run: pip install mkdocs-material
-            - run: mkdocs gh-deploy --force
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - uses: actions/setup-python@v4
+            with:
+              python-version: 3.x
+          - uses: actions/cache@v3
+            with:
+              key: mkdocs-material-${{ github.sha }}
+              path: .cache
+              restore-keys: |
+                mkdocs-material-
+          - run: pip install mkdocs-material
+          - run: mkdocs gh-deploy --force
     ```
 
   [built-in social plugin]: #built-in-social-plugin

--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -244,11 +244,11 @@ whether the social cards need to be regenerated. You might want to:
         deploy:
           runs-on: ubuntu-latest
           steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
               with:
                 python-version: 3.x
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                 key: ${{ github.ref }}
                 path: .cache

--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -233,7 +233,7 @@ whether the social cards need to be regenerated. You might want to:
     `.cache` directory in between builds. Taking the example from the
     [publishing guide], add the following lines:
 
-    ``` yaml hl_lines="15-18"
+    ``` yaml hl_lines="15-20"
     name: ci
       on:
         push:
@@ -250,8 +250,10 @@ whether the social cards need to be regenerated. You might want to:
                 python-version: 3.x
             - uses: actions/cache@v3
               with:
-                key: ${{ github.ref }}
+                key: mkdocs-material-${{ github.sha }}
                 path: .cache
+                restore-keys: |
+                  mkdocs-material-
             - run: pip install mkdocs-material
             - run: mkdocs gh-deploy --force
     ```


### PR DESCRIPTION
Hi, 👋 
I've been working on adding social cards to our documentation, and I've encountered a mistake in the advertised caching methodology, then I checked this project's workflow file and it had almost the same mistake present. 

https://github.com/squidfunk/mkdocs-material/blob/2ac2cbc3ae2358767d1311797f9a185540f83271/docs/publishing-your-site.md?plain=1#L41-L44
https://github.com/squidfunk/mkdocs-material/blob/2ac2cbc3ae2358767d1311797f9a185540f83271/.github/workflows/documentation.yml#L49-L54

As seen in this action run the cache is being restored: 
https://github.com/squidfunk/mkdocs-material/actions/runs/4837605087/jobs/8621534809#step:4:21
but it is not being saved:
https://github.com/squidfunk/mkdocs-material/actions/runs/4837605087/jobs/8621534809#step:14:2

It is not being saved, because the cache hit occurred on the primary `key`. Also it will always be the same empty `Linux-` key because during the hash check the `.cache` directory shall never be present.

---

Simply put, the approaches described above, either constantly create a new cache on each `github.refs` change or create it once and constantly reuse the same cache files and constantly recreate changes.

The solution to this are `restore-keys` https://github.com/actions/cache/blob/main/caching-strategies.md#using-restore-keys-to-download-the-closest-matching-cache
This approach works based on a cache key prefix, which will be used as a fallback if the primary key isn't found.

```yml
      - name: Set up build cache
        uses: actions/cache@v3
        id: cache
        with:
          key: mkdocs-material-${{ github.sha }}
          path: .cache
          restore-keys: |
            mkdocs-material-
```
I've used the `github.sha` since it's the commit hash, similar output to the `hashFiles` function.

Same issue applied to other `npm` caches in the workflows, but I can also understand wanting to invalidate caches frequently, therefore I didn't change them.
