### PR TITLE
Make extra.version.default match against the version string

### DIFF
--- a/src/templates/assets/javascripts/integrations/version/index.ts
+++ b/src/templates/assets/javascripts/integrations/version/index.ts
@@ -168,8 +168,8 @@ export function setupVersionSelector(
 
         /* Check if version is considered a default */
         main: for (const ignore of ignored)
-          for (const alias of current.aliases)
-            if (new RegExp(ignore, "i").test(alias)) {
+          for (const version of current.aliases.concat(current.version))
+            if (new RegExp(ignore, "i").test(version)) {
               outdated = false
               break main
             }


### PR DESCRIPTION
Currently, the `extra.version.default` configuration option only matches against aliases and not the actual version string.

This can be cumbersome in the following scenario:

```yaml
extra:
  version:
    provider: mike
    default:
      - nightly
      - stable
```

In this case, `nightly` is used as a version string, while `stable` is an alias pointing to an actual version number. The goal is to suppress the outdated message header for both of them. If `extra.version.default` matches both the version string and aliases, I can simply deploy with:

```bash
mike deploy nightly
mike deploy --update-aliases 0.1 stable
```

Without this fix, a workaround is required, such as using `mike deploy nightly continuously`.