### PR TITLE
Add custom tag `!relative` to VS Code settings docs

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -66,6 +66,7 @@ theme:
               "yaml.customTags": [ // (1)!
                 "!ENV scalar",
                 "!ENV sequence",
+                "!relative scalar",
                 "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg",
                 "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
                 "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"


### PR DESCRIPTION
I've added the custom tag [`!relative`](https://www.mkdocs.org/user-guide/configuration/#paths-relative-to-the-current-file-or-site) to the [VS Code settings docs](https://squidfunk.github.io/mkdocs-material/creating-your-site/#minimal-configuration-visual-studio-code).