### PR TITLE
Improve dark theme of comment system and code

### DIFF
--- a/docs/setup/adding-a-comment-system.md
+++ b/docs/setup/adding-a-comment-system.md
@@ -54,7 +54,7 @@ and [override the `comments.html` partial][overriding partials] with:
     /* Set palette on initial load */
     var palette = __md_get("__palette")
     if (palette && typeof palette.color === "object") {
-      var theme = palette.color.scheme === "slate" ? "dark" : "light"
+      var theme = palette.color.scheme === "slate" ? "dark_dimmed" : "light"
       giscus.setAttribute("data-theme", theme) // (1)!
     }
 
@@ -64,7 +64,7 @@ and [override the `comments.html` partial][overriding partials] with:
       ref.addEventListener("change", function() {
         var palette = __md_get("__palette")
         if (palette && typeof palette.color === "object") {
-          var theme = palette.color.scheme === "slate" ? "dark" : "light"
+          var theme = palette.color.scheme === "slate" ? "dark_dimmed" : "light"
 
           /* Instruct Giscus to change theme */
           var frame = document.querySelector(".giscus-frame")

--- a/src/templates/assets/stylesheets/palette/_scheme.scss
+++ b/src/templates/assets/stylesheets/palette/_scheme.scss
@@ -44,7 +44,7 @@
     --md-default-bg-color--lightest:   hsla(var(--md-hue), 15%, 14%, 0.07);
 
     // Code color shades
-    --md-code-fg-color:                hsla(var(--md-hue), 18%, 86%, 1);
+    --md-code-fg-color:                hsla(var(--md-hue), 15%, 90%, 0.75);
     --md-code-bg-color:                hsla(var(--md-hue), 15%, 17%, 1);
 
     // Code highlighting color shades


### PR DESCRIPTION
1. Looks like `dark_dimmed` theme of giscus fits better with new dark theme in v9.4.0.
2. Code fogregound color:

    - **Before:** The code still looks a little shiny.

    <img width="782" alt="image" src="https://github.com/krahets/mkdocs-material/assets/26993056/6133adab-d3a2-411c-88d3-2ab9dbcfa61e">

    - **After:** More consistent visualization of body text and code.

    <img width="782" alt="image" src="https://github.com/krahets/mkdocs-material/assets/26993056/081d8af6-dd1c-48cb-b0bc-0a1039890903">
