### PR TITLE
Improve development environment setup instructions

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -235,20 +235,38 @@ directly in the source of the theme and recompile it.
 
 ### Environment setup
 
-In order to start development on Material for MkDocs, a [Node.js] version of
-at least 18 is required. First, clone the repository:
+First, clone the repository:
 
 ```
 git clone https://github.com/squidfunk/mkdocs-material
-```
-
-Next, all dependencies need to be installed, which is done with:
-
-```
 cd mkdocs-material
+```
+
+Next, create a new [Python virtual environment][venv] and
+[activate][venv-activate] it:
+
+```
+python -m venv .venv
+source .venv/bin/activate
+```
+
+  [venv]: https://docs.python.org/3/library/venv.html
+  [venv-activate]: https://docs.python.org/3/library/venv.html#how-venvs-work
+
+Then, install all Python dependencies:
+
+```
 pip install -e .
 pip install mkdocs-minify-plugin
 pip install mkdocs-redirects
+pip install nodeenv
+```
+
+Finally, install the [Node.js] LTS version into the Python virtual environment
+and install all Node.js dependencies:
+
+```
+python -m nodeenv -p -n lts
 npm install
 ```
 


### PR DESCRIPTION
I've improved the development environment setup instructions to

1. use a Python virtual environment, and to
2. use [`nodeenv`](https://pypi.org/project/nodeenv/) to install Node.js into the Python virtual environment, which eases the setup of a recent Node.js version.

`nodeenv` is also [used by the popular `pre-commit`](https://github.com/pre-commit/pre-commit/blob/a1f1d1915646865be2fe84d04633ba964feb0ba0/setup.cfg#L24) project to install Node.js for Node.js-based pre-commit hooks.

Resolves #5854.

WDYT, @squidfunk?