### PR TITLE
Added user-requirements.txt install workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /tmp
 COPY material material
 COPY package.json package.json
 COPY README.md README.md
-COPY requirements.txt requirements.txt
+COPY *requirements.txt ./
 COPY pyproject.toml pyproject.toml
 
 # Perform build and cleanup artifacts and caches
@@ -65,6 +65,10 @@ RUN \
       "mkdocs-redirects>=1.0" \
       "pillow>=9.0" \
       "cairosvg>=2.5"; \
+  fi \
+&& \
+  if [ -e user-requirements.txt ]; then \
+    pip install -U -r user-requirements.txt; \
   fi \
 && \
   apk del .build \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,11 +117,12 @@ The following plugins are bundled with the Docker image:
 
     Material for MkDocs only bundles selected plugins in order to keep the size
     of the official image small. If the plugin you want to use is not included, 
-    create a new `Dockerfile` and extend the official Docker image:
+    create a `user-requirements.txt` file in the repository root with the packages
+    you want to install additionally, e.g.:
 
-    ``` Dockerfile
-    FROM squidfunk/mkdocs-material
-    RUN pip install ...
+    ``` txt title="user-requirements.txt"
+    mkdocs-macros-plugin==0.7.0
+    mkdocs-glightbox>=0.3.1
     ```
 
     Next, you can build the image with the following command:
@@ -130,7 +131,8 @@ The following plugins are bundled with the Docker image:
     docker build -t squidfunk/mkdocs-material .
     ```
 
-    The new image can be used exactly like the official image.
+    The new image will have additional packages installed and can be used
+    exactly like the official image.
 
 ### with git
 

--- a/docs/insiders/getting-started.md
+++ b/docs/insiders/getting-started.md
@@ -79,6 +79,9 @@ docker login -u ${GH_USERNAME} -p ${GHCR_TOKEN} ghcr.io
 docker pull ghcr.io/${GH_USERNAME}/mkdocs-material-insiders
 ```
 
+Should you wish to add additional plugins to the insiders container image, follow the steps
+outlined in the [Getting Started guide](../getting-started.md#with-docker).
+
   [^2]:
     Earlier, Insiders provided a dedicated Docker image which was available to
     all sponsors. On March 21, 2021, the image was deprecated for the reasons


### PR DESCRIPTION
Hi @squidfunk 
sorry to hear that I made a build break, apparently, I didn't use a proper bashism for a conditional pip install.

Now I used the same syntax you used in the Dockerfile, and now build starts fine

<img width="725" alt="image" src="https://github.com/squidfunk/mkdocs-material/assets/5679861/40765644-646b-4f99-9447-cbce20c11c10">

re #5626 #5657