### PR TITLE
 Not clear how to disable navigation.instant for local pages #6105 

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -225,3 +225,10 @@ or your private web space.
 
   [GitHub Pages]: publishing-your-site.md#github-pages
   [GitLab pages]: publishing-your-site.md#gitlab-pages
+
+If you intend to distribute your documentation as a set of files to be
+read from a local filesystem rather than a web server (such as in a
+`.zip` file), please read the notes about [building for offline
+usage].
+
+  [building for offline usage]: setup/building-for-offline-usage.md


### PR DESCRIPTION
I have added a note about building for offline usage and a link to the building for offline usage page. 

That page could, in turn, do with an addition to show how the group plugin can be used to turn off functionality that will not work offline. I suggest developing this as an example. Happy to do it if you agree this is the right approach.