### PR TITLE
Allow hiding page title using front matter

### DIFF
--- a/docs/setup/setting-up-the-header.md
+++ b/docs/setup/setting-up-the-header.md
@@ -25,6 +25,26 @@ theme:
     - header.autohide
 ```
 
+### Hiding the page title
+
+<!-- md:version 9.4.4 -->
+<!-- md:flag metadata -->
+
+In documents missing a `<h1>` at the top of the page, Material for MkDocs
+automatically inserts a title. If you want to provide your own hero graphic or
+main heading (like for a landing page), it can be useful to hide the page title,
+as it consumes quite a bit of vertical space. 
+
+A document's title can be hidden with the front matter `hide` property. Add the
+following lines at the top of a Markdown file:
+
+```yaml
+---
+hide:
+  - title
+---
+```
+
 ### Announcement bar
 
 <!-- md:version 5.0.0 -->

--- a/src/templates/partials/content.html
+++ b/src/templates/partials/content.html
@@ -31,8 +31,10 @@
 <!--
   Hack: check whether the content contains a h1 headline. If it doesn't, the
   page title (or respectively site name) is used as the main headline.
+  Optionally skip this behaviour if the hide meta contains 'title'.
 -->
-{% if "\x3ch1" not in page.content %}
+{% if "\x3ch1" not in page.content and
+      "title" not in page.meta.hide %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}
 


### PR DESCRIPTION
For special documents like landing pages, it can be necessary to hide the first `<h1>`. Unfortunately, this can currently only be done by overriding partials/content.html, which I'd rather not carry a copy of in my documentation.

I think `material/templates/partials/content.html` needs to be regenerated, but I couldn't immediately find how to do that.