### PR TITLE
git-committers 2.0: add token documentation

### DIFF
--- a/docs/setup/adding-a-git-repository.md
+++ b/docs/setup/adding-a-git-repository.md
@@ -274,6 +274,7 @@ plugins:
   - git-committers:
       repository: squidfunk/mkdocs-material
       branch: main
+      token: !ENV GH_TOKEN
 ```
 
 The following configuration options are supported:
@@ -311,6 +312,18 @@ The following configuration options are supported:
     plugins:
       - git-committers:
           branch: main
+    ```
+
+<!-- md:option git-committers.token -->
+
+:   <!-- md:default none --> <!-- md:flag required -->
+    This property must be set with a GitHub Personal Access Token, so that the plugin can execute
+    GraphQL API calls to retrieve contributors:
+
+    ``` yaml
+    plugins:
+      - git-committers:
+          token: !ENV GH_TOKEN
     ```
 
 The other configuration options of this extension are not officially supported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ recommended = [
   "mkdocs-rss-plugin~=1.6"
 ]
 git = [
-  "mkdocs-git-committers-plugin-2~=1.1",
+  "mkdocs-git-committers-plugin-2~=2.0",
   "mkdocs-git-revision-date-localized-plugin~=1.2"
 ]
 imaging = [


### PR DESCRIPTION
As we are getting closer to having git-committers be included in mkdocs-material (yeah!), I took some time to update [mkdocs-git-committers-plugin-2 plugin](https://github.com/ojacques/mkdocs-git-committers-plugin-2) so that it:

- Does not use an undocumented GitHub endpoint to fetch contributors, but GitHub's GraphQL V4 API
- Support private repositories
- Does not use BeautifulSoup nor lxml: only `requests`, and `gitpython` as prerequisites (no change on those prerequisites)

As a consequence, a GitHub token is needed.

This PR:

- Updates the documentation for the `token` configuration item
- Update `pyproject.toml` to point to 2.0 release

I hope I am not missing something. Otherwise, let me know.