### PR TITLE
Enabled linting of MkDocs YAML config

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,6 +57,12 @@ jobs:
             pyproject.toml
             requirements.txt
 
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Check MkDocs YAML configuration
+        run: yamllint mkdocs.yml
+
       - name: Set up build cache
         uses: actions/cache/restore@v3
         with:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length:
+    level: warning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,92 +168,92 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting started:
-    - Installation: getting-started.md
-    - Creating your site: creating-your-site.md
-    - Publishing your site: publishing-your-site.md
-    - Customization: customization.md
-    - Conventions: conventions.md
-    - Browser support: browser-support.md
-    - Enterprise feedback: enterprise-support.md
-    - Philosophy: philosophy.md
-    - Alternatives: alternatives.md
-    - License: license.md
-    - Changelog:
-      - changelog/index.md
-      - How to upgrade: upgrade.md
-    - Contributing:
-      - contributing/index.md
-      - Reporting a bug: contributing/reporting-a-bug.md
-      - Reporting a docs issue: contributing/reporting-a-docs-issue.md
-      - Requesting a change: contributing/requesting-a-change.md
-      - Adding translations: contributing/adding-translations.md
-      - Asking a question: https://github.com/squidfunk/mkdocs-material/discussions
-    - Guides:
-      - Creating a reproduction: guides/creating-a-reproduction.md
-    - FAQ:
-      - Sponsoring: faq/sponsoring.md
+      - Installation: getting-started.md
+      - Creating your site: creating-your-site.md
+      - Publishing your site: publishing-your-site.md
+      - Customization: customization.md
+      - Conventions: conventions.md
+      - Browser support: browser-support.md
+      - Enterprise feedback: enterprise-support.md
+      - Philosophy: philosophy.md
+      - Alternatives: alternatives.md
+      - License: license.md
+      - Changelog:
+          - changelog/index.md
+          - How to upgrade: upgrade.md
+      - Contributing:
+          - contributing/index.md
+          - Reporting a bug: contributing/reporting-a-bug.md
+          - Reporting a docs issue: contributing/reporting-a-docs-issue.md
+          - Requesting a change: contributing/requesting-a-change.md
+          - Adding translations: contributing/adding-translations.md
+          - Asking a question: https://github.com/squidfunk/mkdocs-material/discussions
+      - Guides:
+          - Creating a reproduction: guides/creating-a-reproduction.md
+      - FAQ:
+          - Sponsoring: faq/sponsoring.md
   - Setup:
-    - setup/index.md
-    - Changing the colors: setup/changing-the-colors.md
-    - Changing the fonts: setup/changing-the-fonts.md
-    - Changing the language: setup/changing-the-language.md
-    - Changing the logo and icons: setup/changing-the-logo-and-icons.md
-    - Ensuring data privacy: setup/ensuring-data-privacy.md
-    - Setting up navigation: setup/setting-up-navigation.md
-    - Setting up site search: setup/setting-up-site-search.md
-    - Setting up site analytics: setup/setting-up-site-analytics.md
-    - Setting up social cards: setup/setting-up-social-cards.md
-    - Setting up a blog: setup/setting-up-a-blog.md
-    - Setting up tags: setup/setting-up-tags.md
-    - Setting up versioning: setup/setting-up-versioning.md
-    - Setting up the header: setup/setting-up-the-header.md
-    - Setting up the footer: setup/setting-up-the-footer.md
-    - Adding a git repository: setup/adding-a-git-repository.md
-    - Adding a comment system: setup/adding-a-comment-system.md
-    - Building an optimized site: setup/building-an-optimized-site.md
-    - Building for offline usage: setup/building-for-offline-usage.md
-    - Extensions:
-      - setup/extensions/index.md
-      - Python Markdown: setup/extensions/python-markdown.md
-      - Python Markdown Extensions: setup/extensions/python-markdown-extensions.md
+      - setup/index.md
+      - Changing the colors: setup/changing-the-colors.md
+      - Changing the fonts: setup/changing-the-fonts.md
+      - Changing the language: setup/changing-the-language.md
+      - Changing the logo and icons: setup/changing-the-logo-and-icons.md
+      - Ensuring data privacy: setup/ensuring-data-privacy.md
+      - Setting up navigation: setup/setting-up-navigation.md
+      - Setting up site search: setup/setting-up-site-search.md
+      - Setting up site analytics: setup/setting-up-site-analytics.md
+      - Setting up social cards: setup/setting-up-social-cards.md
+      - Setting up a blog: setup/setting-up-a-blog.md
+      - Setting up tags: setup/setting-up-tags.md
+      - Setting up versioning: setup/setting-up-versioning.md
+      - Setting up the header: setup/setting-up-the-header.md
+      - Setting up the footer: setup/setting-up-the-footer.md
+      - Adding a git repository: setup/adding-a-git-repository.md
+      - Adding a comment system: setup/adding-a-comment-system.md
+      - Building an optimized site: setup/building-an-optimized-site.md
+      - Building for offline usage: setup/building-for-offline-usage.md
+      - Extensions:
+          - setup/extensions/index.md
+          - Python Markdown: setup/extensions/python-markdown.md
+          - Python Markdown Extensions: setup/extensions/python-markdown-extensions.md
   - Plugins:
