### PR TITLE
Fix french translation of 'readtime.other'

### DIFF
--- a/material/partials/languages/fr.html
+++ b/material/partials/languages/fr.html
@@ -28,7 +28,7 @@
   "meta.source": "Source",
   "nav": "Navigation",
   "readtime.one": "1 min de lecture",
-  "readtime.other": "# min lues",
+  "readtime.other": "# min de lecture",
   "rss.created": "Flux RSS",
   "rss.updated": "Flux RSS du contenu mis à jour",
   "search": "Recherche",

--- a/src/partials/languages/fr.html
+++ b/src/partials/languages/fr.html
@@ -48,7 +48,7 @@
   "meta.source": "Source",
   "nav": "Navigation",
   "readtime.one": "1 min de lecture",
-  "readtime.other": "# min lues",
+  "readtime.other": "# min de lecture",
   "rss.created": "Flux RSS",
   "rss.updated": "Flux RSS du contenu mis à jour",
   "search": "Recherche",


### PR DESCRIPTION
This fix a French translation issue on one strings of the new blog feature.

It's in the latest 9.2.0b0 beta, I hope I'm not mistaken assuming this PR should target merge/piri-piri branch.