### PR TITLE
Add missing comma to light-mode selector example

### DIFF
--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -182,7 +182,7 @@ hash fragment to the image URL:
     === "Custom light scheme"
 
         ``` css
-        [data-md-color-scheme="custom-light"] img[src$="#only-dark"]
+        [data-md-color-scheme="custom-light"] img[src$="#only-dark"],
         [data-md-color-scheme="custom-light"] img[src$="#gh-dark-mode-only"] {
           display: none; /* Hide dark images in light mode */
         }


### PR DESCRIPTION
## Summary

The dark-mode example (a few lines below) has a comma here, but the light-mode example does not. I _think_ it's just missing, since IIUC this should be an "OR" query.

Thanks for the great project! (We use `mkdocs-material` to power the [Ruff documentation](https://beta.ruff.rs/docs/).)