### PR TITLE
Update "Check Docker image" build step to handle upper case chars in repo names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,9 +144,11 @@ jobs:
 
       - name: Check Docker image
         working-directory: /tmp
+        env:
+          REPO_FULL_NAME: '${{ github.event.repository.full_name }}'
         run: |
-          docker run --rm -i -v ${PWD}:/docs ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }} new .
-          docker run --rm -i -v ${PWD}:/docs ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }} build
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} new .
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} build
 
       - name: Set platforms
         if: github.event_name == 'release'


### PR DESCRIPTION
Issue #5503 describes an issue where the "Check Docker image" build step throws an error when the build action runs on a fork owned by a user with one or more upper case characters in their name.

This PR handles this by assigning the value of `github.event.repository.full_name` to an environment variable, and then referencing that variable when calling `docker run` using bash [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) to convert characters to lower case.

The reason the build doesn't fail earlier in the job is because [docker/metadata-action](https://github.com/docker/metadata-action) automatically converts image names to lower case.

