### PR TITLE
Specify container image in GitLab CI job instead of globally

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -152,9 +152,9 @@ contents:
 === "Material for MkDocs"
 
     ``` yaml
-    image: python:latest
     pages:
       stage: deploy
+      image: python:latest
       script:
         - pip install mkdocs-material
         - mkdocs build --site-dir public
@@ -168,9 +168,9 @@ contents:
 === "Insiders"
 
     ``` yaml
-    image: python:latest
     pages:
       stage: deploy
+      image: python:latest
       script: # (1)!
         - pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
         - mkdocs build --site-dir public


### PR DESCRIPTION
I've moved the `image` setting for GitLab CI from the global level down to the `pages` CI job specification in the docs on publishing a site via GitLab Pages. I think this is a better example as the `python:latest` image might only apply to the `pages` job. Specifying it locally is definitely correct whereas specifying it globally _may_ be correct, but we cannot know as it depends on the rest of the CI config.