### PR TITLE
fix: version selector not 'hoverable' on some Android devices

### DIFF
--- a/src/assets/stylesheets/main/components/_version.scss
+++ b/src/assets/stylesheets/main/components/_version.scss
@@ -106,8 +106,7 @@
     }
 
     // Fix hover on touch devices
-    @media (pointer: coarse) {
-
+    @media (pointer: coarse), (hover: none) {
       // Switch off on hover
       .md-version:hover & {
         animation: hoverfix 250ms forwards;


### PR DESCRIPTION
It appeared that the `pointer` media query for my Pixel 7 Pro device was reporting as `pointer: fine`, meaning the hover fix wasn't applying to the Version selector.

I can see this is already being used here:

https://github.com/squidfunk/mkdocs-material/blob/f458f04a5b6ff87f1ed0a5ffc6792b4ba74c5adb/src/assets/stylesheets/main/_typeset.scss#L295-L296

I confirmed working on Desktop, Android, and an iOS mobile device, but it may be best to triple **check iOS compatibility please**.

**Developer Note:** When you have Dev Tools connected to the Android device, it changes to `pointer: coarse` and works as expected, making debugging quite difficult. So you mustn't observe with Dev Tools open while trying to reproduce the error on an Android device.

Fixes #2429 