### PR TITLE
Install extras from local package for development environment setup

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -301,16 +301,14 @@ Then, install all Python dependencies:
 === "Material for MkDocs"
 
     ```
-    pip install -e .
-    pip install "mkdocs-material[recommended]"
+    pip install -e ".[recommended]"
     pip install nodeenv
     ```
 
 === "Insiders"
 
     ```
-    pip install -e .
-    pip install "mkdocs-material[recommended, imaging]"
+    pip install -e ".[recommended, imaging]"
     pip install nodeenv
     ```
 


### PR DESCRIPTION
I've fixed a documentation error in the [development environment setup](https://squidfunk.github.io/mkdocs-material/customization/#environment-setup) instructions about installing Python package extras. Before, the extras were installed from the latest _release_ which may lead to a broken development installation if the latest _development version_ had changed the extras in some way. Now, the extras shall be installed also from the latest development version.