### PR TITLE
Escape snippet syntax in code block example

### DIFF
--- a/docs/reference/code-blocks.md
+++ b/docs/reference/code-blocks.md
@@ -460,7 +460,7 @@ from within a code block:
 
 ```` markdown title="Code block with external content"
 ``` title=".browserslistrc"
---8<-- ".browserslistrc"
+;--8<-- ".browserslistrc"
 ```
 ````
 


### PR DESCRIPTION
I've fixed the [code block example in the docs which demonstrates how to embed external files through the snippet syntax](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files). The snippet syntax was not [escaped](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#escaping-snippets-notation), so the plugin actually embedded the content of the referenced file.