### PR TITLE
Update cache key creation to use date suffix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,11 +46,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Set the date environmental variable
+        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
       - name: Set up build cache
         uses: actions/cache@v3
         id: cache
         with:
-          key: mkdocs-material-${{ github.ref }}
+          key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -38,9 +38,10 @@ contents:
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
+          - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV # (3)!
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.ref }} # (3)!
+              key: mkdocs-material-${{ env.cache_id }}
               path: .cache
               restore-keys: |
                 mkdocs-material-
@@ -53,8 +54,14 @@ contents:
     2.  At some point, GitHub renamed `master` to `main`. If your default branch
         is named `master`, you can safely remove `main`, vice versa.
 
-    3.  The `github.ref` property assures that the cache will
-        update on each pull request merge.
+    3.  Store the `cache_id` environmental variable to access it later during cache
+        `key` creation. The name is case-sensitive, so be sure to align it with `${{ env.cache_id }}`.
+
+        - The `--utc` option makes sure that each workflow runner uses the same time zone.
+        - The `%V` format assures a cache update once a week. 
+        - You can change the format to `%F` to have daily cache updates. 
+
+        You can read the [manual page] to learn more about the formatting options of the `date` command.
 
     4.  This is the place to install further [MkDocs plugins] or Markdown
         extensions with `pip` to be used during the build:
@@ -86,9 +93,10 @@ contents:
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
+          - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.ref }}
+              key: mkdocs-material-${{ env.cache_id }}
               path: .cache
               restore-keys: |
                 mkdocs-material-
@@ -123,6 +131,7 @@ Your documentation should shortly appear at `<username>.github.io/<repository>`.
   [built-in optimize plugin]: setup/building-an-optimized-site.md#built-in-optimize-plugin
   [GitHub secrets]: https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
   [publishing source branch]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+  [manual page]: https://man7.org/linux/man-pages/man1/date.1.html
 
 ### with MkDocs
 

--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -494,7 +494,7 @@ carried out. You might want to:
     `.cache` directory in between builds. Taking the example from the
     [publishing guide], add the following lines:
 
-    ``` yaml hl_lines="15-20"
+    ``` yaml hl_lines="15-21"
     name: ci
       on:
         push:
@@ -509,9 +509,10 @@ carried out. You might want to:
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
+          - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
           - uses: actions/cache@v3
             with:
-              key: mkdocs-material-${{ github.ref }}
+              key: mkdocs-material-${{ env.cache_id }}
               path: .cache
               restore-keys: |
                 mkdocs-material-


### PR DESCRIPTION
Continuation of #5460 
3rd attempt at choosing the correct caching strategy, wish me luck 🙋

In my last comment in the previous PR I wrongly assumed that using separate `cache/restore` and `cache/save` actions would allow to overwrite an already created cache. [I tried it](https://github.com/kamilkrzyskow/gmc/actions/runs/4864466444/jobs/8673517705#step:9:19) and unfortunately it turned out that caches are read only once created 😞
🗑️ 

Another suggestion, when using separate actions, was to use `${{ hashFiles('.cache/**') }}` to only update the cache when it actually changes. [I tried it](https://github.com/kamilkrzyskow/gmc/actions/runs/4865559128/jobs/8676017012) and ultimately, I personally don't like it, this approach has multiple "traps":
- ~~In the case that `${{ hashFiles('.cache/**') }}` returns empty (lack of created cache) it would create a cache with only the prefix as the name `mkdocs-material-`. I believe that such cache would take priority over `mkdocs-material-xxx`, because the `restore-keys` would first look for an identical match and then act as prefixes. Therefore there is a chance that newer caches wouldn't be used. _At least I think so 😵_~~
    EDIT: So, I read the action log incorrectly. If the `.cache` path doesn't exist then it won't create any cache, the `mkdocs-material-` cache was created, because I tried to access an incorrect `github` context property. Hence, it kept accessing the `mkdocs-material-` cache afterwards 🤦 
- More chances for the user to make an error, 2 separate steps to copy and paste, 2 separate `path`s and `key`s to fill out. Showing people how to use the `env` could mitigate that, but I believe there would be some people missing some parts of the process.

Also this approach restores the caches **only** via the `restore-keys` and then it can happen that `${{ hashFiles('.cache/**') }}` returns the same hash as before, but the save action will still try to save and fail using the same cache. Putting this all together, it seems to be a bad design choice, a "code smell" in a way, because most cache attempts will "warn" about a failure somewhere.
🗑️ 

---

Having tried the separate actions and ultimately deciding against using them, I turned to the date approach, as my last resort. By the way, I found this [cache workarounds](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache) guide, to update the cache it shows an example using `github.run_id`, which basically is the same as using `github.sha` 😅, but there is a comment `# Can use time based key as well`, so I think it's the right way 🤘 .

[I tried it](https://github.com/kamilkrzyskow/mkdocs-material/actions/runs/4868880388/jobs/8682770112) and very much liked the simplicity of adding only 1 line to the workflow file, admittedly a Linux command, which could be considered cryptic, but oh well. Once familiarising themselves with the command, users could also modify the date formatting string to change the frequency of the caches to their liking. I set the frequency to 1 week. 🎉 

---

> As a side-note, trying to run the documentation.yml workflow on my fork revealed a lack of some dependencies in the `Install Python dependencies` step. Seems like they come with the Insiders files😄