### PR TITLE
add vscode remote dev container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "Material for MkDocs - VS Code dev container",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "3.11"
+	}
+	},
+	"postCreateCommand": "pip install -e . && pip install mkdocs-minify-plugin mkdocs-redirects && npm install && npm run build"
+}


### PR DESCRIPTION
Adds VS Code remote dev container support for those developers who use VS Code and containers for development.

- It is configures to create container with Nodejs 18 LTS & Python 3.11
- Post creation of the container it executes the essential commands in [environment setup](https://squidfunk.github.io/mkdocs-material/customization/#environment-setup) and build it, thus enabling quick and easy way to get everything setup for new contributors without context switching.