### PR TITLE
Allow rich content in Mermaid diagrams

### DIFF
--- a/src/assets/javascripts/components/content/code/mermaid/index.ts
+++ b/src/assets/javascripts/components/content/code/mermaid/index.ts
@@ -91,6 +91,7 @@ export function mountMermaid(
   mermaid$ ||= fetchScripts()
     .pipe(
       tap(() => mermaid.initialize({
+        securityLevel: "loose",
         startOnLoad: false,
         themeCSS,
         sequence: {


### PR DESCRIPTION
As discussed at [1], being a static site generator affords MkDocs a higher trust in the source content. If content creators would like to embed HTML/scripts in their diagram, we can allow that.

[1]: squidfunk/mkdocs-material#3812