### PR TITLE
added md-ellipsis span to toc-item.html

### DIFF
--- a/material/templates/partials/toc-item.html
+++ b/material/templates/partials/toc-item.html
@@ -3,7 +3,9 @@
 -#}
 <li class="md-nav__item">
   <a href="{{ toc_item.url }}" class="md-nav__link">
-    {{ toc_item.title }}
+    <span class="md-ellipsis">
+      {{ toc_item.title }}
+    </span>
   </a>
   {% if toc_item.children %}
     <nav class="md-nav" aria-label="{{ toc_item.title | striptags }}">

--- a/src/templates/partials/toc-item.html
+++ b/src/templates/partials/toc-item.html
@@ -23,7 +23,9 @@
 <!-- Table of contents item -->
 <li class="md-nav__item">
   <a href="{{ toc_item.url }}" class="md-nav__link">
-    {{ toc_item.title }}
+    <span class="md-ellipsis">
+      {{ toc_item.title }}
+    </span>
   </a>
 
   <!-- Table of contents list -->


### PR DESCRIPTION
This should fix https://github.com/squidfunk/mkdocs-material/issues/6344.

In the public version, long TOC items were not wrapped in `.md-ellipsis` and so just cut off. Seemed an unintended divergence between the two versions to me.