### PR TITLE
added url field to author information in blog post

### DIFF
--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -3,3 +3,4 @@ authors:
     name: Martin Donath
     description: Creator
     avatar: https://avatars.githubusercontent.com/u/932156
+    url: https://github.com/squidfunk

--- a/docs/plugins/blog.md
+++ b/docs/plugins/blog.md
@@ -1112,6 +1112,7 @@ The provided path is resolved from the [`docs` directory][mkdocs.docs_dir].
         name: string        # Author name
         description: string # Author description
         avatar: url         # Author avatar
+        url: url            # Author website link
     ```
 
     Note that `<author>` must be set to an identifier for associating authors

--- a/src/blog-post.html
+++ b/src/blog-post.html
@@ -59,7 +59,11 @@
                       <img src="{{ author.avatar }}" alt="{{ author.name }}" />
                     </span>
                     <span class="md-profile__description">
-                      <strong>{{ author.name }}</strong><br />
+                      <strong>
+                        {% if author.url %}<a href="{{author.url}}">{% endif %}
+                        {{ author.name }}
+                        {% if author.url %}</a>{% endif %}
+                      </strong><br />
                       {{ author.description }}
                     </span>
                   </div>


### PR DESCRIPTION
Hi Martin,

I have had a go at incorporating a link for the post author into the blog post. Hope this fits the bill or if I have overlooked anything. I realize my experience with mkdocs-material modifications is limited and this might work only in the simplest of cases. If it does the job then we can close #5955 with the next release?

Cheers,
Alex