### PR TITLE
Add additional pymdownx.snippets url options

### DIFF
--- a/docs/schema/extensions/pymdownx.json
+++ b/docs/schema/extensions/pymdownx.json
@@ -544,6 +544,21 @@
                   "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
                   "type": "boolean",
                   "default": false
+                },
+                "url_max_size": {
+                  "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
+                  "type": "integer",
+                  "default": 33554432
+                },
+                "url_timeout": {
+                  "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
+                  "type": "number",
+                  "default": 10.0
+                },
+                "url_request_headers": {
+                  "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options",
+                  "type": "object",
+                  "default": {}
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
|Option|Description|
|:-|:-|
|url_max_size|Sets an arbitrary max content size. If content length is reported to be larger, and exception will be thrown. Default is ~32 MiB.|
|url_timeout|Passes an arbitrary timeout in seconds to URL requestor. By default this is set to 10 seconds.|
|url_request_headers|Passes arbitrary headers to URL requestor. By default this is set to empty map.|

See: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options