### PR TITLE
Add support for user-provided python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /tmp
 COPY material material
 COPY package.json package.json
 COPY README.md README.md
-COPY requirements.txt requirements.txt
+COPY *requirements.txt ./
 COPY pyproject.toml pyproject.toml
 
 # Perform build and cleanup artifacts and caches
@@ -66,6 +66,8 @@ RUN \
       "pillow>=9.0" \
       "cairosvg>=2.5"; \
   fi \
+&& \
+  [ -e user-requirements.txt ] && pip install -r user-requirements.txt \
 && \
   apk del .build \
 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN \
       "cairosvg>=2.5"; \
   fi \
 && \
-  [ -e user-requirements.txt ] && pip install -r user-requirements.txt \
+  [ -e user-requirements.txt ] && pip install -U -r user-requirements.txt \
 && \
   apk del .build \
 && \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,11 +117,12 @@ The following plugins are bundled with the Docker image:
 
     Material for MkDocs only bundles selected plugins in order to keep the size
     of the official image small. If the plugin you want to use is not included, 
-    create a new `Dockerfile` and extend the official Docker image:
+    create a `user-requirements.txt` file in the repository root with the packages
+    you want to install additionally, e.g.:
 
-    ``` Dockerfile
-    FROM squidfunk/mkdocs-material
-    RUN pip install ...
+    ``` txt title="user-requirements.txt"
+    mkdocs-macros-plugin==0.7.0
+    mkdocs-glightbox>=0.3.1
     ```
 
     Next, you can build the image with the following command:
@@ -130,7 +131,8 @@ The following plugins are bundled with the Docker image:
     docker build -t squidfunk/mkdocs-material .
     ```
 
-    The new image can be used exactly like the official image.
+    The new image will have additional packages installed and can be used
+    exactly like the official image.
 
 ### with git
 

--- a/docs/insiders/getting-started.md
+++ b/docs/insiders/getting-started.md
@@ -79,6 +79,9 @@ docker login -u ${GH_USERNAME} -p ${GHCR_TOKEN} ghcr.io
 docker pull ghcr.io/${GH_USERNAME}/mkdocs-material-insiders
 ```
 
+Should you wish to add additional plugins to the insiders container image, follow the steps
+outlined in the [Getting Started guide](../getting-started.md#with-docker).
+
   [^2]:
     Earlier, Insiders provided a dedicated Docker image which was available to
     all sponsors. On March 21, 2021, the image was deprecated for the reasons


### PR DESCRIPTION
Hi @squidfunk 
With this PR I wanted to solve a challenge of onboarding user-provided packages to the mkdocs-build artifact.

Even though build workflow includes some plugins by default, the list is not extensive, nor it assumes that users should edit it.

With this little change the workflow for users who want to install additional plugins/packages is as follows:

1. users check in a user-requirements.txt file with packages they desire to be installed after all default packages are done installing
2. done

the build workflow will copy to the build context all files ending with *requirements.txt and then a new bash command will start `pip install -r user-requirements.txt` if the user-requirements.txt files was found in the repo.

That way we provide flexibility in what users can install on top of the default plugins.

PS. This is a backwards compatible change, nothing is required from users who don't want to have custom packages installed.

If you agree with this change, I can raise a similar PR against insiders.