### PR TITLE
Fixed `extra:analytics` schema for custom providers

### DIFF
--- a/docs/schema/extra.json
+++ b/docs/schema/extra.json
@@ -41,11 +41,6 @@
                     "pattern": "^G-\\w{10}$"
                   },
                   {
-                    "title": "Universal Analytics",
-                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-                    "pattern": "^UA-\\w{9}-\\w$"
-                  },
-                  {
                     "title": "Unknown property",
                     "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
                     "type": "string"
@@ -448,7 +443,7 @@
       "body": {
         "analytics": {
           "provider": "${1:google}",
-          "property": "${2:UA-XXXXXXXX-X}"
+          "property": "${2:G-XXXXXXXXXX}"
         }
       }
     }

--- a/docs/schema/extra.json
+++ b/docs/schema/extra.json
@@ -13,99 +13,80 @@
       "title": "Analytics provider",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
       "type": "object",
-      "properties": {
-        "provider": {
-          "title": "Analytics provider",
-          "anyOf": [
-            {
-              "title": "Google Analytics",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-              "enum": [
-                "google"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "property": {
-          "anyOf": [
-            {
-              "title": "Google Analytics 4",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-              "pattern": "^G-\\w{10}$"
-            },
-            {
-              "title": "Universal Analytics",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-              "pattern": "^UA-\\w{9}-\\w$"
-            },
-            {
-              "title": "Unknown property",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-              "type": "string"
-            }
-          ]
-        },
-        "feedback": {
-          "title": "Was this page helpful?",
-          "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
-          "type": "object",
-          "properties": {
-            "title": {
-              "title": "Feedback widget title",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
-              "type": "string",
-              "default": "Was this page helpful?"
-            },
-            "ratings": {
-              "title": "Feedback ratings",
-              "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
-              "type": "array",
-              "items": {
-                "title": "Feedback rating",
-                "type": "object",
-                "properties": {
-                  "icon": {
-                    "$ref": "#/$defs/icon"
-                  },
-                  "name": {
-                    "title": "Feedback rating name",
-                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.name",
-                    "type": "string"
-                  },
-                  "data": {
-                    "title": "Feedback rating data",
-                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.data",
-                    "type": "number"
-                  },
-                  "note": {
-                    "title": "Feedback rating data",
-                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.note",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "icon",
-                  "name",
-                  "data",
-                  "note"
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "google"
                 ]
               }
             }
           },
-          "additionalProperties": false,
-          "required": [
-            "title"
-          ]
+          "then": {
+            "properties": {
+              "provider": {
+                "title": "Google Analytics",
+                "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
+                "enum": [
+                  "google"
+                ]
+              },
+              "property": {
+                "anyOf": [
+                  {
+                    "title": "Google Analytics 4",
+                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
+                    "pattern": "^G-\\w{10}$"
+                  },
+                  {
+                    "title": "Universal Analytics",
+                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
+                    "pattern": "^UA-\\w{9}-\\w$"
+                  },
+                  {
+                    "title": "Unknown property",
+                    "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
+                    "type": "string"
+                  }
+                ]
+              },
+              "feedback": {
+                "$ref": "#/$defs/feedback"
+              }
+            },
+            "required": [
+              "provider",
+              "property"
+            ],
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "type": "string"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "provider": {
+                "title": "Custom analytics provider",
+                "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#custom-site-analytics",
+                "type": "string"
+              },
+              "feedback": {
+                "$ref": "#/$defs/feedback"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          }
         }
-      },
-      "additionalProperties": false,
-      "required": [
-        "provider",
-        "property"
       ],
       "defaultSnippets": [
         {
@@ -405,6 +386,59 @@
           "title": "Unknown icon",
           "type": "string"
         }
+      ]
+    },
+    "feedback": {
+      "title": "Was this page helpful?",
+      "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
+      "type": "object",
+      "properties": {
+        "title": {
+          "title": "Feedback widget title",
+          "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
+          "type": "string",
+          "default": "Was this page helpful?"
+        },
+        "ratings": {
+          "title": "Feedback ratings",
+          "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful",
+          "type": "array",
+          "items": {
+            "title": "Feedback rating",
+            "type": "object",
+            "properties": {
+              "icon": {
+                "$ref": "#/$defs/icon"
+              },
+              "name": {
+                "title": "Feedback rating name",
+                "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.name",
+                "type": "string"
+              },
+              "data": {
+                "title": "Feedback rating data",
+                "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.data",
+                "type": "number"
+              },
+              "note": {
+                "title": "Feedback rating data",
+                "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#+analytics.feedback.ratings.note",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "icon",
+              "name",
+              "data",
+              "note"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "title"
       ]
     }
   },


### PR DESCRIPTION
I've fixed the JSON schema for specifying custom providers which don't use the `property` property like Google Analytics and/or have additional properties.

This is a set of test cases that show the current validation results in [VS Code](https://squidfunk.github.io/mkdocs-material/creating-your-site/#minimal-configuration-visual-studio-code):

```yaml
site_name: Docs with analytics

theme:
  name: material

extra:
  # expected: ✅ / actual ✅
  analytics:
    provider: google
    property: G-XXXXXXXXXX

  # expected: ✅ / actual ✅
  analytics:
    provider: google
    property: G-XXXXXXXXXX
    feedback:
      title: Was this page helpful?

  # expected: ❌ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: google
    property2: G-XXXXXXXXXX # 🚩 Property property2 is not allowed. yaml-schema: Analytics provider

  # expected: ❌ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: google
    property2: G-XXXXXXXXXX # 🚩 Property property2 is not allowed. yaml-schema: Analytics provider
    feedback:
      title: Was this page helpful?

  # expected: ✅ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: custom

  # expected: ✅ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: custom
    feedback:
      title: Was this page helpful?

  # expected: ✅ / actual: ✅
  analytics:
    provider: custom
    property: custom-property

  # expected: ✅ / actual: ✅
  analytics:
    provider: custom
    property: custom-property
    feedback:
      title: Was this page helpful?

  # expected: ✅ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: plausible
    domain: example.com # 🚩 Property domain is not allowed. yaml-schema: Analytics provider

  # expected: ✅ / actual: ❌
  analytics: # 🚩 Missing property "property". yaml-schema: Analytics provider
    provider: plausible
    domain: example.com # 🚩 Property domain is not allowed. yaml-schema: Analytics provider
    feedback:
      title: Was this page helpful?
```

With the changed schema in this PR, all test cases yield the expected results.

Before, the schema didn't couple `provider: google` with making `property` required, and as a side-effect, `property` was always defined using a schema specific to Google Analytics. Further, `additionalProperties: false` prevented any other custom properties that may be needed for some analytics solution.

Now, `provider: google`, `property` with the Google-specific schema, declaring both as required properties, and disallowing additional properties are all coupled. For any other `provider: <string>`, additional properties are allowed without defined schemas. The probably obvious approaches to express this with JSON Schema are to use

* `oneOf`, which doesn't work because the schema for `provider: <string>` is a superset of `provider: google`, so more than one schema matches, or
* `anyOf` as an attempt at fixing the problem with `oneOf`, but then the `provider: <string>` schema matches _always_ and the additional constraints from the `provider: google` schema don't apply.

The solution I've implemented uses a combination of `allOf` and [`if-then`](https://json-schema.org/understanding-json-schema/reference/conditionals#ifthenelse) (without `else`), such that any valid config of a defined provider (only Google Analytics at the moment) matches both the corresponding schema _and_ the `provider: <string>` schema, whereas a config of a custom provider matches _only_ the `provider: <string>` schema. Note that it's important to declare also the `feedback` property in each `allOf` schema of a specific provider because `additionalProperties: false` limits the set of valid properties only to those defined in the same schema and doesn't recognize the `feedback` property schema in the parent schema of `allOf`. But for clarity, I've also declared the `feedback` property in the `provider: <string>` schema, although it isn't necessary as the missing `additionalProperties` implies `true`, so `feedback` would be allowed anyway.

I hope the rationale of the solution, combined with the PR diff, is somewhat clear, although I'm not sure I was able to explain it so well.

WDYT, @squidfunk?