### PR TITLE
Add `type` property to `theme:font` schema to support `font: false`

### DIFF
--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -885,6 +885,7 @@
         {
           "title": "Google Fonts",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/changing-the-fonts/",
+          "type": "object",
           "properties": {
             "text": {
               "$ref": "assets/fonts.json"


### PR DESCRIPTION
I've fixed the JSON schema for `mkdocs.yml` to pass validation for:

```yaml
theme:
  font: false
```

Before, VS Code was showing the following error after [configuring the schema URL](https://squidfunk.github.io/mkdocs-material/creating-your-site/#minimal-configuration-visual-studio-code):

```
Matches multiple schemas when only one must validate.yaml-schema: Theme configuration
```

The problem was caused by the fact that a schema

```jsonc
{
  "properties": {
    // ...
  }
}
```

with no required properties and no `type` specification validates

```json
true
```

successfully, so both `oneOf` subschemas matched `false` while `oneOf` requires exactly one matching subschema. Adding `"type": "object"` to the first subschema prevents `false` from matching it. Besides it's more explicit, which I consider to be better.