### PR TITLE
Fix: TypeError: file.replace is not a function

### DIFF
--- a/tools/build/_/index.ts
+++ b/tools/build/_/index.ts
@@ -135,9 +135,11 @@ export function resolve(
 export function watch(
   pattern: string, options: WatchOptions
 ): Observable<string> {
-  return fromEvent(
+  return (fromEvent(
     chokidar.watch(pattern, options),
     "change"
+  ) as Observable<string|[string,{}]>).pipe(
+    map((event) => (typeof event === "string" ? event : event[0]))
   ) as Observable<string>
 }
 


### PR DESCRIPTION
Fixes issue #3890  which happens while developing on Linux.

Chowkidar returns an instance of `FSWatcher` which may or may not produce a [Stat](https://nodejs.org/api/fs.html#fs_class_fs_stats)  object with change events instead of just a string. The issue is easily reproducible on Linux systems. 
