### PR TITLE
fixed typo: "hosting" -> "hoisting"

### DIFF
--- a/docs/schema/plugins/projects.json
+++ b/docs/schema/plugins/projects.json
@@ -66,7 +66,7 @@
                 }
               ]
             },
-            "hosting": {
+            "hoisting": {
               "title": "Enable hoisting",
               "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/projects/#config.hoisting",
               "type": "boolean",


### PR DESCRIPTION
2nd attempt at producing a clean PR for a single character change

"hoisting" was mis-spelled "hosting" in `docs/schema/plugins/projects.json`