### PR TITLE
Getting request total off of Content-Length header rather than event to bypass chrome bug

### DIFF
--- a/src/templates/assets/javascripts/browser/request/index.ts
+++ b/src/templates/assets/javascripts/browser/request/index.ts
@@ -85,7 +85,12 @@ export function request(
     // Handle download progress
     if (typeof options?.progress$ !== "undefined") {
       req.addEventListener("progress", event => {
-        options.progress$!.next((event.loaded / event.total) * 100)
+        if(event.lengthComputable){
+          options.progress$!.next((event.loaded / event.total) * 100)
+        } else { // https://bugs.chromium.org/p/chromium/issues/detail?id=463622
+          const totalFromHeader = Number(req.getResponseHeader("Content-Length")) ?? 0
+          options.progress$!.next((event.loaded / totalFromHeader) * 100)
+        }
       })
 
       // Immediately set progress to 5% to indicate that we're loading

--- a/src/templates/assets/javascripts/browser/request/index.ts
+++ b/src/templates/assets/javascripts/browser/request/index.ts
@@ -85,10 +85,10 @@ export function request(
     // Handle download progress
     if (typeof options?.progress$ !== "undefined") {
       req.addEventListener("progress", event => {
-        if(event.lengthComputable){
+        if (event.lengthComputable) {
           options.progress$!.next((event.loaded / event.total) * 100)
         } else { // https://bugs.chromium.org/p/chromium/issues/detail?id=463622
-          const totalFromHeader = Number(req.getResponseHeader("Content-Length")) ?? 0
+          const totalFromHeader = Number(req.getResponseHeader("Content-Length")) || 0
           options.progress$!.next((event.loaded / totalFromHeader) * 100)
         }
       })


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=463622