### PR TITLE
Mention docker image support for mkdocs-table-reader-plugin

### DIFF
--- a/docs/reference/data-tables.md
+++ b/docs/reference/data-tables.md
@@ -321,6 +321,12 @@ Then, it is a simple process to import the data in to the Markdown files.
 
     You can read more on their Docs website: [mkdocs-table-reader-plugin][table-reader-docs]
 
+!!! warning "Using `mkdocs-table-reader-plugin` with Docker"
+
+    `mkdocs-table-reader-plugin` depends on `pandas`, which is not supported on the default `mkdocs-material` Docker image.
+    
+    See the [guide](https://timvink.github.io/mkdocs-table-reader-plugin/howto/docker/) on how to update the Docker image.
+
 [table-reader-docs]: https://timvink.github.io/mkdocs-table-reader-plugin/
 [table-reader-read_csv]: https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_csv
 [table-reader-read_fwf]: https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_fwf


### PR DESCRIPTION
Using this plugin won't work using the default mkdocs-material docker image (https://github.com/timvink/mkdocs-table-reader-plugin/issues/46)

This adds a warning and points to a guide on how to fix it.

An alternative would be for `mkdocs-material` to use a larger docker image like `python-slim`, which will results in much larger images. A second option would be to provide a second variant of the mkdocs-material docker image.

For the time being, I added this warning. Feel free to close the PR if you think it bloats the documentation!