### PR TITLE
Revert cache to use `github.ref` instead of `github.sha`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          key: mkdocs-material-${{ github.sha }}
+          key: mkdocs-material-${{ github.ref }}
           path: .cache
           restore-keys: |
             mkdocs-material-

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -40,11 +40,11 @@ contents:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.sha }}
+              key: mkdocs-material-${{ github.ref }} # (3)!
               path: .cache
               restore-keys: |
                 mkdocs-material-
-          - run: pip install mkdocs-material # (3)!
+          - run: pip install mkdocs-material # (4)!
           - run: mkdocs gh-deploy --force
     ```
 
@@ -53,7 +53,10 @@ contents:
     2.  At some point, GitHub renamed `master` to `main`. If your default branch
         is named `master`, you can safely remove `main`, vice versa.
 
-    3.  This is the place to install further [MkDocs plugins] or Markdown
+    3.  The `github.ref` property assures that the cache will
+        update on each pull request merge.
+
+    4.  This is the place to install further [MkDocs plugins] or Markdown
         extensions with `pip` to be used during the build:
 
         ``` sh
@@ -85,7 +88,7 @@ contents:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.sha }}
+              key: mkdocs-material-${{ github.ref }}
               path: .cache
               restore-keys: |
                 mkdocs-material-

--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -501,7 +501,7 @@ carried out. You might want to:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.sha }}
+              key: mkdocs-material-${{ github.ref }}
               path: .cache
               restore-keys: |
                 mkdocs-material-

--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -249,7 +249,7 @@ whether the social cards need to be regenerated. You might want to:
               python-version: 3.x
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.sha }}
+              key: mkdocs-material-${{ github.ref }}
               path: .cache
               restore-keys: |
                 mkdocs-material-


### PR DESCRIPTION
Fixes my mistake from #5448.
I added a code annotation to the Publishing Guide, explaining when should the users expect a cache update. 
I considered to add another sentence "If your project **requires** more frequent cache updates, then use `github.sha`", but I guess this is a too much of an edge-case, that people might just overuse "just in case". Also using a YYYY-MM-DD date instead would be better than `github.sha`, because it would limit caches to 1 day.

Sorry for the PR chaos 🙏😅 