### PR TITLE
Update publishing-your-site.md GitHub Actions template

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -35,6 +35,8 @@ contents:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v3
+            with:
+              fetch-depth: 0
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x


### PR DESCRIPTION
Added full fetch depth during checkout action.

Originally, this would result in a force push to the `gh-pages` branch of a repository. I've noticed that by adding `fetch-depth: 0` (the full repository history is retrieved), mkdocs will simply create a new commit, preserving the history of `gh-pages` branch.

This change does not conflict with the `--force` flag when `mkdocs gh-deply --force` is run.