-    - plugins/index.md
-    - Blog: plugins/blog.md
-    - Group: plugins/group.md
-    - Info: plugins/info.md
-    - Meta: plugins/meta.md
-    - Offline: plugins/offline.md
-    - Optimize: plugins/optimize.md
-    - Privacy: plugins/privacy.md
-    - Projects: plugins/projects.md
-    - Search: plugins/search.md
-    - Social: plugins/social.md
-    - Tags: plugins/tags.md
-    - Typeset: plugins/typeset.md
-    - Requirements:
-      - Image processing: plugins/requirements/image-processing.md
-      - Caching: plugins/requirements/caching.md
+      - plugins/index.md
+      - Blog: plugins/blog.md
+      - Group: plugins/group.md
+      - Info: plugins/info.md
+      - Meta: plugins/meta.md
+      - Offline: plugins/offline.md
+      - Optimize: plugins/optimize.md
+      - Privacy: plugins/privacy.md
+      - Projects: plugins/projects.md
+      - Search: plugins/search.md
+      - Social: plugins/social.md
+      - Tags: plugins/tags.md
+      - Typeset: plugins/typeset.md
+      - Requirements:
+          - Image processing: plugins/requirements/image-processing.md
+          - Caching: plugins/requirements/caching.md
   - Reference:
-    - reference/index.md
-    - Admonitions: reference/admonitions.md
-    - Annotations: reference/annotations.md
-    - Buttons: reference/buttons.md
-    - Code blocks: reference/code-blocks.md
-    - Content tabs: reference/content-tabs.md
-    - Data tables: reference/data-tables.md
-    - Diagrams: reference/diagrams.md
-    - Footnotes: reference/footnotes.md
-    - Formatting: reference/formatting.md
-    - Grids: reference/grids.md
-    - Icons, Emojis: reference/icons-emojis.md
-    - Images: reference/images.md
-    - Lists: reference/lists.md
-    - Math: reference/math.md
-    - Tooltips: reference/tooltips.md
+      - reference/index.md
+      - Admonitions: reference/admonitions.md
+      - Annotations: reference/annotations.md
+      - Buttons: reference/buttons.md
+      - Code blocks: reference/code-blocks.md
+      - Content tabs: reference/content-tabs.md
+      - Data tables: reference/data-tables.md
+      - Diagrams: reference/diagrams.md
+      - Footnotes: reference/footnotes.md
+      - Formatting: reference/formatting.md
+      - Grids: reference/grids.md
+      - Icons, Emojis: reference/icons-emojis.md
+      - Images: reference/images.md
+      - Lists: reference/lists.md
+      - Math: reference/math.md
+      - Tooltips: reference/tooltips.md
   - Insiders:
-    - insiders/index.md
-    - Getting started:
-      - Installation: insiders/getting-started.md
-      - Changelog: insiders/changelog.md
+      - insiders/index.md
+      - Getting started:
+          - Installation: insiders/getting-started.md
+          - Changelog: insiders/changelog.md
   - Blog:
-    - blog/index.md
+      - blog/index.md


### PR DESCRIPTION
This might be controversial, so please bear with me.

YAML indentation rules are:

- 2 spaces per level
- optionally, arrays can have extra 2 space indentation

According to these rules, however you take the second one, this is wrong

``` yaml
nav:
  - Home: index.md
  - Getting started:
    - Installation: getting-started.md
    - Creating your site: creating-your-site.md
```

and should be either (`yaml.org`  website style)

``` yaml
nav:
- Home: index.md
- Getting started:
  - Installation: getting-started.md
  - Creating your site: creating-your-site.md
```

or

``` yaml
nav:
  - Home: index.md
  - Getting started:
      - Installation: getting-started.md
      - Creating your site: creating-your-site.md
```

I have to admit that it did throw me off at first, but it started to make sense soon afterward: namely, the dashes are always vertically four spaces separated from each other. (For the top-level keys, one could imagine dash being at character position -2 with space at character position -1.)

I like the second option more so I prepared the pull request accordingly. The configuration in the pull request could be adjusted to enforce the first option instead.

Anyhow, if you would agree that this style should be followed, this pull request updates `mkdocs.yml` to pass the linter checking and adds `yamllint` syntax checking during documentation deployment. The config for `yamllint` uses the default ruleset except for long lines, where a warning is issued instead of an error.