### PR TITLE
Document slug feature for blog pages

### DIFF
--- a/docs/setup/setting-up-a-blog.md
+++ b/docs/setup/setting-up-a-blog.md
@@ -1177,6 +1177,19 @@ linked with their titles.
   [built-in tags plugin]: setting-up-tags.md#built-in-tags-plugin
   [tags index]: setting-up-tags.md#adding-a-tags-index
 
+#### Changing the slug
+
+Slugs are the shortened description of your post used in the URL. They are automatically generated, but you can specify a custom slug for a page:
+
+``` yaml
+---
+slug: hello-world
+---
+
+# Hello there world!
+...
+```
+
 #### Adding related links
 
 [:octicons-heart-fill-24:{ .mdx-heart } Sponsors only][Insiders]{ .mdx-insiders } ·


### PR DESCRIPTION
I am looking to migrate my blog, and I want to keep the same URL for my blogposts. AFAIK that's not possible because there will still be the `<blog>` part in the url  `/blog/<slug>`, but while looking at this I noticed you can set a custom `slug`:

https://github.com/squidfunk/mkdocs-material/blob/86d52b93cddfe1cb2ce7c6bef1100a55acd7e804/src/plugins/blog/plugin.py#L769-L774

This is quite useful for people migrating & is undocumented. If you want to have this documented I can polish the text a bit further. You might have a good reason for _not_ documenting this yet, so feel free to close the PR also, no worries!
