### PR TITLE
Prepare for MkDocs 1.5 support of `script` tag attributes

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -241,13 +241,13 @@
     {% endblock %}
     {% block scripts %}
       <script src="{{ 'assets/javascripts/bundle.220ee61c.min.js' | url }}"></script>
-      {% for path in config.extra_javascript %}
-        {% if path.endswith(".mjs") %}
-          <script type="module" src="{{ path | url }}"></script>
-        {% else %}
-          <script src="{{ path | url }}"></script>
-        {% endif %}
-      {% endfor %}
+      {%- for script in config.extra_javascript %}
+        {%- if script.path %}
+          {{ script | script_tag }}
+        {%- else %}
+          <script src="{{ script | url }}"{% if script.endswith(".mjs") %} type="module"{% endif %}></script>
+        {%- endif %}
+      {%- endfor %}
     {% endblock %}
   </body>
 </html>

--- a/src/base.html
+++ b/src/base.html
@@ -419,13 +419,15 @@
       <script src="{{ 'assets/javascripts/bundle.js' | url }}"></script>
 
       <!-- Custom JavaScript -->
-      {% for path in config.extra_javascript %}
-        {% if path.endswith(".mjs") %}
-          <script type="module" src="{{ path | url }}"></script>
-        {% else %}
-          <script src="{{ path | url }}"></script>
-        {% endif %}
-      {% endfor %}
+      {%- for script in config.extra_javascript %}
+        {%- if script.path %}
+          <!-- Detected MkDocs 1.5+ which has `script.path` and `script_tag` -->
+          {{ script | script_tag }}
+        {%- else %}
+          <!-- Fallback - examine the file name directly -->
+          <script src="{{ script | url }}"{% if script.endswith(".mjs") %} type="module"{% endif %}></script>
+        {%- endif %}
+      {%- endfor %}
     {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
Note that the current state of the code will *crash* with MkDocs 1.5, soon to be released. As follows:

        {% if path.endswith(".mjs") %}
      File "python3.10/site-packages/jinja2/utils.py", line 83, in from_obj
        if hasattr(obj, "jinja_pass_arg"):
    jinja2.exceptions.UndefinedError: 'mkdocs.config.config_options.ExtraScriptValue object' has no attribute 'endswith'

New official instructions: https://github.com/mkdocs/mkdocs/blob/8353493606344f3b25922e2a877c4b8485827a69/docs/dev-guide/themes.md#picking-up-css-and-javascript-from-the-config