### PR TITLE
added short description + links to MkDocs docu

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -145,10 +145,10 @@ mkdocs gh-deploy --force
 This will build your documentation and deploy it to a branch
 `gh-pages` in your repository. See [this overview in the MkDocs
 documentation] for more information. For a description of the
-arguments, see [this section in the MkDocs documentation].
+arguments, see [the documentation for the command].
 
   [this overview in the MkDocs documentation]: https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages
-  [this section in the MkDocs documentation]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
+  [the documentation for the command]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
 
 ## GitLab Pages
 

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -142,6 +142,14 @@ the following command from the directory containing the `mkdocs.yml` file:
 mkdocs gh-deploy --force
 ```
 
+This will build your documentation and deploy it to a branch
+`gh-pages` in your repository. See [this overview in the MkDocs
+documentation] for more information. For a description of the
+arguments, see [this section in the MkDocs documentation].
+
+  [this overview in the MkDocs documentation]: https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages
+  [this section in the MkDocs documentation]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
+
 ## GitLab Pages
 
 If you're hosting your code on GitLab, deploying to [GitLab Pages] can be done


### PR DESCRIPTION
I thought the description of how to deploy from your local machine to GH Pages was a bit brief.