### PR TITLE
+doc: mention icon on custom page status and example

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -130,10 +130,17 @@ status: new
 ...
 ```
 
-The following status identifiers are currently supported:
+The following status identifiers are already defined:
 
 - :material-alert-decagram: – `new`
 - :material-trash-can: – `deprecated`
+
+You can define a custom page status this way but if you want it to
+have an icon other than the default one you need to also configure
+that in your `extra.css`. We have an [example for a custom
+page status] to get you started.
+
+[example for a custom page status]: https://mkdocs-material.github.io/examples/page-status/
 
 ### Setting the page `subtitle`
 


### PR DESCRIPTION
Based on https://github.com/squidfunk/mkdocs-material/discussions/6208, I added a note that a custom tag that needs an icon will need customization in `extra.css` and provided a link to the example in the text. I was not sure what you meant by "dumbing down the example" - it is already minimal, no?

While we are at it, the README pages for examples probably should have the download links just as they appear in the documentation, right?