### PR TITLE
fix: Additional dependencies for development #6085 

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -242,7 +242,7 @@ directly in the source of the theme and recompile it.
 First, clone the repository for the edition you want to work on. Note
 that you need to be a member of [Insiders] to access its repository.
 
-  [Insiders]: insiders.md
+  [Insiders]: insiders/index.md
 
 === "Material for MkDocs"
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -258,9 +258,15 @@ sponsor first to gain access.
     Insiders documentation] and make it available in the `$GH_TOKEN` 
     variable. 
 
+    ``` sh
+    git clone https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git # (1)!
     ```
-    git clone https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
-    ```
+
+    1. If you are using SSH keys for authenticating with GitHub, you can
+       clone Insiders with this command:
+       ```
+       git clone git@github.com:squidfunk/mkdocs-material-insiders.git
+       ```
 
     [as described in the Insiders documentation]: insiders/getting-started.md#requirements
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -239,8 +239,9 @@ directly in the source of the theme and recompile it.
 
 ### Environment setup
 
-First, clone the repository for the edition you want to work on. Note
-that you need to be a member of [Insiders] to access its repository.
+First, clone the repository for the edition you want to work on. If
+you want to clone the Insiders repository, you need to become a
+sponsor first to gain access.
 
   [Insiders]: insiders/index.md
 
@@ -251,7 +252,7 @@ that you need to be a member of [Insiders] to access its repository.
     cd mkdocs-material
     ```
 
-=== "Insiders (with token)"
+=== "Insiders"
 
     You will need to have a GitHub access token [as described in the
     Insiders documentation] and make it available in the `$GH_TOKEN` 
@@ -263,15 +264,6 @@ that you need to be a member of [Insiders] to access its repository.
 
     [as described in the Insiders documentation]: insiders/getting-started.md#requirements
 
-=== "Insiders (with SSH key)"
-
-    If you are using SSH keys for authenticating with GitHub, you can
-    clone Insiders with this command:
-
-    ```
-    git clone git@github.com:squidfunk/mkdocs-material-insiders.git
-    ```
-
 Next, create a new [Python virtual environment][venv] and
 [activate][venv-activate] it:
 
@@ -280,7 +272,7 @@ python -m venv venv
 source venv/bin/activate
 ```
 
-!!! note "Get pip to refuse working outside a `venv`"
+!!! note "Ensure pip always runs in a virtual environment"
 
     If you set the environment variable `PIP_REQUIRE_VIRTUALENV` to
     `true`, `pip` will refuse to install anything outside a virtual

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -239,12 +239,38 @@ directly in the source of the theme and recompile it.
 
 ### Environment setup
 
-First, clone the repository:
+First, clone the repository for the edition you want to work on. Note
+that you need to be a member of [Insiders] to access its repository.
 
-```
-git clone https://github.com/squidfunk/mkdocs-material
-cd mkdocs-material
-```
+  [Insiders]: insiders.md
+
+=== "Material for MkDocs"
+
+    ```
+    git clone https://github.com/squidfunk/mkdocs-material
+    cd mkdocs-material
+    ```
+
+=== "Insiders (with token)"
+
+    You will need to have a GitHub access token [as described in the
+    Insiders documentation] and make it available in the `$GH_TOKEN` 
+    variable. 
+
+    ```
+    git clone https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+    ```
+
+    [as described in the Insiders documentation]: insiders/getting-started.md#requirements
+
+=== "Insiders (with SSH key)"
+
+    If you are using SSH keys for authenticating with GitHub, you can
+    clone Insiders with this command:
+
+    ```
+    git clone git@github.com:squidfunk/mkdocs-material-insiders.git
+    ```
 
 Next, create a new [Python virtual environment][venv] and
 [activate][venv-activate] it:
@@ -254,17 +280,46 @@ python -m venv venv
 source venv/bin/activate
 ```
 
+!!! note "Get pip to refuse working outside a `venv`"
+
+    If you set the environment variable `PIP_REQUIRE_VIRTUALENV` to
+    `true`, `pip` will refuse to install anything outside a virtual
+    environment. Forgetting to activate a `venv` can be very annoying
+    as it will install all sorts of things outside virtual
+    environments over time, possibly leading to further errors. So, 
+    you may want to add this to your `.bashrc` or `.zshrc` and
+    re-start your shell:
+
+    ```
+    export PIP_REQUIRE_VIRTUALENV=true
+    ```
+
   [venv]: https://docs.python.org/3/library/venv.html
   [venv-activate]: https://docs.python.org/3/library/venv.html#how-venvs-work
 
 Then, install all Python dependencies:
 
-```
-pip install -e .
-pip install mkdocs-minify-plugin
-pip install mkdocs-redirects
-pip install nodeenv
-```
+=== "Material for MkDocs"
+
+    ```
+    pip install -e .
+    pip install "mkdocs-material[recommended]"
+    pip install nodeenv
+    ```
+
+=== "Insiders"
+
+    ```
+    pip install -e .
+    pip install "mkdocs-material[recommended, imaging]"
+    pip install nodeenv
+    ```
+
+    In addition, you will need to install the `cairo` and `pngquant` libraries in your
+    system, as described in the [image processing] requirements guide.
+
+    [image processing]: plugins/requirements/image-processing.md
+
 
 Finally, install the [Node.js] LTS version into the Python virtual environment
 and install all Node.js dependencies:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -262,11 +262,12 @@ sponsor first to gain access.
     git clone https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git # (1)!
     ```
 
-    1. If you are using SSH keys for authenticating with GitHub, you can
-       clone Insiders with this command:
-       ```
-       git clone git@github.com:squidfunk/mkdocs-material-insiders.git
-       ```
+    1.  If you are using SSH keys for authenticating with GitHub, you can
+        clone Insiders with this command:
+
+        ```
+        git clone git@github.com:squidfunk/mkdocs-material-insiders.git
+        ```
 
     [as described in the Insiders documentation]: insiders/getting-started.md#requirements
 


### PR DESCRIPTION
I added instructions for working on Insiders and also changed the instructions for installing optional dependencies to use the definitions in `pyproject.toml`. 

As I keep forgetting to activate a `venv` and end up installing things globally, I added a note about getting `pip` to refuse installing things outside a `venv`. Seems I am not the only person who keeps making that mistake, so I thought it would be useful for people here as many of our customers will not be hard-core Pythonistas.

Hope this fits the bill. I got stuck on this a little bit because I looked for ways to make things run on Windows but that is a battle we can fight another day, perhaps when we find someone who is native in that environment.