### PR TITLE
Google Fonts Privacy FAQ: updated URL

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -145,10 +145,10 @@ mkdocs gh-deploy --force
 This will build your documentation and deploy it to a branch
 `gh-pages` in your repository. See [this overview in the MkDocs
 documentation] for more information. For a description of the
-arguments, see [this section in the MkDocs documentation].
+arguments, see [the documentation for the command].
 
   [this overview in the MkDocs documentation]: https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages
-  [this section in the MkDocs documentation]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
+  [the documentation for the command]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
 
 ## GitLab Pages
 

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -142,6 +142,14 @@ the following command from the directory containing the `mkdocs.yml` file:
 mkdocs gh-deploy --force
 ```
 
+This will build your documentation and deploy it to a branch
+`gh-pages` in your repository. See [this overview in the MkDocs
+documentation] for more information. For a description of the
+arguments, see [this section in the MkDocs documentation].
+
+  [this overview in the MkDocs documentation]: https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages
+  [this section in the MkDocs documentation]: https://www.mkdocs.org/user-guide/cli/#mkdocs-gh-deploy
+
 ## GitLab Pages
 
 If you're hosting your code on GitLab, deploying to [GitLab Pages] can be done

--- a/docs/setup/changing-the-fonts.md
+++ b/docs/setup/changing-the-fonts.md
@@ -67,7 +67,7 @@ theme:
     while complying with the __General Data Protection Regulation__ (GDPR),
     by automatically downloading and self-hosting the web font files.
 
-  [data privacy]: https://developers.google.com/fonts/faq#what_does_using_the_google_fonts_api_mean_for_the_privacy_of_my_users
+  [data privacy]: https://developers.google.com/fonts/faq/privacy
   [built-in privacy plugin]:../plugins/privacy.md
 
 ## Customization


### PR DESCRIPTION
The previous link to the Google Fonts privacy FAQ was broken as they moved the content into its own section. I assume this is still the thing to point at?