### PR TITLE
Fix wrong documentation link to Built-in projects plugin

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -95,7 +95,7 @@ minimal reproductions for bug reports:
   [group]: group.md
   [info]: info.md
   [meta]: meta.md
-  [projects]: meta.md
+  [projects]: projects.md
 
 ### Optimization
 


### PR DESCRIPTION
See https://squidfunk.github.io/mkdocs-material/plugins/#management