### PR TITLE
Fix a broken link in the documentation

### DIFF
--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -85,7 +85,7 @@ the defaults, or use:
 ### Choosing a font
 
 Some fonts do not contain CJK characters, like for example the
-[default font, `Roboto`][roboto]. In case your `site_name`, `site_description`, or
+[default font, `Roboto`][font]. In case your `site_name`, `site_description`, or
 page title contain CJK characters, choose another font from [Google Fonts] which
 comes with CJK characters, e.g. one from the `Noto Sans` font family:
 
@@ -125,7 +125,7 @@ comes with CJK characters, e.g. one from the `Noto Sans` font family:
             font_family: Noto Sans KR
     ```
 
-  [roboto]: https://fonts.google.com/specimen/Roboto
+  [font]: changing-the-fonts.md#regular-font
 
 ### Changing the layout
 

--- a/docs/setup/setting-up-social-cards.md
+++ b/docs/setup/setting-up-social-cards.md
@@ -85,7 +85,7 @@ the defaults, or use:
 ### Choosing a font
 
 Some fonts do not contain CJK characters, like for example the
-[default font, `Roboto`][font]. In case your `site_name`, `site_description`, or
+[default font, `Roboto`][roboto]. In case your `site_name`, `site_description`, or
 page title contain CJK characters, choose another font from [Google Fonts] which
 comes with CJK characters, e.g. one from the `Noto Sans` font family:
 
@@ -124,6 +124,8 @@ comes with CJK characters, e.g. one from the `Noto Sans` font family:
           cards_layout_options:
             font_family: Noto Sans KR
     ```
+
+  [roboto]: https://fonts.google.com/specimen/Roboto
 
 ### Changing the layout
 


### PR DESCRIPTION
Fixes this link:

> ![image](https://github.com/squidfunk/mkdocs-material/assets/7273074/131eff9c-7a54-4021-8927-b4d9581052a3)

I'm not sure what the originally intended link target is, so I replaced it with one that I find suitable.