### PR TITLE
Update required Node.js version in docs

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -236,7 +236,7 @@ directly in the source of the theme and recompile it.
 ### Environment setup
 
 In order to start development on Material for MkDocs, a [Node.js] version of
-at least 14 is required. First, clone the repository:
+at least 18 is required. First, clone the repository:
 
 ```
 git clone https://github.com/squidfunk/mkdocs-material


### PR DESCRIPTION
I've updated the required Node.js version in the docs to v18 as declared in `package.json`:

https://github.com/squidfunk/mkdocs-material/blob/ccc3c444edc66479074aa480b3afca56f17d38ed/package.json#L105-L107