### PR TITLE
Adding github-actions user/email for commits generated by mkdocs

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -35,6 +35,10 @@ contents:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
+          - name: Configure Git Credentials
+            run: |
+              git config user.name github-actions[bot]
+              git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x
@@ -90,6 +94,10 @@ contents:
         if: github.event.repository.fork == false
         steps:
           - uses: actions/checkout@v4
+          - name: Configure Git Credentials
+            run: |
+              git config user.name github-actions[bot]
+              git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           - uses: actions/setup-python@v4
             with:
               python-version: 3.x


### PR DESCRIPTION
This PR fixes each commit author from being marked `Unknown` to `github-actions[bot]`.

Originally, without setting git credentials, you have this result:
![image](https://github.com/squidfunk/mkdocs-material/assets/48845764/56bd85e5-e2e9-4698-8695-c1ca92852032)

By setting the git credentials to `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
![image](https://github.com/squidfunk/mkdocs-material/assets/48845764/22327c6a-19ca-4e4e-b899-e8194cfb2e1c)

Related issues and PR's:
- actions/checkout#13
- actions/checkout#1184

Some of the PR's mention setting git to just `github-actions <github-actions@github.com>`, but there is no actual account associated