### PR TITLE
ci(docker): distribute build across runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,10 +119,62 @@ jobs:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: twine upload --disable-progress-bar -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} dist/*
 
-  docker:
+  docker-test:
     runs-on: ubuntu-latest
+    env:
+      BUILD_TAG: mkdocs-material:test
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/bake-action@v4
+        with:
+          targets: image-local
+        env:
+          DEFAULT_TAG: ${{ env.BUILD_TAG }}
+
+      - name: Check Docker image
+        working-directory: /tmp
+        env:
+          REPO_FULL_NAME: '${{ github.event.repository.full_name }}'
+        run: |
+          docker run --rm -i -v ${PWD}:/docs ${{ env.BUILD_TAG }} new .
+          docker run --rm -i -v ${PWD}:/docs ${{ env.BUILD_TAG }} build
+
+  docker-build-prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create matrix
+        id: platforms
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
+          else
+            echo 'matrix=["linux/amd64"]' >>${GITHUB_OUTPUT}
+          fi
+
+      - name: Show matrix
+        run: |
+          echo ${{ steps.platforms.outputs.matrix }}
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs:
+      - docker-build-prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.docker-build-prepare.outputs.matrix) }}
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -163,43 +215,89 @@ jobs:
           flavor: |
             latest=${{ github.event.release.prerelease == false }}
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
+      - name: Rename meta bake definition file
+        run: |
+          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
+
+      - name: Upload meta bake definition
+        uses: actions/upload-artifact@v3
         with:
-          context: .
-          load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          name: bake-meta
+          path: /tmp/bake-meta.json
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Check Docker image
-        working-directory: /tmp
-        env:
-          REPO_FULL_NAME: '${{ github.event.repository.full_name }}'
-        run: |
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} new .
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} build
-
-      - name: Set platforms
-        if: github.event_name == 'release'
-        run: |
-          echo "PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_ENV
-
-      - name: Publish Docker image
-        uses: docker/build-push-action@v5
+      - name: Build
+        id: bake
+        uses: docker/bake-action@v4
         with:
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          push: ${{ github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          files: |
+            ./docker-bake.hcl
+            /tmp/bake-meta.json
+          targets: image
+          set: |
+            *.tags=
+            *.platform=${{ matrix.platform }}
+            *.output=type=image,"name=${{ github.event.repository.full_name }},ghcr.io/${{ github.event.repository.full_name }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'release' }}
 
-      - name: Check manifest
-        if: github.event_name == 'release'
+      - name: Export digest
         run: |
-          docker buildx imagetools inspect ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}
+          mkdir -p /tmp/digests
+          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Inspect image
-        if: github.event_name == 'release'
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs:
+      - docker-build
+    steps:
+      - name: Download meta bake definition
+        uses: actions/download-artifact@v3
+        with:
+          name: bake-meta
+          path: /tmp
+
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
         run: |
-          docker pull ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}
-          docker image inspect ${{ github.event.repository.full_name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ github.event.repository.full_name }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
+            $(printf '${{ github.event.repository.full_name }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ github.event.repository.full_name }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
+            $(printf 'ghcr.io/${{ github.event.repository.full_name }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)
+          docker buildx imagetools inspect ${{ github.event.repository.full_name }}:${tag}
+          docker buildx imagetools inspect ghcr.io/${{ github.event.repository.full_name }}:${tag}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,31 @@
+variable "DEFAULT_TAG" {
+  default = "mkdocs-material:local"
+}
+
+// Special target: https://github.com/docker/metadata-action#bake-definition
+target "docker-metadata-action" {
+  tags = ["${DEFAULT_TAG}"]
+}
+
+// Default target if none specified
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v7",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
follow-up https://github.com/squidfunk/mkdocs-material/pull/5102#issuecomment-1445416401

Made some changes in the workflow so build for each platform is distributed across runners per docs: https://docs.docker.com/build/ci/github-actions/multi-platform/#with-bake