### PR TITLE
Replaced `enum` by `const` for constant value types in schemas

### DIFF
--- a/docs/schema/assets/fonts.json
+++ b/docs/schema/assets/fonts.json
@@ -7,11069 +7,7907 @@
     {
       "title": "ABeeZee",
       "markdownDescription": "https://fonts.google.com/specimen/ABeeZee",
-      "enum": [
-        "ABeeZee"
-      ]
+      "const": "ABeeZee"
     },
     {
       "title": "ADLaM Display",
       "markdownDescription": "https://fonts.google.com/specimen/ADLaM+Display",
-      "enum": [
-        "ADLaM Display"
-      ]
+      "const": "ADLaM Display"
     },
     {
       "title": "AR One Sans",
       "markdownDescription": "https://fonts.google.com/specimen/AR+One+Sans",
-      "enum": [
-        "AR One Sans"
-      ]
+      "const": "AR One Sans"
     },
     {
       "title": "Abel",
       "markdownDescription": "https://fonts.google.com/specimen/Abel",
-      "enum": [
-        "Abel"
-      ]
+      "const": "Abel"
     },
     {
       "title": "Abhaya Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Abhaya+Libre",
-      "enum": [
-        "Abhaya Libre"
-      ]
+      "const": "Abhaya Libre"
     },
     {
       "title": "Aboreto",
       "markdownDescription": "https://fonts.google.com/specimen/Aboreto",
-      "enum": [
-        "Aboreto"
-      ]
+      "const": "Aboreto"
     },
     {
       "title": "Abril Fatface",
       "markdownDescription": "https://fonts.google.com/specimen/Abril+Fatface",
-      "enum": [
-        "Abril Fatface"
-      ]
+      "const": "Abril Fatface"
     },
     {
       "title": "Abyssinica SIL",
       "markdownDescription": "https://fonts.google.com/specimen/Abyssinica+SIL",
-      "enum": [
-        "Abyssinica SIL"
-      ]
+      "const": "Abyssinica SIL"
     },
     {
       "title": "Aclonica",
       "markdownDescription": "https://fonts.google.com/specimen/Aclonica",
-      "enum": [
-        "Aclonica"
-      ]
+      "const": "Aclonica"
     },
     {
       "title": "Acme",
       "markdownDescription": "https://fonts.google.com/specimen/Acme",
-      "enum": [
-        "Acme"
-      ]
+      "const": "Acme"
     },
     {
       "title": "Actor",
       "markdownDescription": "https://fonts.google.com/specimen/Actor",
-      "enum": [
-        "Actor"
-      ]
+      "const": "Actor"
     },
     {
       "title": "Adamina",
       "markdownDescription": "https://fonts.google.com/specimen/Adamina",
-      "enum": [
-        "Adamina"
-      ]
+      "const": "Adamina"
     },
     {
       "title": "Advent Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Advent+Pro",
-      "enum": [
-        "Advent Pro"
-      ]
+      "const": "Advent Pro"
     },
     {
       "title": "Agdasima",
       "markdownDescription": "https://fonts.google.com/specimen/Agdasima",
-      "enum": [
-        "Agdasima"
-      ]
+      "const": "Agdasima"
     },
     {
       "title": "Aguafina Script",
       "markdownDescription": "https://fonts.google.com/specimen/Aguafina+Script",
-      "enum": [
-        "Aguafina Script"
-      ]
+      "const": "Aguafina Script"
     },
     {
       "title": "Akatab",
       "markdownDescription": "https://fonts.google.com/specimen/Akatab",
-      "enum": [
-        "Akatab"
-      ]
+      "const": "Akatab"
     },
     {
       "title": "Akaya Kanadaka",
       "markdownDescription": "https://fonts.google.com/specimen/Akaya+Kanadaka",
-      "enum": [
-        "Akaya Kanadaka"
-      ]
+      "const": "Akaya Kanadaka"
     },
     {
       "title": "Akaya Telivigala",
       "markdownDescription": "https://fonts.google.com/specimen/Akaya+Telivigala",
-      "enum": [
-        "Akaya Telivigala"
-      ]
+      "const": "Akaya Telivigala"
     },
     {
       "title": "Akronim",
       "markdownDescription": "https://fonts.google.com/specimen/Akronim",
-      "enum": [
-        "Akronim"
-      ]
+      "const": "Akronim"
     },
     {
       "title": "Akshar",
       "markdownDescription": "https://fonts.google.com/specimen/Akshar",
-      "enum": [
-        "Akshar"
-      ]
+      "const": "Akshar"
     },
     {
       "title": "Aladin",
       "markdownDescription": "https://fonts.google.com/specimen/Aladin",
-      "enum": [
-        "Aladin"
-      ]
+      "const": "Aladin"
     },
     {
       "title": "Alata",
       "markdownDescription": "https://fonts.google.com/specimen/Alata",
-      "enum": [
-        "Alata"
-      ]
+      "const": "Alata"
     },
     {
       "title": "Alatsi",
       "markdownDescription": "https://fonts.google.com/specimen/Alatsi",
-      "enum": [
-        "Alatsi"
-      ]
+      "const": "Alatsi"
     },
     {
       "title": "Albert Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Albert+Sans",
-      "enum": [
-        "Albert Sans"
-      ]
+      "const": "Albert Sans"
     },
     {
       "title": "Aldrich",
       "markdownDescription": "https://fonts.google.com/specimen/Aldrich",
-      "enum": [
-        "Aldrich"
-      ]
+      "const": "Aldrich"
     },
     {
       "title": "Alef",
       "markdownDescription": "https://fonts.google.com/specimen/Alef",
-      "enum": [
-        "Alef"
-      ]
+      "const": "Alef"
     },
     {
       "title": "Alegreya",
       "markdownDescription": "https://fonts.google.com/specimen/Alegreya",
-      "enum": [
-        "Alegreya"
-      ]
+      "const": "Alegreya"
     },
     {
       "title": "Alegreya SC",
       "markdownDescription": "https://fonts.google.com/specimen/Alegreya+SC",
-      "enum": [
-        "Alegreya SC"
-      ]
+      "const": "Alegreya SC"
     },
     {
       "title": "Alegreya Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Alegreya+Sans",
-      "enum": [
-        "Alegreya Sans"
-      ]
+      "const": "Alegreya Sans"
     },
     {
       "title": "Alegreya Sans SC",
       "markdownDescription": "https://fonts.google.com/specimen/Alegreya+Sans+SC",
-      "enum": [
-        "Alegreya Sans SC"
-      ]
+      "const": "Alegreya Sans SC"
     },
     {
       "title": "Aleo",
       "markdownDescription": "https://fonts.google.com/specimen/Aleo",
-      "enum": [
-        "Aleo"
-      ]
+      "const": "Aleo"
     },
     {
       "title": "Alex Brush",
       "markdownDescription": "https://fonts.google.com/specimen/Alex+Brush",
-      "enum": [
-        "Alex Brush"
-      ]
+      "const": "Alex Brush"
     },
     {
       "title": "Alexandria",
       "markdownDescription": "https://fonts.google.com/specimen/Alexandria",
-      "enum": [
-        "Alexandria"
-      ]
+      "const": "Alexandria"
     },
     {
       "title": "Alfa Slab One",
       "markdownDescription": "https://fonts.google.com/specimen/Alfa+Slab+One",
-      "enum": [
-        "Alfa Slab One"
-      ]
+      "const": "Alfa Slab One"
     },
     {
       "title": "Alice",
       "markdownDescription": "https://fonts.google.com/specimen/Alice",
-      "enum": [
-        "Alice"
-      ]
+      "const": "Alice"
     },
     {
       "title": "Alike",
       "markdownDescription": "https://fonts.google.com/specimen/Alike",
-      "enum": [
-        "Alike"
-      ]
+      "const": "Alike"
     },
     {
       "title": "Alike Angular",
       "markdownDescription": "https://fonts.google.com/specimen/Alike+Angular",
-      "enum": [
-        "Alike Angular"
-      ]
+      "const": "Alike Angular"
     },
     {
       "title": "Alkalami",
       "markdownDescription": "https://fonts.google.com/specimen/Alkalami",
-      "enum": [
-        "Alkalami"
-      ]
+      "const": "Alkalami"
     },
     {
       "title": "Alkatra",
       "markdownDescription": "https://fonts.google.com/specimen/Alkatra",
-      "enum": [
-        "Alkatra"
-      ]
+      "const": "Alkatra"
     },
     {
       "title": "Allan",
       "markdownDescription": "https://fonts.google.com/specimen/Allan",
-      "enum": [
-        "Allan"
-      ]
+      "const": "Allan"
     },
     {
       "title": "Allerta",
       "markdownDescription": "https://fonts.google.com/specimen/Allerta",
-      "enum": [
-        "Allerta"
-      ]
+      "const": "Allerta"
     },
     {
       "title": "Allerta Stencil",
       "markdownDescription": "https://fonts.google.com/specimen/Allerta+Stencil",
-      "enum": [
-        "Allerta Stencil"
-      ]
+      "const": "Allerta Stencil"
     },
     {
       "title": "Allison",
       "markdownDescription": "https://fonts.google.com/specimen/Allison",
-      "enum": [
-        "Allison"
-      ]
+      "const": "Allison"
     },
     {
       "title": "Allura",
       "markdownDescription": "https://fonts.google.com/specimen/Allura",
-      "enum": [
-        "Allura"
-      ]
+      "const": "Allura"
     },
     {
       "title": "Almarai",
       "markdownDescription": "https://fonts.google.com/specimen/Almarai",
-      "enum": [
-        "Almarai"
-      ]
+      "const": "Almarai"
     },
     {
       "title": "Almendra",
       "markdownDescription": "https://fonts.google.com/specimen/Almendra",
-      "enum": [
-        "Almendra"
-      ]
+      "const": "Almendra"
     },
     {
       "title": "Almendra Display",
       "markdownDescription": "https://fonts.google.com/specimen/Almendra+Display",
-      "enum": [
-        "Almendra Display"
-      ]
+      "const": "Almendra Display"
     },
     {
       "title": "Almendra SC",
       "markdownDescription": "https://fonts.google.com/specimen/Almendra+SC",
-      "enum": [
-        "Almendra SC"
-      ]
+      "const": "Almendra SC"
     },
     {
       "title": "Alumni Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Alumni+Sans",
-      "enum": [
-        "Alumni Sans"
-      ]
+      "const": "Alumni Sans"
     },
     {
       "title": "Alumni Sans Collegiate One",
       "markdownDescription": "https://fonts.google.com/specimen/Alumni+Sans+Collegiate+One",
-      "enum": [
-        "Alumni Sans Collegiate One"
-      ]
+      "const": "Alumni Sans Collegiate One"
     },
     {
       "title": "Alumni Sans Inline One",
       "markdownDescription": "https://fonts.google.com/specimen/Alumni+Sans+Inline+One",
-      "enum": [
-        "Alumni Sans Inline One"
-      ]
+      "const": "Alumni Sans Inline One"
     },
     {
       "title": "Alumni Sans Pinstripe",
       "markdownDescription": "https://fonts.google.com/specimen/Alumni+Sans+Pinstripe",
-      "enum": [
-        "Alumni Sans Pinstripe"
-      ]
+      "const": "Alumni Sans Pinstripe"
     },
     {
       "title": "Amarante",
       "markdownDescription": "https://fonts.google.com/specimen/Amarante",
-      "enum": [
-        "Amarante"
-      ]
+      "const": "Amarante"
     },
     {
       "title": "Amaranth",
       "markdownDescription": "https://fonts.google.com/specimen/Amaranth",
-      "enum": [
-        "Amaranth"
-      ]
+      "const": "Amaranth"
     },
     {
       "title": "Amatic SC",
       "markdownDescription": "https://fonts.google.com/specimen/Amatic+SC",
-      "enum": [
-        "Amatic SC"
-      ]
+      "const": "Amatic SC"
     },
     {
       "title": "Amethysta",
       "markdownDescription": "https://fonts.google.com/specimen/Amethysta",
-      "enum": [
-        "Amethysta"
-      ]
+      "const": "Amethysta"
     },
     {
       "title": "Amiko",
       "markdownDescription": "https://fonts.google.com/specimen/Amiko",
-      "enum": [
-        "Amiko"
-      ]
+      "const": "Amiko"
     },
     {
       "title": "Amiri",
       "markdownDescription": "https://fonts.google.com/specimen/Amiri",
-      "enum": [
-        "Amiri"
-      ]
+      "const": "Amiri"
     },
     {
       "title": "Amiri Quran",
       "markdownDescription": "https://fonts.google.com/specimen/Amiri+Quran",
-      "enum": [
-        "Amiri Quran"
-      ]
+      "const": "Amiri Quran"
     },
     {
       "title": "Amita",
       "markdownDescription": "https://fonts.google.com/specimen/Amita",
-      "enum": [
-        "Amita"
-      ]
+      "const": "Amita"
     },
     {
       "title": "Anaheim",
       "markdownDescription": "https://fonts.google.com/specimen/Anaheim",
-      "enum": [
-        "Anaheim"
-      ]
+      "const": "Anaheim"
     },
     {
       "title": "Andada Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Andada+Pro",
-      "enum": [
-        "Andada Pro"
-      ]
+      "const": "Andada Pro"
     },
     {
       "title": "Andika",
       "markdownDescription": "https://fonts.google.com/specimen/Andika",
-      "enum": [
-        "Andika"
-      ]
+      "const": "Andika"
     },
     {
       "title": "Anek Bangla",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Bangla",
-      "enum": [
-        "Anek Bangla"
-      ]
+      "const": "Anek Bangla"
     },
     {
       "title": "Anek Devanagari",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Devanagari",
-      "enum": [
-        "Anek Devanagari"
-      ]
+      "const": "Anek Devanagari"
     },
     {
       "title": "Anek Gujarati",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Gujarati",
-      "enum": [
-        "Anek Gujarati"
-      ]
+      "const": "Anek Gujarati"
     },
     {
       "title": "Anek Gurmukhi",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Gurmukhi",
-      "enum": [
-        "Anek Gurmukhi"
-      ]
+      "const": "Anek Gurmukhi"
     },
     {
       "title": "Anek Kannada",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Kannada",
-      "enum": [
-        "Anek Kannada"
-      ]
+      "const": "Anek Kannada"
     },
     {
       "title": "Anek Latin",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Latin",
-      "enum": [
-        "Anek Latin"
-      ]
+      "const": "Anek Latin"
     },
     {
       "title": "Anek Malayalam",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Malayalam",
-      "enum": [
-        "Anek Malayalam"
-      ]
+      "const": "Anek Malayalam"
     },
     {
       "title": "Anek Odia",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Odia",
-      "enum": [
-        "Anek Odia"
-      ]
+      "const": "Anek Odia"
     },
     {
       "title": "Anek Tamil",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Tamil",
-      "enum": [
-        "Anek Tamil"
-      ]
+      "const": "Anek Tamil"
     },
     {
       "title": "Anek Telugu",
       "markdownDescription": "https://fonts.google.com/specimen/Anek+Telugu",
-      "enum": [
-        "Anek Telugu"
-      ]
+      "const": "Anek Telugu"
     },
     {
       "title": "Angkor",
       "markdownDescription": "https://fonts.google.com/specimen/Angkor",
-      "enum": [
-        "Angkor"
-      ]
+      "const": "Angkor"
     },
     {
       "title": "Annie Use Your Telescope",
       "markdownDescription": "https://fonts.google.com/specimen/Annie+Use+Your+Telescope",
-      "enum": [
-        "Annie Use Your Telescope"
-      ]
+      "const": "Annie Use Your Telescope"
     },
     {
       "title": "Anonymous Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Anonymous+Pro",
-      "enum": [
-        "Anonymous Pro"
-      ]
+      "const": "Anonymous Pro"
     },
     {
       "title": "Antic",
       "markdownDescription": "https://fonts.google.com/specimen/Antic",
-      "enum": [
-        "Antic"
-      ]
+      "const": "Antic"
     },
     {
       "title": "Antic Didone",
       "markdownDescription": "https://fonts.google.com/specimen/Antic+Didone",
-      "enum": [
-        "Antic Didone"
-      ]
+      "const": "Antic Didone"
     },
     {
       "title": "Antic Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Antic+Slab",
-      "enum": [
-        "Antic Slab"
-      ]
+      "const": "Antic Slab"
     },
     {
       "title": "Anton",
       "markdownDescription": "https://fonts.google.com/specimen/Anton",
-      "enum": [
-        "Anton"
-      ]
+      "const": "Anton"
     },
     {
       "title": "Antonio",
       "markdownDescription": "https://fonts.google.com/specimen/Antonio",
-      "enum": [
-        "Antonio"
-      ]
+      "const": "Antonio"
     },
     {
       "title": "Anuphan",
       "markdownDescription": "https://fonts.google.com/specimen/Anuphan",
-      "enum": [
-        "Anuphan"
-      ]
+      "const": "Anuphan"
     },
     {
       "title": "Anybody",
       "markdownDescription": "https://fonts.google.com/specimen/Anybody",
-      "enum": [
-        "Anybody"
-      ]
+      "const": "Anybody"
     },
     {
       "title": "Aoboshi One",
       "markdownDescription": "https://fonts.google.com/specimen/Aoboshi+One",
-      "enum": [
-        "Aoboshi One"
-      ]
+      "const": "Aoboshi One"
     },
     {
       "title": "Arapey",
       "markdownDescription": "https://fonts.google.com/specimen/Arapey",
-      "enum": [
-        "Arapey"
-      ]
+      "const": "Arapey"
     },
     {
       "title": "Arbutus",
       "markdownDescription": "https://fonts.google.com/specimen/Arbutus",
-      "enum": [
-        "Arbutus"
-      ]
+      "const": "Arbutus"
     },
     {
       "title": "Arbutus Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Arbutus+Slab",
-      "enum": [
-        "Arbutus Slab"
-      ]
+      "const": "Arbutus Slab"
     },
     {
       "title": "Architects Daughter",
       "markdownDescription": "https://fonts.google.com/specimen/Architects+Daughter",
-      "enum": [
-        "Architects Daughter"
-      ]
+      "const": "Architects Daughter"
     },
     {
       "title": "Archivo",
       "markdownDescription": "https://fonts.google.com/specimen/Archivo",
-      "enum": [
-        "Archivo"
-      ]
+      "const": "Archivo"
     },
     {
       "title": "Archivo Black",
       "markdownDescription": "https://fonts.google.com/specimen/Archivo+Black",
-      "enum": [
-        "Archivo Black"
-      ]
+      "const": "Archivo Black"
     },
     {
       "title": "Archivo Narrow",
       "markdownDescription": "https://fonts.google.com/specimen/Archivo+Narrow",
-      "enum": [
-        "Archivo Narrow"
-      ]
+      "const": "Archivo Narrow"
     },
     {
       "title": "Are You Serious",
       "markdownDescription": "https://fonts.google.com/specimen/Are+You+Serious",
-      "enum": [
-        "Are You Serious"
-      ]
+      "const": "Are You Serious"
     },
     {
       "title": "Aref Ruqaa",
       "markdownDescription": "https://fonts.google.com/specimen/Aref+Ruqaa",
-      "enum": [
-        "Aref Ruqaa"
-      ]
+      "const": "Aref Ruqaa"
     },
     {
       "title": "Aref Ruqaa Ink",
       "markdownDescription": "https://fonts.google.com/specimen/Aref+Ruqaa+Ink",
-      "enum": [
-        "Aref Ruqaa Ink"
-      ]
+      "const": "Aref Ruqaa Ink"
     },
     {
       "title": "Arima",
       "markdownDescription": "https://fonts.google.com/specimen/Arima",
-      "enum": [
-        "Arima"
-      ]
+      "const": "Arima"
     },
     {
       "title": "Arima Madurai",
       "markdownDescription": "https://fonts.google.com/specimen/Arima+Madurai",
-      "enum": [
-        "Arima Madurai"
-      ]
+      "const": "Arima Madurai"
     },
     {
       "title": "Arimo",
       "markdownDescription": "https://fonts.google.com/specimen/Arimo",
-      "enum": [
-        "Arimo"
-      ]
+      "const": "Arimo"
     },
     {
       "title": "Arizonia",
       "markdownDescription": "https://fonts.google.com/specimen/Arizonia",
-      "enum": [
-        "Arizonia"
-      ]
+      "const": "Arizonia"
     },
     {
       "title": "Armata",
       "markdownDescription": "https://fonts.google.com/specimen/Armata",
-      "enum": [
-        "Armata"
-      ]
+      "const": "Armata"
     },
     {
       "title": "Arsenal",
       "markdownDescription": "https://fonts.google.com/specimen/Arsenal",
-      "enum": [
-        "Arsenal"
-      ]
+      "const": "Arsenal"
     },
     {
       "title": "Artifika",
       "markdownDescription": "https://fonts.google.com/specimen/Artifika",
-      "enum": [
-        "Artifika"
-      ]
+      "const": "Artifika"
     },
     {
       "title": "Arvo",
       "markdownDescription": "https://fonts.google.com/specimen/Arvo",
-      "enum": [
-        "Arvo"
-      ]
+      "const": "Arvo"
     },
     {
       "title": "Arya",
       "markdownDescription": "https://fonts.google.com/specimen/Arya",
-      "enum": [
-        "Arya"
-      ]
+      "const": "Arya"
     },
     {
       "title": "Asap",
       "markdownDescription": "https://fonts.google.com/specimen/Asap",
-      "enum": [
-        "Asap"
-      ]
+      "const": "Asap"
     },
     {
       "title": "Asap Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Asap+Condensed",
-      "enum": [
-        "Asap Condensed"
-      ]
+      "const": "Asap Condensed"
     },
     {
       "title": "Asar",
       "markdownDescription": "https://fonts.google.com/specimen/Asar",
-      "enum": [
-        "Asar"
-      ]
+      "const": "Asar"
     },
     {
       "title": "Asset",
       "markdownDescription": "https://fonts.google.com/specimen/Asset",
-      "enum": [
-        "Asset"
-      ]
+      "const": "Asset"
     },
     {
       "title": "Assistant",
       "markdownDescription": "https://fonts.google.com/specimen/Assistant",
-      "enum": [
-        "Assistant"
-      ]
+      "const": "Assistant"
     },
     {
       "title": "Astloch",
       "markdownDescription": "https://fonts.google.com/specimen/Astloch",
-      "enum": [
-        "Astloch"
-      ]
+      "const": "Astloch"
     },
     {
       "title": "Asul",
       "markdownDescription": "https://fonts.google.com/specimen/Asul",
-      "enum": [
-        "Asul"
-      ]
+      "const": "Asul"
     },
     {
       "title": "Athiti",
       "markdownDescription": "https://fonts.google.com/specimen/Athiti",
-      "enum": [
-        "Athiti"
-      ]
+      "const": "Athiti"
     },
     {
       "title": "Atkinson Hyperlegible",
       "markdownDescription": "https://fonts.google.com/specimen/Atkinson+Hyperlegible",
-      "enum": [
-        "Atkinson Hyperlegible"
-      ]
+      "const": "Atkinson Hyperlegible"
     },
     {
       "title": "Atma",
       "markdownDescription": "https://fonts.google.com/specimen/Atma",
-      "enum": [
-        "Atma"
-      ]
+      "const": "Atma"
     },
     {
       "title": "Atomic Age",
       "markdownDescription": "https://fonts.google.com/specimen/Atomic+Age",
-      "enum": [
-        "Atomic Age"
-      ]
+      "const": "Atomic Age"
     },
     {
       "title": "Aubrey",
       "markdownDescription": "https://fonts.google.com/specimen/Aubrey",
-      "enum": [
-        "Aubrey"
-      ]
+      "const": "Aubrey"
     },
     {
       "title": "Audiowide",
       "markdownDescription": "https://fonts.google.com/specimen/Audiowide",
-      "enum": [
-        "Audiowide"
-      ]
+      "const": "Audiowide"
     },
     {
       "title": "Autour One",
       "markdownDescription": "https://fonts.google.com/specimen/Autour+One",
-      "enum": [
-        "Autour One"
-      ]
+      "const": "Autour One"
     },
     {
       "title": "Average",
       "markdownDescription": "https://fonts.google.com/specimen/Average",
-      "enum": [
-        "Average"
-      ]
+      "const": "Average"
     },
     {
       "title": "Average Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Average+Sans",
-      "enum": [
-        "Average Sans"
-      ]
+      "const": "Average Sans"
     },
     {
       "title": "Averia Gruesa Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Averia+Gruesa+Libre",
-      "enum": [
-        "Averia Gruesa Libre"
-      ]
+      "const": "Averia Gruesa Libre"
     },
     {
       "title": "Averia Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Averia+Libre",
-      "enum": [
-        "Averia Libre"
-      ]
+      "const": "Averia Libre"
     },
     {
       "title": "Averia Sans Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Averia+Sans+Libre",
-      "enum": [
-        "Averia Sans Libre"
-      ]
+      "const": "Averia Sans Libre"
     },
     {
       "title": "Averia Serif Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Averia+Serif+Libre",
-      "enum": [
-        "Averia Serif Libre"
-      ]
+      "const": "Averia Serif Libre"
     },
     {
       "title": "Azeret Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Azeret+Mono",
-      "enum": [
-        "Azeret Mono"
-      ]
+      "const": "Azeret Mono"
     },
     {
       "title": "B612",
       "markdownDescription": "https://fonts.google.com/specimen/B612",
-      "enum": [
-        "B612"
-      ]
+      "const": "B612"
     },
     {
       "title": "B612 Mono",
       "markdownDescription": "https://fonts.google.com/specimen/B612+Mono",
-      "enum": [
-        "B612 Mono"
-      ]
+      "const": "B612 Mono"
     },
     {
       "title": "BIZ UDGothic",
       "markdownDescription": "https://fonts.google.com/specimen/BIZ+UDGothic",
-      "enum": [
-        "BIZ UDGothic"
-      ]
+      "const": "BIZ UDGothic"
     },
     {
       "title": "BIZ UDMincho",
       "markdownDescription": "https://fonts.google.com/specimen/BIZ+UDMincho",
-      "enum": [
-        "BIZ UDMincho"
-      ]
+      "const": "BIZ UDMincho"
     },
     {
       "title": "BIZ UDPGothic",
       "markdownDescription": "https://fonts.google.com/specimen/BIZ+UDPGothic",
-      "enum": [
-        "BIZ UDPGothic"
-      ]
+      "const": "BIZ UDPGothic"
     },
     {
       "title": "BIZ UDPMincho",
       "markdownDescription": "https://fonts.google.com/specimen/BIZ+UDPMincho",
-      "enum": [
-        "BIZ UDPMincho"
-      ]
+      "const": "BIZ UDPMincho"
     },
     {
       "title": "Babylonica",
       "markdownDescription": "https://fonts.google.com/specimen/Babylonica",
-      "enum": [
-        "Babylonica"
-      ]
+      "const": "Babylonica"
     },
     {
       "title": "Bacasime Antique",
       "markdownDescription": "https://fonts.google.com/specimen/Bacasime+Antique",
-      "enum": [
-        "Bacasime Antique"
-      ]
+      "const": "Bacasime Antique"
     },
     {
       "title": "Bad Script",
       "markdownDescription": "https://fonts.google.com/specimen/Bad+Script",
-      "enum": [
-        "Bad Script"
-      ]
+      "const": "Bad Script"
     },
     {
       "title": "Bagel Fat One",
       "markdownDescription": "https://fonts.google.com/specimen/Bagel+Fat+One",
-      "enum": [
-        "Bagel Fat One"
-      ]
+      "const": "Bagel Fat One"
     },
     {
       "title": "Bahiana",
       "markdownDescription": "https://fonts.google.com/specimen/Bahiana",
-      "enum": [
-        "Bahiana"
-      ]
+      "const": "Bahiana"
     },
     {
       "title": "Bahianita",
       "markdownDescription": "https://fonts.google.com/specimen/Bahianita",
-      "enum": [
-        "Bahianita"
-      ]
+      "const": "Bahianita"
     },
     {
       "title": "Bai Jamjuree",
       "markdownDescription": "https://fonts.google.com/specimen/Bai+Jamjuree",
-      "enum": [
-        "Bai Jamjuree"
-      ]
+      "const": "Bai Jamjuree"
     },
     {
       "title": "Bakbak One",
       "markdownDescription": "https://fonts.google.com/specimen/Bakbak+One",
-      "enum": [
-        "Bakbak One"
-      ]
+      "const": "Bakbak One"
     },
     {
       "title": "Ballet",
       "markdownDescription": "https://fonts.google.com/specimen/Ballet",
-      "enum": [
-        "Ballet"
-      ]
+      "const": "Ballet"
     },
     {
       "title": "Baloo 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+2",
-      "enum": [
-        "Baloo 2"
-      ]
+      "const": "Baloo 2"
     },
     {
       "title": "Baloo Bhai 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Bhai+2",
-      "enum": [
-        "Baloo Bhai 2"
-      ]
+      "const": "Baloo Bhai 2"
     },
     {
       "title": "Baloo Bhaijaan 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Bhaijaan+2",
-      "enum": [
-        "Baloo Bhaijaan 2"
-      ]
+      "const": "Baloo Bhaijaan 2"
     },
     {
       "title": "Baloo Bhaina 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Bhaina+2",
-      "enum": [
-        "Baloo Bhaina 2"
-      ]
+      "const": "Baloo Bhaina 2"
     },
     {
       "title": "Baloo Chettan 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Chettan+2",
-      "enum": [
-        "Baloo Chettan 2"
-      ]
+      "const": "Baloo Chettan 2"
     },
     {
       "title": "Baloo Da 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Da+2",
-      "enum": [
-        "Baloo Da 2"
-      ]
+      "const": "Baloo Da 2"
     },
     {
       "title": "Baloo Paaji 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Paaji+2",
-      "enum": [
-        "Baloo Paaji 2"
-      ]
+      "const": "Baloo Paaji 2"
     },
     {
       "title": "Baloo Tamma 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Tamma+2",
-      "enum": [
-        "Baloo Tamma 2"
-      ]
+      "const": "Baloo Tamma 2"
     },
     {
       "title": "Baloo Tammudu 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Tammudu+2",
-      "enum": [
-        "Baloo Tammudu 2"
-      ]
+      "const": "Baloo Tammudu 2"
     },
     {
       "title": "Baloo Thambi 2",
       "markdownDescription": "https://fonts.google.com/specimen/Baloo+Thambi+2",
-      "enum": [
-        "Baloo Thambi 2"
-      ]
+      "const": "Baloo Thambi 2"
     },
     {
       "title": "Balsamiq Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Balsamiq+Sans",
-      "enum": [
-        "Balsamiq Sans"
-      ]
+      "const": "Balsamiq Sans"
     },
     {
       "title": "Balthazar",
       "markdownDescription": "https://fonts.google.com/specimen/Balthazar",
-      "enum": [
-        "Balthazar"
-      ]
+      "const": "Balthazar"
     },
     {
       "title": "Bangers",
       "markdownDescription": "https://fonts.google.com/specimen/Bangers",
-      "enum": [
-        "Bangers"
-      ]
+      "const": "Bangers"
     },
     {
       "title": "Barlow",
       "markdownDescription": "https://fonts.google.com/specimen/Barlow",
-      "enum": [
-        "Barlow"
-      ]
+      "const": "Barlow"
     },
     {
       "title": "Barlow Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Barlow+Condensed",
-      "enum": [
-        "Barlow Condensed"
-      ]
+      "const": "Barlow Condensed"
     },
     {
       "title": "Barlow Semi Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Barlow+Semi+Condensed",
-      "enum": [
-        "Barlow Semi Condensed"
-      ]
+      "const": "Barlow Semi Condensed"
     },
     {
       "title": "Barriecito",
       "markdownDescription": "https://fonts.google.com/specimen/Barriecito",
-      "enum": [
-        "Barriecito"
-      ]
+      "const": "Barriecito"
     },
     {
       "title": "Barrio",
       "markdownDescription": "https://fonts.google.com/specimen/Barrio",
-      "enum": [
-        "Barrio"
-      ]
+      "const": "Barrio"
     },
     {
       "title": "Basic",
       "markdownDescription": "https://fonts.google.com/specimen/Basic",
-      "enum": [
-        "Basic"
-      ]
+      "const": "Basic"
     },
     {
       "title": "Baskervville",
       "markdownDescription": "https://fonts.google.com/specimen/Baskervville",
-      "enum": [
-        "Baskervville"
-      ]
+      "const": "Baskervville"
     },
     {
       "title": "Battambang",
       "markdownDescription": "https://fonts.google.com/specimen/Battambang",
-      "enum": [
-        "Battambang"
-      ]
+      "const": "Battambang"
     },
     {
       "title": "Baumans",
       "markdownDescription": "https://fonts.google.com/specimen/Baumans",
-      "enum": [
-        "Baumans"
-      ]
+      "const": "Baumans"
     },
     {
       "title": "Bayon",
       "markdownDescription": "https://fonts.google.com/specimen/Bayon",
-      "enum": [
-        "Bayon"
-      ]
+      "const": "Bayon"
     },
     {
       "title": "Be Vietnam Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Be+Vietnam+Pro",
-      "enum": [
-        "Be Vietnam Pro"
-      ]
+      "const": "Be Vietnam Pro"
     },
     {
       "title": "Beau Rivage",
       "markdownDescription": "https://fonts.google.com/specimen/Beau+Rivage",
-      "enum": [
-        "Beau Rivage"
-      ]
+      "const": "Beau Rivage"
     },
     {
       "title": "Bebas Neue",
       "markdownDescription": "https://fonts.google.com/specimen/Bebas+Neue",
-      "enum": [
-        "Bebas Neue"
-      ]
+      "const": "Bebas Neue"
     },
     {
       "title": "Belanosima",
       "markdownDescription": "https://fonts.google.com/specimen/Belanosima",
-      "enum": [
-        "Belanosima"
-      ]
+      "const": "Belanosima"
     },
     {
       "title": "Belgrano",
       "markdownDescription": "https://fonts.google.com/specimen/Belgrano",
-      "enum": [
-        "Belgrano"
-      ]
+      "const": "Belgrano"
     },
     {
       "title": "Bellefair",
       "markdownDescription": "https://fonts.google.com/specimen/Bellefair",
-      "enum": [
-        "Bellefair"
-      ]
+      "const": "Bellefair"
     },
     {
       "title": "Belleza",
       "markdownDescription": "https://fonts.google.com/specimen/Belleza",
-      "enum": [
-        "Belleza"
-      ]
+      "const": "Belleza"
     },
     {
       "title": "Bellota",
       "markdownDescription": "https://fonts.google.com/specimen/Bellota",
-      "enum": [
-        "Bellota"
-      ]
+      "const": "Bellota"
     },
     {
       "title": "Bellota Text",
       "markdownDescription": "https://fonts.google.com/specimen/Bellota+Text",
-      "enum": [
-        "Bellota Text"
-      ]
+      "const": "Bellota Text"
     },
     {
       "title": "BenchNine",
       "markdownDescription": "https://fonts.google.com/specimen/BenchNine",
-      "enum": [
-        "BenchNine"
-      ]
+      "const": "BenchNine"
     },
     {
       "title": "Benne",
       "markdownDescription": "https://fonts.google.com/specimen/Benne",
-      "enum": [
-        "Benne"
-      ]
+      "const": "Benne"
     },
     {
       "title": "Bentham",
       "markdownDescription": "https://fonts.google.com/specimen/Bentham",
-      "enum": [
-        "Bentham"
-      ]
+      "const": "Bentham"
     },
     {
       "title": "Berkshire Swash",
       "markdownDescription": "https://fonts.google.com/specimen/Berkshire+Swash",
-      "enum": [
-        "Berkshire Swash"
-      ]
+      "const": "Berkshire Swash"
     },
     {
       "title": "Besley",
       "markdownDescription": "https://fonts.google.com/specimen/Besley",
-      "enum": [
-        "Besley"
-      ]
+      "const": "Besley"
     },
     {
       "title": "Beth Ellen",
       "markdownDescription": "https://fonts.google.com/specimen/Beth+Ellen",
-      "enum": [
-        "Beth Ellen"
-      ]
+      "const": "Beth Ellen"
     },
     {
       "title": "Bevan",
       "markdownDescription": "https://fonts.google.com/specimen/Bevan",
-      "enum": [
-        "Bevan"
-      ]
+      "const": "Bevan"
     },
     {
       "title": "BhuTuka Expanded One",
       "markdownDescription": "https://fonts.google.com/specimen/BhuTuka+Expanded+One",
-      "enum": [
-        "BhuTuka Expanded One"
-      ]
+      "const": "BhuTuka Expanded One"
     },
     {
       "title": "Big Shoulders Display",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Display",
-      "enum": [
-        "Big Shoulders Display"
-      ]
+      "const": "Big Shoulders Display"
     },
     {
       "title": "Big Shoulders Inline Display",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Inline+Display",
-      "enum": [
-        "Big Shoulders Inline Display"
-      ]
+      "const": "Big Shoulders Inline Display"
     },
     {
       "title": "Big Shoulders Inline Text",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Inline+Text",
-      "enum": [
-        "Big Shoulders Inline Text"
-      ]
+      "const": "Big Shoulders Inline Text"
     },
     {
       "title": "Big Shoulders Stencil Display",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Stencil+Display",
-      "enum": [
-        "Big Shoulders Stencil Display"
-      ]
+      "const": "Big Shoulders Stencil Display"
     },
     {
       "title": "Big Shoulders Stencil Text",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Stencil+Text",
-      "enum": [
-        "Big Shoulders Stencil Text"
-      ]
+      "const": "Big Shoulders Stencil Text"
     },
     {
       "title": "Big Shoulders Text",
       "markdownDescription": "https://fonts.google.com/specimen/Big+Shoulders+Text",
-      "enum": [
-        "Big Shoulders Text"
-      ]
+      "const": "Big Shoulders Text"
     },
     {
       "title": "Bigelow Rules",
       "markdownDescription": "https://fonts.google.com/specimen/Bigelow+Rules",
-      "enum": [
-        "Bigelow Rules"
-      ]
+      "const": "Bigelow Rules"
     },
     {
       "title": "Bigshot One",
       "markdownDescription": "https://fonts.google.com/specimen/Bigshot+One",
-      "enum": [
-        "Bigshot One"
-      ]
+      "const": "Bigshot One"
     },
     {
       "title": "Bilbo",
       "markdownDescription": "https://fonts.google.com/specimen/Bilbo",
-      "enum": [
-        "Bilbo"
-      ]
+      "const": "Bilbo"
     },
     {
       "title": "Bilbo Swash Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Bilbo+Swash+Caps",
-      "enum": [
-        "Bilbo Swash Caps"
-      ]
+      "const": "Bilbo Swash Caps"
     },
     {
       "title": "BioRhyme",
       "markdownDescription": "https://fonts.google.com/specimen/BioRhyme",
-      "enum": [
-        "BioRhyme"
-      ]
+      "const": "BioRhyme"
     },
     {
       "title": "BioRhyme Expanded",
       "markdownDescription": "https://fonts.google.com/specimen/BioRhyme+Expanded",
-      "enum": [
-        "BioRhyme Expanded"
-      ]
+      "const": "BioRhyme Expanded"
     },
     {
       "title": "Birthstone",
       "markdownDescription": "https://fonts.google.com/specimen/Birthstone",
-      "enum": [
-        "Birthstone"
-      ]
+      "const": "Birthstone"
     },
     {
       "title": "Birthstone Bounce",
       "markdownDescription": "https://fonts.google.com/specimen/Birthstone+Bounce",
-      "enum": [
-        "Birthstone Bounce"
-      ]
+      "const": "Birthstone Bounce"
     },
     {
       "title": "Biryani",
       "markdownDescription": "https://fonts.google.com/specimen/Biryani",
-      "enum": [
-        "Biryani"
-      ]
+      "const": "Biryani"
     },
     {
       "title": "Bitter",
       "markdownDescription": "https://fonts.google.com/specimen/Bitter",
-      "enum": [
-        "Bitter"
-      ]
+      "const": "Bitter"
     },
     {
       "title": "Black And White Picture",
       "markdownDescription": "https://fonts.google.com/specimen/Black+And+White+Picture",
-      "enum": [
-        "Black And White Picture"
-      ]
+      "const": "Black And White Picture"
     },
     {
       "title": "Black Han Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Black+Han+Sans",
-      "enum": [
-        "Black Han Sans"
-      ]
+      "const": "Black Han Sans"
     },
     {
       "title": "Black Ops One",
       "markdownDescription": "https://fonts.google.com/specimen/Black+Ops+One",
-      "enum": [
-        "Black Ops One"
-      ]
+      "const": "Black Ops One"
     },
     {
       "title": "Blaka",
       "markdownDescription": "https://fonts.google.com/specimen/Blaka",
-      "enum": [
-        "Blaka"
-      ]
+      "const": "Blaka"
     },
     {
       "title": "Blaka Hollow",
       "markdownDescription": "https://fonts.google.com/specimen/Blaka+Hollow",
-      "enum": [
-        "Blaka Hollow"
-      ]
+      "const": "Blaka Hollow"
     },
     {
       "title": "Blaka Ink",
       "markdownDescription": "https://fonts.google.com/specimen/Blaka+Ink",
-      "enum": [
-        "Blaka Ink"
-      ]
+      "const": "Blaka Ink"
     },
     {
       "title": "Blinker",
       "markdownDescription": "https://fonts.google.com/specimen/Blinker",
-      "enum": [
-        "Blinker"
-      ]
+      "const": "Blinker"
     },
     {
       "title": "Bodoni Moda",
       "markdownDescription": "https://fonts.google.com/specimen/Bodoni+Moda",
-      "enum": [
-        "Bodoni Moda"
-      ]
+      "const": "Bodoni Moda"
     },
     {
       "title": "Bokor",
       "markdownDescription": "https://fonts.google.com/specimen/Bokor",
-      "enum": [
-        "Bokor"
-      ]
+      "const": "Bokor"
     },
     {
       "title": "Bona Nova",
       "markdownDescription": "https://fonts.google.com/specimen/Bona+Nova",
-      "enum": [
-        "Bona Nova"
-      ]
+      "const": "Bona Nova"
     },
     {
       "title": "Bonbon",
       "markdownDescription": "https://fonts.google.com/specimen/Bonbon",
-      "enum": [
-        "Bonbon"
-      ]
+      "const": "Bonbon"
     },
     {
       "title": "Bonheur Royale",
       "markdownDescription": "https://fonts.google.com/specimen/Bonheur+Royale",
-      "enum": [
-        "Bonheur Royale"
-      ]
+      "const": "Bonheur Royale"
     },
     {
       "title": "Boogaloo",
       "markdownDescription": "https://fonts.google.com/specimen/Boogaloo",
-      "enum": [
-        "Boogaloo"
-      ]
+      "const": "Boogaloo"
     },
     {
       "title": "Borel",
       "markdownDescription": "https://fonts.google.com/specimen/Borel",
-      "enum": [
-        "Borel"
-      ]
+      "const": "Borel"
     },
     {
       "title": "Bowlby One",
       "markdownDescription": "https://fonts.google.com/specimen/Bowlby+One",
-      "enum": [
-        "Bowlby One"
-      ]
+      "const": "Bowlby One"
     },
     {
       "title": "Bowlby One SC",
       "markdownDescription": "https://fonts.google.com/specimen/Bowlby+One+SC",
-      "enum": [
-        "Bowlby One SC"
-      ]
+      "const": "Bowlby One SC"
     },
     {
       "title": "Braah One",
       "markdownDescription": "https://fonts.google.com/specimen/Braah+One",
-      "enum": [
-        "Braah One"
-      ]
+      "const": "Braah One"
     },
     {
       "title": "Brawler",
       "markdownDescription": "https://fonts.google.com/specimen/Brawler",
-      "enum": [
-        "Brawler"
-      ]
+      "const": "Brawler"
     },
     {
       "title": "Bree Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Bree+Serif",
-      "enum": [
-        "Bree Serif"
-      ]
+      "const": "Bree Serif"
     },
     {
       "title": "Bricolage Grotesque",
       "markdownDescription": "https://fonts.google.com/specimen/Bricolage+Grotesque",
-      "enum": [
-        "Bricolage Grotesque"
-      ]
+      "const": "Bricolage Grotesque"
     },
     {
       "title": "Bruno Ace",
       "markdownDescription": "https://fonts.google.com/specimen/Bruno+Ace",
-      "enum": [
-        "Bruno Ace"
-      ]
+      "const": "Bruno Ace"
     },
     {
       "title": "Bruno Ace SC",
       "markdownDescription": "https://fonts.google.com/specimen/Bruno+Ace+SC",
-      "enum": [
-        "Bruno Ace SC"
-      ]
+      "const": "Bruno Ace SC"
     },
     {
       "title": "Brygada 1918",
       "markdownDescription": "https://fonts.google.com/specimen/Brygada+1918",
-      "enum": [
-        "Brygada 1918"
-      ]
+      "const": "Brygada 1918"
     },
     {
       "title": "Bubblegum Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Bubblegum+Sans",
-      "enum": [
-        "Bubblegum Sans"
-      ]
+      "const": "Bubblegum Sans"
     },
     {
       "title": "Bubbler One",
       "markdownDescription": "https://fonts.google.com/specimen/Bubbler+One",
-      "enum": [
-        "Bubbler One"
-      ]
+      "const": "Bubbler One"
     },
     {
       "title": "Buda",
       "markdownDescription": "https://fonts.google.com/specimen/Buda",
-      "enum": [
-        "Buda"
-      ]
+      "const": "Buda"
     },
     {
       "title": "Buenard",
       "markdownDescription": "https://fonts.google.com/specimen/Buenard",
-      "enum": [
-        "Buenard"
-      ]
+      "const": "Buenard"
     },
     {
       "title": "Bungee",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee",
-      "enum": [
-        "Bungee"
-      ]
+      "const": "Bungee"
     },
     {
       "title": "Bungee Hairline",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee+Hairline",
-      "enum": [
-        "Bungee Hairline"
-      ]
+      "const": "Bungee Hairline"
     },
     {
       "title": "Bungee Inline",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee+Inline",
-      "enum": [
-        "Bungee Inline"
-      ]
+      "const": "Bungee Inline"
     },
     {
       "title": "Bungee Outline",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee+Outline",
-      "enum": [
-        "Bungee Outline"
-      ]
+      "const": "Bungee Outline"
     },
     {
       "title": "Bungee Shade",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee+Shade",
-      "enum": [
-        "Bungee Shade"
-      ]
+      "const": "Bungee Shade"
     },
     {
       "title": "Bungee Spice",
       "markdownDescription": "https://fonts.google.com/specimen/Bungee+Spice",
-      "enum": [
-        "Bungee Spice"
-      ]
+      "const": "Bungee Spice"
     },
     {
       "title": "Butcherman",
       "markdownDescription": "https://fonts.google.com/specimen/Butcherman",
-      "enum": [
-        "Butcherman"
-      ]
+      "const": "Butcherman"
     },
     {
       "title": "Butterfly Kids",
       "markdownDescription": "https://fonts.google.com/specimen/Butterfly+Kids",
-      "enum": [
-        "Butterfly Kids"
-      ]
+      "const": "Butterfly Kids"
     },
     {
       "title": "Cabin",
       "markdownDescription": "https://fonts.google.com/specimen/Cabin",
-      "enum": [
-        "Cabin"
-      ]
+      "const": "Cabin"
     },
     {
       "title": "Cabin Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Cabin+Condensed",
-      "enum": [
-        "Cabin Condensed"
-      ]
+      "const": "Cabin Condensed"
     },
     {
       "title": "Cabin Sketch",
       "markdownDescription": "https://fonts.google.com/specimen/Cabin+Sketch",
-      "enum": [
-        "Cabin Sketch"
-      ]
+      "const": "Cabin Sketch"
     },
     {
       "title": "Caesar Dressing",
       "markdownDescription": "https://fonts.google.com/specimen/Caesar+Dressing",
-      "enum": [
-        "Caesar Dressing"
-      ]
+      "const": "Caesar Dressing"
     },
     {
       "title": "Cagliostro",
       "markdownDescription": "https://fonts.google.com/specimen/Cagliostro",
-      "enum": [
-        "Cagliostro"
-      ]
+      "const": "Cagliostro"
     },
     {
       "title": "Cairo",
       "markdownDescription": "https://fonts.google.com/specimen/Cairo",
-      "enum": [
-        "Cairo"
-      ]
+      "const": "Cairo"
     },
     {
       "title": "Cairo Play",
       "markdownDescription": "https://fonts.google.com/specimen/Cairo+Play",
-      "enum": [
-        "Cairo Play"
-      ]
+      "const": "Cairo Play"
     },
     {
       "title": "Caladea",
       "markdownDescription": "https://fonts.google.com/specimen/Caladea",
-      "enum": [
-        "Caladea"
-      ]
+      "const": "Caladea"
     },
     {
       "title": "Calistoga",
       "markdownDescription": "https://fonts.google.com/specimen/Calistoga",
-      "enum": [
-        "Calistoga"
-      ]
+      "const": "Calistoga"
     },
     {
       "title": "Calligraffitti",
       "markdownDescription": "https://fonts.google.com/specimen/Calligraffitti",
-      "enum": [
-        "Calligraffitti"
-      ]
+      "const": "Calligraffitti"
     },
     {
       "title": "Cambay",
       "markdownDescription": "https://fonts.google.com/specimen/Cambay",
-      "enum": [
-        "Cambay"
-      ]
+      "const": "Cambay"
     },
     {
       "title": "Cambo",
       "markdownDescription": "https://fonts.google.com/specimen/Cambo",
-      "enum": [
-        "Cambo"
-      ]
+      "const": "Cambo"
     },
     {
       "title": "Candal",
       "markdownDescription": "https://fonts.google.com/specimen/Candal",
-      "enum": [
-        "Candal"
-      ]
+      "const": "Candal"
     },
     {
       "title": "Cantarell",
       "markdownDescription": "https://fonts.google.com/specimen/Cantarell",
-      "enum": [
-        "Cantarell"
-      ]
+      "const": "Cantarell"
     },
     {
       "title": "Cantata One",
       "markdownDescription": "https://fonts.google.com/specimen/Cantata+One",
-      "enum": [
-        "Cantata One"
-      ]
+      "const": "Cantata One"
     },
     {
       "title": "Cantora One",
       "markdownDescription": "https://fonts.google.com/specimen/Cantora+One",
-      "enum": [
-        "Cantora One"
-      ]
+      "const": "Cantora One"
     },
     {
       "title": "Caprasimo",
       "markdownDescription": "https://fonts.google.com/specimen/Caprasimo",
-      "enum": [
-        "Caprasimo"
-      ]
+      "const": "Caprasimo"
     },
     {
       "title": "Capriola",
       "markdownDescription": "https://fonts.google.com/specimen/Capriola",
-      "enum": [
-        "Capriola"
-      ]
+      "const": "Capriola"
     },
     {
       "title": "Caramel",
       "markdownDescription": "https://fonts.google.com/specimen/Caramel",
-      "enum": [
-        "Caramel"
-      ]
+      "const": "Caramel"
     },
     {
       "title": "Carattere",
       "markdownDescription": "https://fonts.google.com/specimen/Carattere",
-      "enum": [
-        "Carattere"
-      ]
+      "const": "Carattere"
     },
     {
       "title": "Cardo",
       "markdownDescription": "https://fonts.google.com/specimen/Cardo",
-      "enum": [
-        "Cardo"
-      ]
+      "const": "Cardo"
     },
     {
       "title": "Carlito",
       "markdownDescription": "https://fonts.google.com/specimen/Carlito",
-      "enum": [
-        "Carlito"
-      ]
+      "const": "Carlito"
     },
     {
       "title": "Carme",
       "markdownDescription": "https://fonts.google.com/specimen/Carme",
-      "enum": [
-        "Carme"
-      ]
+      "const": "Carme"
     },
     {
       "title": "Carrois Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Carrois+Gothic",
-      "enum": [
-        "Carrois Gothic"
-      ]
+      "const": "Carrois Gothic"
     },
     {
       "title": "Carrois Gothic SC",
       "markdownDescription": "https://fonts.google.com/specimen/Carrois+Gothic+SC",
-      "enum": [
-        "Carrois Gothic SC"
-      ]
+      "const": "Carrois Gothic SC"
     },
     {
       "title": "Carter One",
       "markdownDescription": "https://fonts.google.com/specimen/Carter+One",
-      "enum": [
-        "Carter One"
-      ]
+      "const": "Carter One"
     },
     {
       "title": "Castoro",
       "markdownDescription": "https://fonts.google.com/specimen/Castoro",
-      "enum": [
-        "Castoro"
-      ]
+      "const": "Castoro"
     },
     {
       "title": "Castoro Titling",
       "markdownDescription": "https://fonts.google.com/specimen/Castoro+Titling",
-      "enum": [
-        "Castoro Titling"
-      ]
+      "const": "Castoro Titling"
     },
     {
       "title": "Catamaran",
       "markdownDescription": "https://fonts.google.com/specimen/Catamaran",
-      "enum": [
-        "Catamaran"
-      ]
+      "const": "Catamaran"
     },
     {
       "title": "Caudex",
       "markdownDescription": "https://fonts.google.com/specimen/Caudex",
-      "enum": [
-        "Caudex"
-      ]
+      "const": "Caudex"
     },
     {
       "title": "Caveat",
       "markdownDescription": "https://fonts.google.com/specimen/Caveat",
-      "enum": [
-        "Caveat"
-      ]
+      "const": "Caveat"
     },
     {
       "title": "Caveat Brush",
       "markdownDescription": "https://fonts.google.com/specimen/Caveat+Brush",
-      "enum": [
-        "Caveat Brush"
-      ]
+      "const": "Caveat Brush"
     },
     {
       "title": "Cedarville Cursive",
       "markdownDescription": "https://fonts.google.com/specimen/Cedarville+Cursive",
-      "enum": [
-        "Cedarville Cursive"
-      ]
+      "const": "Cedarville Cursive"
     },
     {
       "title": "Ceviche One",
       "markdownDescription": "https://fonts.google.com/specimen/Ceviche+One",
-      "enum": [
-        "Ceviche One"
-      ]
+      "const": "Ceviche One"
     },
     {
       "title": "Chakra Petch",
       "markdownDescription": "https://fonts.google.com/specimen/Chakra+Petch",
-      "enum": [
-        "Chakra Petch"
-      ]
+      "const": "Chakra Petch"
     },
     {
       "title": "Changa",
       "markdownDescription": "https://fonts.google.com/specimen/Changa",
-      "enum": [
-        "Changa"
-      ]
+      "const": "Changa"
     },
     {
       "title": "Changa One",
       "markdownDescription": "https://fonts.google.com/specimen/Changa+One",
-      "enum": [
-        "Changa One"
-      ]
+      "const": "Changa One"
     },
     {
       "title": "Chango",
       "markdownDescription": "https://fonts.google.com/specimen/Chango",
-      "enum": [
-        "Chango"
-      ]
+      "const": "Chango"
     },
     {
       "title": "Charis SIL",
       "markdownDescription": "https://fonts.google.com/specimen/Charis+SIL",
-      "enum": [
-        "Charis SIL"
-      ]
+      "const": "Charis SIL"
     },
     {
       "title": "Charm",
       "markdownDescription": "https://fonts.google.com/specimen/Charm",
-      "enum": [
-        "Charm"
-      ]
+      "const": "Charm"
     },
     {
       "title": "Charmonman",
       "markdownDescription": "https://fonts.google.com/specimen/Charmonman",
-      "enum": [
-        "Charmonman"
-      ]
+      "const": "Charmonman"
     },
     {
       "title": "Chathura",
       "markdownDescription": "https://fonts.google.com/specimen/Chathura",
-      "enum": [
-        "Chathura"
-      ]
+      "const": "Chathura"
     },
     {
       "title": "Chau Philomene One",
       "markdownDescription": "https://fonts.google.com/specimen/Chau+Philomene+One",
-      "enum": [
-        "Chau Philomene One"
-      ]
+      "const": "Chau Philomene One"
     },
     {
       "title": "Chela One",
       "markdownDescription": "https://fonts.google.com/specimen/Chela+One",
-      "enum": [
-        "Chela One"
-      ]
+      "const": "Chela One"
     },
     {
       "title": "Chelsea Market",
       "markdownDescription": "https://fonts.google.com/specimen/Chelsea+Market",
-      "enum": [
-        "Chelsea Market"
-      ]
+      "const": "Chelsea Market"
     },
     {
       "title": "Chenla",
       "markdownDescription": "https://fonts.google.com/specimen/Chenla",
-      "enum": [
-        "Chenla"
-      ]
+      "const": "Chenla"
     },
     {
       "title": "Cherish",
       "markdownDescription": "https://fonts.google.com/specimen/Cherish",
-      "enum": [
-        "Cherish"
-      ]
+      "const": "Cherish"
     },
     {
       "title": "Cherry Bomb One",
       "markdownDescription": "https://fonts.google.com/specimen/Cherry+Bomb+One",
-      "enum": [
-        "Cherry Bomb One"
-      ]
+      "const": "Cherry Bomb One"
     },
     {
       "title": "Cherry Cream Soda",
       "markdownDescription": "https://fonts.google.com/specimen/Cherry+Cream+Soda",
-      "enum": [
-        "Cherry Cream Soda"
-      ]
+      "const": "Cherry Cream Soda"
     },
     {
       "title": "Cherry Swash",
       "markdownDescription": "https://fonts.google.com/specimen/Cherry+Swash",
-      "enum": [
-        "Cherry Swash"
-      ]
+      "const": "Cherry Swash"
     },
     {
       "title": "Chewy",
       "markdownDescription": "https://fonts.google.com/specimen/Chewy",
-      "enum": [
-        "Chewy"
-      ]
+      "const": "Chewy"
     },
     {
       "title": "Chicle",
       "markdownDescription": "https://fonts.google.com/specimen/Chicle",
-      "enum": [
-        "Chicle"
-      ]
+      "const": "Chicle"
     },
     {
       "title": "Chilanka",
       "markdownDescription": "https://fonts.google.com/specimen/Chilanka",
-      "enum": [
-        "Chilanka"
-      ]
+      "const": "Chilanka"
     },
     {
       "title": "Chivo",
       "markdownDescription": "https://fonts.google.com/specimen/Chivo",
-      "enum": [
-        "Chivo"
-      ]
+      "const": "Chivo"
     },
     {
       "title": "Chivo Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Chivo+Mono",
-      "enum": [
-        "Chivo Mono"
-      ]
+      "const": "Chivo Mono"
     },
     {
       "title": "Chokokutai",
       "markdownDescription": "https://fonts.google.com/specimen/Chokokutai",
-      "enum": [
-        "Chokokutai"
-      ]
+      "const": "Chokokutai"
     },
     {
       "title": "Chonburi",
       "markdownDescription": "https://fonts.google.com/specimen/Chonburi",
-      "enum": [
-        "Chonburi"
-      ]
+      "const": "Chonburi"
     },
     {
       "title": "Cinzel",
       "markdownDescription": "https://fonts.google.com/specimen/Cinzel",
-      "enum": [
-        "Cinzel"
-      ]
+      "const": "Cinzel"
     },
     {
       "title": "Cinzel Decorative",
       "markdownDescription": "https://fonts.google.com/specimen/Cinzel+Decorative",
-      "enum": [
-        "Cinzel Decorative"
-      ]
+      "const": "Cinzel Decorative"
     },
     {
       "title": "Clicker Script",
       "markdownDescription": "https://fonts.google.com/specimen/Clicker+Script",
-      "enum": [
-        "Clicker Script"
-      ]
+      "const": "Clicker Script"
     },
     {
       "title": "Climate Crisis",
       "markdownDescription": "https://fonts.google.com/specimen/Climate+Crisis",
-      "enum": [
-        "Climate Crisis"
-      ]
+      "const": "Climate Crisis"
     },
     {
       "title": "Coda",
       "markdownDescription": "https://fonts.google.com/specimen/Coda",
-      "enum": [
-        "Coda"
-      ]
+      "const": "Coda"
     },
     {
       "title": "Coda Caption",
       "markdownDescription": "https://fonts.google.com/specimen/Coda+Caption",
-      "enum": [
-        "Coda Caption"
-      ]
+      "const": "Coda Caption"
     },
     {
       "title": "Codystar",
       "markdownDescription": "https://fonts.google.com/specimen/Codystar",
-      "enum": [
-        "Codystar"
-      ]
+      "const": "Codystar"
     },
     {
       "title": "Coiny",
       "markdownDescription": "https://fonts.google.com/specimen/Coiny",
-      "enum": [
-        "Coiny"
-      ]
+      "const": "Coiny"
     },
     {
       "title": "Combo",
       "markdownDescription": "https://fonts.google.com/specimen/Combo",
-      "enum": [
-        "Combo"
-      ]
+      "const": "Combo"
     },
     {
       "title": "Comfortaa",
       "markdownDescription": "https://fonts.google.com/specimen/Comfortaa",
-      "enum": [
-        "Comfortaa"
-      ]
+      "const": "Comfortaa"
     },
     {
       "title": "Comforter",
       "markdownDescription": "https://fonts.google.com/specimen/Comforter",
-      "enum": [
-        "Comforter"
-      ]
+      "const": "Comforter"
     },
     {
       "title": "Comforter Brush",
       "markdownDescription": "https://fonts.google.com/specimen/Comforter+Brush",
-      "enum": [
-        "Comforter Brush"
-      ]
+      "const": "Comforter Brush"
     },
     {
       "title": "Comic Neue",
       "markdownDescription": "https://fonts.google.com/specimen/Comic+Neue",
-      "enum": [
-        "Comic Neue"
-      ]
+      "const": "Comic Neue"
     },
     {
       "title": "Coming Soon",
       "markdownDescription": "https://fonts.google.com/specimen/Coming+Soon",
-      "enum": [
-        "Coming Soon"
-      ]
+      "const": "Coming Soon"
     },
     {
       "title": "Comme",
       "markdownDescription": "https://fonts.google.com/specimen/Comme",
-      "enum": [
-        "Comme"
-      ]
+      "const": "Comme"
     },
     {
       "title": "Commissioner",
       "markdownDescription": "https://fonts.google.com/specimen/Commissioner",
-      "enum": [
-        "Commissioner"
-      ]
+      "const": "Commissioner"
     },
     {
       "title": "Concert One",
       "markdownDescription": "https://fonts.google.com/specimen/Concert+One",
-      "enum": [
-        "Concert One"
-      ]
+      "const": "Concert One"
     },
     {
       "title": "Condiment",
       "markdownDescription": "https://fonts.google.com/specimen/Condiment",
-      "enum": [
-        "Condiment"
-      ]
+      "const": "Condiment"
     },
     {
       "title": "Content",
       "markdownDescription": "https://fonts.google.com/specimen/Content",
-      "enum": [
-        "Content"
-      ]
+      "const": "Content"
     },
     {
       "title": "Contrail One",
       "markdownDescription": "https://fonts.google.com/specimen/Contrail+One",
-      "enum": [
-        "Contrail One"
-      ]
+      "const": "Contrail One"
     },
     {
       "title": "Convergence",
       "markdownDescription": "https://fonts.google.com/specimen/Convergence",
-      "enum": [
-        "Convergence"
-      ]
+      "const": "Convergence"
     },
     {
       "title": "Cookie",
       "markdownDescription": "https://fonts.google.com/specimen/Cookie",
-      "enum": [
-        "Cookie"
-      ]
+      "const": "Cookie"
     },
     {
       "title": "Copse",
       "markdownDescription": "https://fonts.google.com/specimen/Copse",
-      "enum": [
-        "Copse"
-      ]
+      "const": "Copse"
     },
     {
       "title": "Corben",
       "markdownDescription": "https://fonts.google.com/specimen/Corben",
-      "enum": [
-        "Corben"
-      ]
+      "const": "Corben"
     },
     {
       "title": "Corinthia",
       "markdownDescription": "https://fonts.google.com/specimen/Corinthia",
-      "enum": [
-        "Corinthia"
-      ]
+      "const": "Corinthia"
     },
     {
       "title": "Cormorant",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant",
-      "enum": [
-        "Cormorant"
-      ]
+      "const": "Cormorant"
     },
     {
       "title": "Cormorant Garamond",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant+Garamond",
-      "enum": [
-        "Cormorant Garamond"
-      ]
+      "const": "Cormorant Garamond"
     },
     {
       "title": "Cormorant Infant",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant+Infant",
-      "enum": [
-        "Cormorant Infant"
-      ]
+      "const": "Cormorant Infant"
     },
     {
       "title": "Cormorant SC",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant+SC",
-      "enum": [
-        "Cormorant SC"
-      ]
+      "const": "Cormorant SC"
     },
     {
       "title": "Cormorant Unicase",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant+Unicase",
-      "enum": [
-        "Cormorant Unicase"
-      ]
+      "const": "Cormorant Unicase"
     },
     {
       "title": "Cormorant Upright",
       "markdownDescription": "https://fonts.google.com/specimen/Cormorant+Upright",
-      "enum": [
-        "Cormorant Upright"
-      ]
+      "const": "Cormorant Upright"
     },
     {
       "title": "Courgette",
       "markdownDescription": "https://fonts.google.com/specimen/Courgette",
-      "enum": [
-        "Courgette"
-      ]
+      "const": "Courgette"
     },
     {
       "title": "Courier Prime",
       "markdownDescription": "https://fonts.google.com/specimen/Courier+Prime",
-      "enum": [
-        "Courier Prime"
-      ]
+      "const": "Courier Prime"
     },
     {
       "title": "Cousine",
       "markdownDescription": "https://fonts.google.com/specimen/Cousine",
-      "enum": [
-        "Cousine"
-      ]
+      "const": "Cousine"
     },
     {
       "title": "Coustard",
       "markdownDescription": "https://fonts.google.com/specimen/Coustard",
-      "enum": [
-        "Coustard"
-      ]
+      "const": "Coustard"
     },
     {
       "title": "Covered By Your Grace",
       "markdownDescription": "https://fonts.google.com/specimen/Covered+By+Your+Grace",
-      "enum": [
-        "Covered By Your Grace"
-      ]
+      "const": "Covered By Your Grace"
     },
     {
       "title": "Crafty Girls",
       "markdownDescription": "https://fonts.google.com/specimen/Crafty+Girls",
-      "enum": [
-        "Crafty Girls"
-      ]
+      "const": "Crafty Girls"
     },
     {
       "title": "Creepster",
       "markdownDescription": "https://fonts.google.com/specimen/Creepster",
-      "enum": [
-        "Creepster"
-      ]
+      "const": "Creepster"
     },
     {
       "title": "Crete Round",
       "markdownDescription": "https://fonts.google.com/specimen/Crete+Round",
-      "enum": [
-        "Crete Round"
-      ]
+      "const": "Crete Round"
     },
     {
       "title": "Crimson Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Crimson+Pro",
-      "enum": [
-        "Crimson Pro"
-      ]
+      "const": "Crimson Pro"
     },
     {
       "title": "Crimson Text",
       "markdownDescription": "https://fonts.google.com/specimen/Crimson+Text",
-      "enum": [
-        "Crimson Text"
-      ]
+      "const": "Crimson Text"
     },
     {
       "title": "Croissant One",
       "markdownDescription": "https://fonts.google.com/specimen/Croissant+One",
-      "enum": [
-        "Croissant One"
-      ]
+      "const": "Croissant One"
     },
     {
       "title": "Crushed",
       "markdownDescription": "https://fonts.google.com/specimen/Crushed",
-      "enum": [
-        "Crushed"
-      ]
+      "const": "Crushed"
     },
     {
       "title": "Cuprum",
       "markdownDescription": "https://fonts.google.com/specimen/Cuprum",
-      "enum": [
-        "Cuprum"
-      ]
+      "const": "Cuprum"
     },
     {
       "title": "Cute Font",
       "markdownDescription": "https://fonts.google.com/specimen/Cute+Font",
-      "enum": [
-        "Cute Font"
-      ]
+      "const": "Cute Font"
     },
     {
       "title": "Cutive",
       "markdownDescription": "https://fonts.google.com/specimen/Cutive",
-      "enum": [
-        "Cutive"
-      ]
+      "const": "Cutive"
     },
     {
       "title": "Cutive Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Cutive+Mono",
-      "enum": [
-        "Cutive Mono"
-      ]
+      "const": "Cutive Mono"
     },
     {
       "title": "DM Mono",
       "markdownDescription": "https://fonts.google.com/specimen/DM+Mono",
-      "enum": [
-        "DM Mono"
-      ]
+      "const": "DM Mono"
     },
     {
       "title": "DM Sans",
       "markdownDescription": "https://fonts.google.com/specimen/DM+Sans",
-      "enum": [
-        "DM Sans"
-      ]
+      "const": "DM Sans"
     },
     {
       "title": "DM Serif Display",
       "markdownDescription": "https://fonts.google.com/specimen/DM+Serif+Display",
-      "enum": [
-        "DM Serif Display"
-      ]
+      "const": "DM Serif Display"
     },
     {
       "title": "DM Serif Text",
       "markdownDescription": "https://fonts.google.com/specimen/DM+Serif+Text",
-      "enum": [
-        "DM Serif Text"
-      ]
+      "const": "DM Serif Text"
     },
     {
       "title": "Dai Banna SIL",
       "markdownDescription": "https://fonts.google.com/specimen/Dai+Banna+SIL",
-      "enum": [
-        "Dai Banna SIL"
-      ]
+      "const": "Dai Banna SIL"
     },
     {
       "title": "Damion",
       "markdownDescription": "https://fonts.google.com/specimen/Damion",
-      "enum": [
-        "Damion"
-      ]
+      "const": "Damion"
     },
     {
       "title": "Dancing Script",
       "markdownDescription": "https://fonts.google.com/specimen/Dancing+Script",
-      "enum": [
-        "Dancing Script"
-      ]
+      "const": "Dancing Script"
     },
     {
       "title": "Dangrek",
       "markdownDescription": "https://fonts.google.com/specimen/Dangrek",
-      "enum": [
-        "Dangrek"
-      ]
+      "const": "Dangrek"
     },
     {
       "title": "Darker Grotesque",
       "markdownDescription": "https://fonts.google.com/specimen/Darker+Grotesque",
-      "enum": [
-        "Darker Grotesque"
-      ]
+      "const": "Darker Grotesque"
     },
     {
       "title": "Darumadrop One",
       "markdownDescription": "https://fonts.google.com/specimen/Darumadrop+One",
-      "enum": [
-        "Darumadrop One"
-      ]
+      "const": "Darumadrop One"
     },
     {
       "title": "David Libre",
       "markdownDescription": "https://fonts.google.com/specimen/David+Libre",
-      "enum": [
-        "David Libre"
-      ]
+      "const": "David Libre"
     },
     {
       "title": "Dawning of a New Day",
       "markdownDescription": "https://fonts.google.com/specimen/Dawning+of+a+New+Day",
-      "enum": [
-        "Dawning of a New Day"
-      ]
+      "const": "Dawning of a New Day"
     },
     {
       "title": "Days One",
       "markdownDescription": "https://fonts.google.com/specimen/Days+One",
-      "enum": [
-        "Days One"
-      ]
+      "const": "Days One"
     },
     {
       "title": "Dekko",
       "markdownDescription": "https://fonts.google.com/specimen/Dekko",
-      "enum": [
-        "Dekko"
-      ]
+      "const": "Dekko"
     },
     {
       "title": "Dela Gothic One",
       "markdownDescription": "https://fonts.google.com/specimen/Dela+Gothic+One",
-      "enum": [
-        "Dela Gothic One"
-      ]
+      "const": "Dela Gothic One"
     },
     {
       "title": "Delicious Handrawn",
       "markdownDescription": "https://fonts.google.com/specimen/Delicious+Handrawn",
-      "enum": [
-        "Delicious Handrawn"
-      ]
+      "const": "Delicious Handrawn"
     },
     {
       "title": "Delius",
       "markdownDescription": "https://fonts.google.com/specimen/Delius",
-      "enum": [
-        "Delius"
-      ]
+      "const": "Delius"
     },
     {
       "title": "Delius Swash Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Delius+Swash+Caps",
-      "enum": [
-        "Delius Swash Caps"
-      ]
+      "const": "Delius Swash Caps"
     },
     {
       "title": "Delius Unicase",
       "markdownDescription": "https://fonts.google.com/specimen/Delius+Unicase",
-      "enum": [
-        "Delius Unicase"
-      ]
+      "const": "Delius Unicase"
     },
     {
       "title": "Della Respira",
       "markdownDescription": "https://fonts.google.com/specimen/Della+Respira",
-      "enum": [
-        "Della Respira"
-      ]
+      "const": "Della Respira"
     },
     {
       "title": "Denk One",
       "markdownDescription": "https://fonts.google.com/specimen/Denk+One",
-      "enum": [
-        "Denk One"
-      ]
+      "const": "Denk One"
     },
     {
       "title": "Devonshire",
       "markdownDescription": "https://fonts.google.com/specimen/Devonshire",
-      "enum": [
-        "Devonshire"
-      ]
+      "const": "Devonshire"
     },
     {
       "title": "Dhurjati",
       "markdownDescription": "https://fonts.google.com/specimen/Dhurjati",
-      "enum": [
-        "Dhurjati"
-      ]
+      "const": "Dhurjati"
     },
     {
       "title": "Didact Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Didact+Gothic",
-      "enum": [
-        "Didact Gothic"
-      ]
+      "const": "Didact Gothic"
     },
     {
       "title": "Diphylleia",
       "markdownDescription": "https://fonts.google.com/specimen/Diphylleia",
-      "enum": [
-        "Diphylleia"
-      ]
+      "const": "Diphylleia"
     },
     {
       "title": "Diplomata",
       "markdownDescription": "https://fonts.google.com/specimen/Diplomata",
-      "enum": [
-        "Diplomata"
-      ]
+      "const": "Diplomata"
     },
     {
       "title": "Diplomata SC",
       "markdownDescription": "https://fonts.google.com/specimen/Diplomata+SC",
-      "enum": [
-        "Diplomata SC"
-      ]
+      "const": "Diplomata SC"
     },
     {
       "title": "Do Hyeon",
       "markdownDescription": "https://fonts.google.com/specimen/Do+Hyeon",
-      "enum": [
-        "Do Hyeon"
-      ]
+      "const": "Do Hyeon"
     },
     {
       "title": "Dokdo",
       "markdownDescription": "https://fonts.google.com/specimen/Dokdo",
-      "enum": [
-        "Dokdo"
-      ]
+      "const": "Dokdo"
     },
     {
       "title": "Domine",
       "markdownDescription": "https://fonts.google.com/specimen/Domine",
-      "enum": [
-        "Domine"
-      ]
+      "const": "Domine"
     },
     {
       "title": "Donegal One",
       "markdownDescription": "https://fonts.google.com/specimen/Donegal+One",
-      "enum": [
-        "Donegal One"
-      ]
+      "const": "Donegal One"
     },
     {
       "title": "Dongle",
       "markdownDescription": "https://fonts.google.com/specimen/Dongle",
-      "enum": [
-        "Dongle"
-      ]
+      "const": "Dongle"
     },
     {
       "title": "Doppio One",
       "markdownDescription": "https://fonts.google.com/specimen/Doppio+One",
-      "enum": [
-        "Doppio One"
-      ]
+      "const": "Doppio One"
     },
     {
       "title": "Dorsa",
       "markdownDescription": "https://fonts.google.com/specimen/Dorsa",
-      "enum": [
-        "Dorsa"
-      ]
+      "const": "Dorsa"
     },
     {
       "title": "Dosis",
       "markdownDescription": "https://fonts.google.com/specimen/Dosis",
-      "enum": [
-        "Dosis"
-      ]
+      "const": "Dosis"
     },
     {
       "title": "DotGothic16",
       "markdownDescription": "https://fonts.google.com/specimen/DotGothic16",
-      "enum": [
-        "DotGothic16"
-      ]
+      "const": "DotGothic16"
     },
     {
       "title": "Dr Sugiyama",
       "markdownDescription": "https://fonts.google.com/specimen/Dr+Sugiyama",
-      "enum": [
-        "Dr Sugiyama"
-      ]
+      "const": "Dr Sugiyama"
     },
     {
       "title": "Duru Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Duru+Sans",
-      "enum": [
-        "Duru Sans"
-      ]
+      "const": "Duru Sans"
     },
     {
       "title": "DynaPuff",
       "markdownDescription": "https://fonts.google.com/specimen/DynaPuff",
-      "enum": [
-        "DynaPuff"
-      ]
+      "const": "DynaPuff"
     },
     {
       "title": "Dynalight",
       "markdownDescription": "https://fonts.google.com/specimen/Dynalight",
-      "enum": [
-        "Dynalight"
-      ]
+      "const": "Dynalight"
     },
     {
       "title": "EB Garamond",
       "markdownDescription": "https://fonts.google.com/specimen/EB+Garamond",
-      "enum": [
-        "EB Garamond"
-      ]
+      "const": "EB Garamond"
     },
     {
       "title": "Eagle Lake",
       "markdownDescription": "https://fonts.google.com/specimen/Eagle+Lake",
-      "enum": [
-        "Eagle Lake"
-      ]
+      "const": "Eagle Lake"
     },
     {
       "title": "East Sea Dokdo",
       "markdownDescription": "https://fonts.google.com/specimen/East+Sea+Dokdo",
-      "enum": [
-        "East Sea Dokdo"
-      ]
+      "const": "East Sea Dokdo"
     },
     {
       "title": "Eater",
       "markdownDescription": "https://fonts.google.com/specimen/Eater",
-      "enum": [
-        "Eater"
-      ]
+      "const": "Eater"
     },
     {
       "title": "Economica",
       "markdownDescription": "https://fonts.google.com/specimen/Economica",
-      "enum": [
-        "Economica"
-      ]
+      "const": "Economica"
     },
     {
       "title": "Eczar",
       "markdownDescription": "https://fonts.google.com/specimen/Eczar",
-      "enum": [
-        "Eczar"
-      ]
+      "const": "Eczar"
     },
     {
       "title": "Edu NSW ACT Foundation",
       "markdownDescription": "https://fonts.google.com/specimen/Edu+NSW+ACT+Foundation",
-      "enum": [
-        "Edu NSW ACT Foundation"
-      ]
+      "const": "Edu NSW ACT Foundation"
     },
     {
       "title": "Edu QLD Beginner",
       "markdownDescription": "https://fonts.google.com/specimen/Edu+QLD+Beginner",
-      "enum": [
-        "Edu QLD Beginner"
-      ]
+      "const": "Edu QLD Beginner"
     },
     {
       "title": "Edu SA Beginner",
       "markdownDescription": "https://fonts.google.com/specimen/Edu+SA+Beginner",
-      "enum": [
-        "Edu SA Beginner"
-      ]
+      "const": "Edu SA Beginner"
     },
     {
       "title": "Edu TAS Beginner",
       "markdownDescription": "https://fonts.google.com/specimen/Edu+TAS+Beginner",
-      "enum": [
-        "Edu TAS Beginner"
-      ]
+      "const": "Edu TAS Beginner"
     },
     {
       "title": "Edu VIC WA NT Beginner",
       "markdownDescription": "https://fonts.google.com/specimen/Edu+VIC+WA+NT+Beginner",
-      "enum": [
-        "Edu VIC WA NT Beginner"
-      ]
+      "const": "Edu VIC WA NT Beginner"
     },
     {
       "title": "El Messiri",
       "markdownDescription": "https://fonts.google.com/specimen/El+Messiri",
-      "enum": [
-        "El Messiri"
-      ]
+      "const": "El Messiri"
     },
     {
       "title": "Electrolize",
       "markdownDescription": "https://fonts.google.com/specimen/Electrolize",
-      "enum": [
-        "Electrolize"
-      ]
+      "const": "Electrolize"
     },
     {
       "title": "Elsie",
       "markdownDescription": "https://fonts.google.com/specimen/Elsie",
-      "enum": [
-        "Elsie"
-      ]
+      "const": "Elsie"
     },
     {
       "title": "Elsie Swash Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Elsie+Swash+Caps",
-      "enum": [
-        "Elsie Swash Caps"
-      ]
+      "const": "Elsie Swash Caps"
     },
     {
       "title": "Emblema One",
       "markdownDescription": "https://fonts.google.com/specimen/Emblema+One",
-      "enum": [
-        "Emblema One"
-      ]
+      "const": "Emblema One"
     },
     {
       "title": "Emilys Candy",
       "markdownDescription": "https://fonts.google.com/specimen/Emilys+Candy",
-      "enum": [
-        "Emilys Candy"
-      ]
+      "const": "Emilys Candy"
     },
     {
       "title": "Encode Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans",
-      "enum": [
-        "Encode Sans"
-      ]
+      "const": "Encode Sans"
     },
     {
       "title": "Encode Sans Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans+Condensed",
-      "enum": [
-        "Encode Sans Condensed"
-      ]
+      "const": "Encode Sans Condensed"
     },
     {
       "title": "Encode Sans Expanded",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans+Expanded",
-      "enum": [
-        "Encode Sans Expanded"
-      ]
+      "const": "Encode Sans Expanded"
     },
     {
       "title": "Encode Sans SC",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans+SC",
-      "enum": [
-        "Encode Sans SC"
-      ]
+      "const": "Encode Sans SC"
     },
     {
       "title": "Encode Sans Semi Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans+Semi+Condensed",
-      "enum": [
-        "Encode Sans Semi Condensed"
-      ]
+      "const": "Encode Sans Semi Condensed"
     },
     {
       "title": "Encode Sans Semi Expanded",
       "markdownDescription": "https://fonts.google.com/specimen/Encode+Sans+Semi+Expanded",
-      "enum": [
-        "Encode Sans Semi Expanded"
-      ]
+      "const": "Encode Sans Semi Expanded"
     },
     {
       "title": "Engagement",
       "markdownDescription": "https://fonts.google.com/specimen/Engagement",
-      "enum": [
-        "Engagement"
-      ]
+      "const": "Engagement"
     },
     {
       "title": "Englebert",
       "markdownDescription": "https://fonts.google.com/specimen/Englebert",
-      "enum": [
-        "Englebert"
-      ]
+      "const": "Englebert"
     },
     {
       "title": "Enriqueta",
       "markdownDescription": "https://fonts.google.com/specimen/Enriqueta",
-      "enum": [
-        "Enriqueta"
-      ]
+      "const": "Enriqueta"
     },
     {
       "title": "Ephesis",
       "markdownDescription": "https://fonts.google.com/specimen/Ephesis",
-      "enum": [
-        "Ephesis"
-      ]
+      "const": "Ephesis"
     },
     {
       "title": "Epilogue",
       "markdownDescription": "https://fonts.google.com/specimen/Epilogue",
-      "enum": [
-        "Epilogue"
-      ]
+      "const": "Epilogue"
     },
     {
       "title": "Erica One",
       "markdownDescription": "https://fonts.google.com/specimen/Erica+One",
-      "enum": [
-        "Erica One"
-      ]
+      "const": "Erica One"
     },
     {
       "title": "Esteban",
       "markdownDescription": "https://fonts.google.com/specimen/Esteban",
-      "enum": [
-        "Esteban"
-      ]
+      "const": "Esteban"
     },
     {
       "title": "Estonia",
       "markdownDescription": "https://fonts.google.com/specimen/Estonia",
-      "enum": [
-        "Estonia"
-      ]
+      "const": "Estonia"
     },
     {
       "title": "Euphoria Script",
       "markdownDescription": "https://fonts.google.com/specimen/Euphoria+Script",
-      "enum": [
-        "Euphoria Script"
-      ]
+      "const": "Euphoria Script"
     },
     {
       "title": "Ewert",
       "markdownDescription": "https://fonts.google.com/specimen/Ewert",
-      "enum": [
-        "Ewert"
-      ]
+      "const": "Ewert"
     },
     {
       "title": "Exo",
       "markdownDescription": "https://fonts.google.com/specimen/Exo",
-      "enum": [
-        "Exo"
-      ]
+      "const": "Exo"
     },
     {
       "title": "Exo 2",
       "markdownDescription": "https://fonts.google.com/specimen/Exo+2",
-      "enum": [
-        "Exo 2"
-      ]
+      "const": "Exo 2"
     },
     {
       "title": "Expletus Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Expletus+Sans",
-      "enum": [
-        "Expletus Sans"
-      ]
+      "const": "Expletus Sans"
     },
     {
       "title": "Explora",
       "markdownDescription": "https://fonts.google.com/specimen/Explora",
-      "enum": [
-        "Explora"
-      ]
+      "const": "Explora"
     },
     {
       "title": "Fahkwang",
       "markdownDescription": "https://fonts.google.com/specimen/Fahkwang",
-      "enum": [
-        "Fahkwang"
-      ]
+      "const": "Fahkwang"
     },
     {
       "title": "Familjen Grotesk",
       "markdownDescription": "https://fonts.google.com/specimen/Familjen+Grotesk",
-      "enum": [
-        "Familjen Grotesk"
-      ]
+      "const": "Familjen Grotesk"
     },
     {
       "title": "Fanwood Text",
       "markdownDescription": "https://fonts.google.com/specimen/Fanwood+Text",
-      "enum": [
-        "Fanwood Text"
-      ]
+      "const": "Fanwood Text"
     },
     {
       "title": "Farro",
       "markdownDescription": "https://fonts.google.com/specimen/Farro",
-      "enum": [
-        "Farro"
-      ]
+      "const": "Farro"
     },
     {
       "title": "Farsan",
       "markdownDescription": "https://fonts.google.com/specimen/Farsan",
-      "enum": [
-        "Farsan"
-      ]
+      "const": "Farsan"
     },
     {
       "title": "Fascinate",
       "markdownDescription": "https://fonts.google.com/specimen/Fascinate",
-      "enum": [
-        "Fascinate"
-      ]
+      "const": "Fascinate"
     },
     {
       "title": "Fascinate Inline",
       "markdownDescription": "https://fonts.google.com/specimen/Fascinate+Inline",
-      "enum": [
-        "Fascinate Inline"
-      ]
+      "const": "Fascinate Inline"
     },
     {
       "title": "Faster One",
       "markdownDescription": "https://fonts.google.com/specimen/Faster+One",
-      "enum": [
-        "Faster One"
-      ]
+      "const": "Faster One"
     },
     {
       "title": "Fasthand",
       "markdownDescription": "https://fonts.google.com/specimen/Fasthand",
-      "enum": [
-        "Fasthand"
-      ]
+      "const": "Fasthand"
     },
     {
       "title": "Fauna One",
       "markdownDescription": "https://fonts.google.com/specimen/Fauna+One",
-      "enum": [
-        "Fauna One"
-      ]
+      "const": "Fauna One"
     },
     {
       "title": "Faustina",
       "markdownDescription": "https://fonts.google.com/specimen/Faustina",
-      "enum": [
-        "Faustina"
-      ]
+      "const": "Faustina"
     },
     {
       "title": "Federant",
       "markdownDescription": "https://fonts.google.com/specimen/Federant",
-      "enum": [
-        "Federant"
-      ]
+      "const": "Federant"
     },
     {
       "title": "Federo",
       "markdownDescription": "https://fonts.google.com/specimen/Federo",
-      "enum": [
-        "Federo"
-      ]
+      "const": "Federo"
     },
     {
       "title": "Felipa",
       "markdownDescription": "https://fonts.google.com/specimen/Felipa",
-      "enum": [
-        "Felipa"
-      ]
+      "const": "Felipa"
     },
     {
       "title": "Fenix",
       "markdownDescription": "https://fonts.google.com/specimen/Fenix",
-      "enum": [
-        "Fenix"
-      ]
+      "const": "Fenix"
     },
     {
       "title": "Festive",
       "markdownDescription": "https://fonts.google.com/specimen/Festive",
-      "enum": [
-        "Festive"
-      ]
+      "const": "Festive"
     },
     {
       "title": "Figtree",
       "markdownDescription": "https://fonts.google.com/specimen/Figtree",
-      "enum": [
-        "Figtree"
-      ]
+      "const": "Figtree"
     },
     {
       "title": "Finger Paint",
       "markdownDescription": "https://fonts.google.com/specimen/Finger+Paint",
-      "enum": [
-        "Finger Paint"
-      ]
+      "const": "Finger Paint"
     },
     {
       "title": "Finlandica",
       "markdownDescription": "https://fonts.google.com/specimen/Finlandica",
-      "enum": [
-        "Finlandica"
-      ]
+      "const": "Finlandica"
     },
     {
       "title": "Fira Code",
       "markdownDescription": "https://fonts.google.com/specimen/Fira+Code",
-      "enum": [
-        "Fira Code"
-      ]
+      "const": "Fira Code"
     },
     {
       "title": "Fira Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Fira+Mono",
-      "enum": [
-        "Fira Mono"
-      ]
+      "const": "Fira Mono"
     },
     {
       "title": "Fira Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Fira+Sans",
-      "enum": [
-        "Fira Sans"
-      ]
+      "const": "Fira Sans"
     },
     {
       "title": "Fira Sans Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Fira+Sans+Condensed",
-      "enum": [
-        "Fira Sans Condensed"
-      ]
+      "const": "Fira Sans Condensed"
     },
     {
       "title": "Fira Sans Extra Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Fira+Sans+Extra+Condensed",
-      "enum": [
-        "Fira Sans Extra Condensed"
-      ]
+      "const": "Fira Sans Extra Condensed"
     },
     {
       "title": "Fjalla One",
       "markdownDescription": "https://fonts.google.com/specimen/Fjalla+One",
-      "enum": [
-        "Fjalla One"
-      ]
+      "const": "Fjalla One"
     },
     {
       "title": "Fjord One",
       "markdownDescription": "https://fonts.google.com/specimen/Fjord+One",
-      "enum": [
-        "Fjord One"
-      ]
+      "const": "Fjord One"
     },
     {
       "title": "Flamenco",
       "markdownDescription": "https://fonts.google.com/specimen/Flamenco",
-      "enum": [
-        "Flamenco"
-      ]
+      "const": "Flamenco"
     },
     {
       "title": "Flavors",
       "markdownDescription": "https://fonts.google.com/specimen/Flavors",
-      "enum": [
-        "Flavors"
-      ]
+      "const": "Flavors"
     },
     {
       "title": "Fleur De Leah",
       "markdownDescription": "https://fonts.google.com/specimen/Fleur+De+Leah",
-      "enum": [
-        "Fleur De Leah"
-      ]
+      "const": "Fleur De Leah"
     },
     {
       "title": "Flow Block",
       "markdownDescription": "https://fonts.google.com/specimen/Flow+Block",
-      "enum": [
-        "Flow Block"
-      ]
+      "const": "Flow Block"
     },
     {
       "title": "Flow Circular",
       "markdownDescription": "https://fonts.google.com/specimen/Flow+Circular",
-      "enum": [
-        "Flow Circular"
-      ]
+      "const": "Flow Circular"
     },
     {
       "title": "Flow Rounded",
       "markdownDescription": "https://fonts.google.com/specimen/Flow+Rounded",
-      "enum": [
-        "Flow Rounded"
-      ]
+      "const": "Flow Rounded"
     },
     {
       "title": "Foldit",
       "markdownDescription": "https://fonts.google.com/specimen/Foldit",
-      "enum": [
-        "Foldit"
-      ]
+      "const": "Foldit"
     },
     {
       "title": "Fondamento",
       "markdownDescription": "https://fonts.google.com/specimen/Fondamento",
-      "enum": [
-        "Fondamento"
-      ]
+      "const": "Fondamento"
     },
     {
       "title": "Fontdiner Swanky",
       "markdownDescription": "https://fonts.google.com/specimen/Fontdiner+Swanky",
-      "enum": [
-        "Fontdiner Swanky"
-      ]
+      "const": "Fontdiner Swanky"
     },
     {
       "title": "Forum",
       "markdownDescription": "https://fonts.google.com/specimen/Forum",
-      "enum": [
-        "Forum"
-      ]
+      "const": "Forum"
     },
     {
       "title": "Fragment Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Fragment+Mono",
-      "enum": [
-        "Fragment Mono"
-      ]
+      "const": "Fragment Mono"
     },
     {
       "title": "Francois One",
       "markdownDescription": "https://fonts.google.com/specimen/Francois+One",
-      "enum": [
-        "Francois One"
-      ]
+      "const": "Francois One"
     },
     {
       "title": "Frank Ruhl Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Frank+Ruhl+Libre",
-      "enum": [
-        "Frank Ruhl Libre"
-      ]
+      "const": "Frank Ruhl Libre"
     },
     {
       "title": "Fraunces",
       "markdownDescription": "https://fonts.google.com/specimen/Fraunces",
-      "enum": [
-        "Fraunces"
-      ]
+      "const": "Fraunces"
     },
     {
       "title": "Freckle Face",
       "markdownDescription": "https://fonts.google.com/specimen/Freckle+Face",
-      "enum": [
-        "Freckle Face"
-      ]
+      "const": "Freckle Face"
     },
     {
       "title": "Fredericka the Great",
       "markdownDescription": "https://fonts.google.com/specimen/Fredericka+the+Great",
-      "enum": [
-        "Fredericka the Great"
-      ]
+      "const": "Fredericka the Great"
     },
     {
       "title": "Fredoka",
       "markdownDescription": "https://fonts.google.com/specimen/Fredoka",
-      "enum": [
-        "Fredoka"
-      ]
+      "const": "Fredoka"
     },
     {
       "title": "Freehand",
       "markdownDescription": "https://fonts.google.com/specimen/Freehand",
-      "enum": [
-        "Freehand"
-      ]
+      "const": "Freehand"
     },
     {
       "title": "Fresca",
       "markdownDescription": "https://fonts.google.com/specimen/Fresca",
-      "enum": [
-        "Fresca"
-      ]
+      "const": "Fresca"
     },
     {
       "title": "Frijole",
       "markdownDescription": "https://fonts.google.com/specimen/Frijole",
-      "enum": [
-        "Frijole"
-      ]
+      "const": "Frijole"
     },
     {
       "title": "Fruktur",
       "markdownDescription": "https://fonts.google.com/specimen/Fruktur",
-      "enum": [
-        "Fruktur"
-      ]
+      "const": "Fruktur"
     },
     {
       "title": "Fugaz One",
       "markdownDescription": "https://fonts.google.com/specimen/Fugaz+One",
-      "enum": [
-        "Fugaz One"
-      ]
+      "const": "Fugaz One"
     },
     {
       "title": "Fuggles",
       "markdownDescription": "https://fonts.google.com/specimen/Fuggles",
-      "enum": [
-        "Fuggles"
-      ]
+      "const": "Fuggles"
     },
     {
       "title": "Fuzzy Bubbles",
       "markdownDescription": "https://fonts.google.com/specimen/Fuzzy+Bubbles",
-      "enum": [
-        "Fuzzy Bubbles"
-      ]
+      "const": "Fuzzy Bubbles"
     },
     {
       "title": "GFS Didot",
       "markdownDescription": "https://fonts.google.com/specimen/GFS+Didot",
-      "enum": [
-        "GFS Didot"
-      ]
+      "const": "GFS Didot"
     },
     {
       "title": "GFS Neohellenic",
       "markdownDescription": "https://fonts.google.com/specimen/GFS+Neohellenic",
-      "enum": [
-        "GFS Neohellenic"
-      ]
+      "const": "GFS Neohellenic"
     },
     {
       "title": "Gabarito",
       "markdownDescription": "https://fonts.google.com/specimen/Gabarito",
-      "enum": [
-        "Gabarito"
-      ]
+      "const": "Gabarito"
     },
     {
       "title": "Gabriela",
       "markdownDescription": "https://fonts.google.com/specimen/Gabriela",
-      "enum": [
-        "Gabriela"
-      ]
+      "const": "Gabriela"
     },
     {
       "title": "Gaegu",
       "markdownDescription": "https://fonts.google.com/specimen/Gaegu",
-      "enum": [
-        "Gaegu"
-      ]
+      "const": "Gaegu"
     },
     {
       "title": "Gafata",
       "markdownDescription": "https://fonts.google.com/specimen/Gafata",
-      "enum": [
-        "Gafata"
-      ]
+      "const": "Gafata"
     },
     {
       "title": "Gajraj One",
       "markdownDescription": "https://fonts.google.com/specimen/Gajraj+One",
-      "enum": [
-        "Gajraj One"
-      ]
+      "const": "Gajraj One"
     },
     {
       "title": "Galada",
       "markdownDescription": "https://fonts.google.com/specimen/Galada",
-      "enum": [
-        "Galada"
-      ]
+      "const": "Galada"
     },
     {
       "title": "Galdeano",
       "markdownDescription": "https://fonts.google.com/specimen/Galdeano",
-      "enum": [
-        "Galdeano"
-      ]
+      "const": "Galdeano"
     },
     {
       "title": "Galindo",
       "markdownDescription": "https://fonts.google.com/specimen/Galindo",
-      "enum": [
-        "Galindo"
-      ]
+      "const": "Galindo"
     },
     {
       "title": "Gamja Flower",
       "markdownDescription": "https://fonts.google.com/specimen/Gamja+Flower",
-      "enum": [
-        "Gamja Flower"
-      ]
+      "const": "Gamja Flower"
     },
     {
       "title": "Gantari",
       "markdownDescription": "https://fonts.google.com/specimen/Gantari",
-      "enum": [
-        "Gantari"
-      ]
+      "const": "Gantari"
     },
     {
       "title": "Gasoek One",
       "markdownDescription": "https://fonts.google.com/specimen/Gasoek+One",
-      "enum": [
-        "Gasoek One"
-      ]
+      "const": "Gasoek One"
     },
     {
       "title": "Gayathri",
       "markdownDescription": "https://fonts.google.com/specimen/Gayathri",
-      "enum": [
-        "Gayathri"
-      ]
+      "const": "Gayathri"
     },
     {
       "title": "Gelasio",
       "markdownDescription": "https://fonts.google.com/specimen/Gelasio",
-      "enum": [
-        "Gelasio"
-      ]
+      "const": "Gelasio"
     },
     {
       "title": "Gemunu Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Gemunu+Libre",
-      "enum": [
-        "Gemunu Libre"
-      ]
+      "const": "Gemunu Libre"
     },
     {
       "title": "Genos",
       "markdownDescription": "https://fonts.google.com/specimen/Genos",
-      "enum": [
-        "Genos"
-      ]
+      "const": "Genos"
     },
     {
       "title": "Gentium Book Plus",
       "markdownDescription": "https://fonts.google.com/specimen/Gentium+Book+Plus",
-      "enum": [
-        "Gentium Book Plus"
-      ]
+      "const": "Gentium Book Plus"
     },
     {
       "title": "Gentium Plus",
       "markdownDescription": "https://fonts.google.com/specimen/Gentium+Plus",
-      "enum": [
-        "Gentium Plus"
-      ]
+      "const": "Gentium Plus"
     },
     {
       "title": "Geo",
       "markdownDescription": "https://fonts.google.com/specimen/Geo",
-      "enum": [
-        "Geo"
-      ]
+      "const": "Geo"
     },
     {
       "title": "Geologica",
       "markdownDescription": "https://fonts.google.com/specimen/Geologica",
-      "enum": [
-        "Geologica"
-      ]
+      "const": "Geologica"
     },
     {
       "title": "Georama",
       "markdownDescription": "https://fonts.google.com/specimen/Georama",
-      "enum": [
-        "Georama"
-      ]
+      "const": "Georama"
     },
     {
       "title": "Geostar",
       "markdownDescription": "https://fonts.google.com/specimen/Geostar",
-      "enum": [
-        "Geostar"
-      ]
+      "const": "Geostar"
     },
     {
       "title": "Geostar Fill",
       "markdownDescription": "https://fonts.google.com/specimen/Geostar+Fill",
-      "enum": [
-        "Geostar Fill"
-      ]
+      "const": "Geostar Fill"
     },
     {
       "title": "Germania One",
       "markdownDescription": "https://fonts.google.com/specimen/Germania+One",
-      "enum": [
-        "Germania One"
-      ]
+      "const": "Germania One"
     },
     {
       "title": "Gideon Roman",
       "markdownDescription": "https://fonts.google.com/specimen/Gideon+Roman",
-      "enum": [
-        "Gideon Roman"
-      ]
+      "const": "Gideon Roman"
     },
     {
       "title": "Gidugu",
       "markdownDescription": "https://fonts.google.com/specimen/Gidugu",
-      "enum": [
-        "Gidugu"
-      ]
+      "const": "Gidugu"
     },
     {
       "title": "Gilda Display",
       "markdownDescription": "https://fonts.google.com/specimen/Gilda+Display",
-      "enum": [
-        "Gilda Display"
-      ]
+      "const": "Gilda Display"
     },
     {
       "title": "Girassol",
       "markdownDescription": "https://fonts.google.com/specimen/Girassol",
-      "enum": [
-        "Girassol"
-      ]
+      "const": "Girassol"
     },
     {
       "title": "Give You Glory",
       "markdownDescription": "https://fonts.google.com/specimen/Give+You+Glory",
-      "enum": [
-        "Give You Glory"
-      ]
+      "const": "Give You Glory"
     },
     {
       "title": "Glass Antiqua",
       "markdownDescription": "https://fonts.google.com/specimen/Glass+Antiqua",
-      "enum": [
-        "Glass Antiqua"
-      ]
+      "const": "Glass Antiqua"
     },
     {
       "title": "Glegoo",
       "markdownDescription": "https://fonts.google.com/specimen/Glegoo",
-      "enum": [
-        "Glegoo"
-      ]
+      "const": "Glegoo"
     },
     {
       "title": "Gloock",
       "markdownDescription": "https://fonts.google.com/specimen/Gloock",
-      "enum": [
-        "Gloock"
-      ]
+      "const": "Gloock"
     },
     {
       "title": "Gloria Hallelujah",
       "markdownDescription": "https://fonts.google.com/specimen/Gloria+Hallelujah",
-      "enum": [
-        "Gloria Hallelujah"
-      ]
+      "const": "Gloria Hallelujah"
     },
     {
       "title": "Glory",
       "markdownDescription": "https://fonts.google.com/specimen/Glory",
-      "enum": [
-        "Glory"
-      ]
+      "const": "Glory"
     },
     {
       "title": "Gluten",
       "markdownDescription": "https://fonts.google.com/specimen/Gluten",
-      "enum": [
-        "Gluten"
-      ]
+      "const": "Gluten"
     },
     {
       "title": "Goblin One",
       "markdownDescription": "https://fonts.google.com/specimen/Goblin+One",
-      "enum": [
-        "Goblin One"
-      ]
+      "const": "Goblin One"
     },
     {
       "title": "Gochi Hand",
       "markdownDescription": "https://fonts.google.com/specimen/Gochi+Hand",
-      "enum": [
-        "Gochi Hand"
-      ]
+      "const": "Gochi Hand"
     },
     {
       "title": "Goldman",
       "markdownDescription": "https://fonts.google.com/specimen/Goldman",
-      "enum": [
-        "Goldman"
-      ]
+      "const": "Goldman"
     },
     {
       "title": "Golos Text",
       "markdownDescription": "https://fonts.google.com/specimen/Golos+Text",
-      "enum": [
-        "Golos Text"
-      ]
+      "const": "Golos Text"
     },
     {
       "title": "Gorditas",
       "markdownDescription": "https://fonts.google.com/specimen/Gorditas",
-      "enum": [
-        "Gorditas"
-      ]
+      "const": "Gorditas"
     },
     {
       "title": "Gothic A1",
       "markdownDescription": "https://fonts.google.com/specimen/Gothic+A1",
-      "enum": [
-        "Gothic A1"
-      ]
+      "const": "Gothic A1"
     },
     {
       "title": "Gotu",
       "markdownDescription": "https://fonts.google.com/specimen/Gotu",
-      "enum": [
-        "Gotu"
-      ]
+      "const": "Gotu"
     },
     {
       "title": "Goudy Bookletter 1911",
       "markdownDescription": "https://fonts.google.com/specimen/Goudy+Bookletter+1911",
-      "enum": [
-        "Goudy Bookletter 1911"
-      ]
+      "const": "Goudy Bookletter 1911"
     },
     {
       "title": "Gowun Batang",
       "markdownDescription": "https://fonts.google.com/specimen/Gowun+Batang",
-      "enum": [
-        "Gowun Batang"
-      ]
+      "const": "Gowun Batang"
     },
     {
       "title": "Gowun Dodum",
       "markdownDescription": "https://fonts.google.com/specimen/Gowun+Dodum",
-      "enum": [
-        "Gowun Dodum"
-      ]
+      "const": "Gowun Dodum"
     },
     {
       "title": "Graduate",
       "markdownDescription": "https://fonts.google.com/specimen/Graduate",
-      "enum": [
-        "Graduate"
-      ]
+      "const": "Graduate"
     },
     {
       "title": "Grand Hotel",
       "markdownDescription": "https://fonts.google.com/specimen/Grand+Hotel",
-      "enum": [
-        "Grand Hotel"
-      ]
+      "const": "Grand Hotel"
     },
     {
       "title": "Grandiflora One",
       "markdownDescription": "https://fonts.google.com/specimen/Grandiflora+One",
-      "enum": [
-        "Grandiflora One"
-      ]
+      "const": "Grandiflora One"
     },
     {
       "title": "Grandstander",
       "markdownDescription": "https://fonts.google.com/specimen/Grandstander",
-      "enum": [
-        "Grandstander"
-      ]
+      "const": "Grandstander"
     },
     {
       "title": "Grape Nuts",
       "markdownDescription": "https://fonts.google.com/specimen/Grape+Nuts",
-      "enum": [
-        "Grape Nuts"
-      ]
+      "const": "Grape Nuts"
     },
     {
       "title": "Gravitas One",
       "markdownDescription": "https://fonts.google.com/specimen/Gravitas+One",
-      "enum": [
-        "Gravitas One"
-      ]
+      "const": "Gravitas One"
     },
     {
       "title": "Great Vibes",
       "markdownDescription": "https://fonts.google.com/specimen/Great+Vibes",
-      "enum": [
-        "Great Vibes"
-      ]
+      "const": "Great Vibes"
     },
     {
       "title": "Grechen Fuemen",
       "markdownDescription": "https://fonts.google.com/specimen/Grechen+Fuemen",
-      "enum": [
-        "Grechen Fuemen"
-      ]
+      "const": "Grechen Fuemen"
     },
     {
       "title": "Grenze",
       "markdownDescription": "https://fonts.google.com/specimen/Grenze",
-      "enum": [
-        "Grenze"
-      ]
+      "const": "Grenze"
     },
     {
       "title": "Grenze Gotisch",
       "markdownDescription": "https://fonts.google.com/specimen/Grenze+Gotisch",
-      "enum": [
-        "Grenze Gotisch"
-      ]
+      "const": "Grenze Gotisch"
     },
     {
       "title": "Grey Qo",
       "markdownDescription": "https://fonts.google.com/specimen/Grey+Qo",
-      "enum": [
-        "Grey Qo"
-      ]
+      "const": "Grey Qo"
     },
     {
       "title": "Griffy",
       "markdownDescription": "https://fonts.google.com/specimen/Griffy",
-      "enum": [
-        "Griffy"
-      ]
+      "const": "Griffy"
     },
     {
       "title": "Gruppo",
       "markdownDescription": "https://fonts.google.com/specimen/Gruppo",
-      "enum": [
-        "Gruppo"
-      ]
+      "const": "Gruppo"
     },
     {
       "title": "Gudea",
       "markdownDescription": "https://fonts.google.com/specimen/Gudea",
-      "enum": [
-        "Gudea"
-      ]
+      "const": "Gudea"
     },
     {
       "title": "Gugi",
       "markdownDescription": "https://fonts.google.com/specimen/Gugi",
-      "enum": [
-        "Gugi"
-      ]
+      "const": "Gugi"
     },
     {
       "title": "Gulzar",
       "markdownDescription": "https://fonts.google.com/specimen/Gulzar",
-      "enum": [
-        "Gulzar"
-      ]
+      "const": "Gulzar"
     },
     {
       "title": "Gupter",
       "markdownDescription": "https://fonts.google.com/specimen/Gupter",
-      "enum": [
-        "Gupter"
-      ]
+      "const": "Gupter"
     },
     {
       "title": "Gurajada",
       "markdownDescription": "https://fonts.google.com/specimen/Gurajada",
-      "enum": [
-        "Gurajada"
-      ]
+      "const": "Gurajada"
     },
     {
       "title": "Gwendolyn",
       "markdownDescription": "https://fonts.google.com/specimen/Gwendolyn",
-      "enum": [
-        "Gwendolyn"
-      ]
+      "const": "Gwendolyn"
     },
     {
       "title": "Habibi",
       "markdownDescription": "https://fonts.google.com/specimen/Habibi",
-      "enum": [
-        "Habibi"
-      ]
+      "const": "Habibi"
     },
     {
       "title": "Hachi Maru Pop",
       "markdownDescription": "https://fonts.google.com/specimen/Hachi+Maru+Pop",
-      "enum": [
-        "Hachi Maru Pop"
-      ]
+      "const": "Hachi Maru Pop"
     },
     {
       "title": "Hahmlet",
       "markdownDescription": "https://fonts.google.com/specimen/Hahmlet",
-      "enum": [
-        "Hahmlet"
-      ]
+      "const": "Hahmlet"
     },
     {
       "title": "Halant",
       "markdownDescription": "https://fonts.google.com/specimen/Halant",
-      "enum": [
-        "Halant"
-      ]
+      "const": "Halant"
     },
     {
       "title": "Hammersmith One",
       "markdownDescription": "https://fonts.google.com/specimen/Hammersmith+One",
-      "enum": [
-        "Hammersmith One"
-      ]
+      "const": "Hammersmith One"
     },
     {
       "title": "Hanalei",
       "markdownDescription": "https://fonts.google.com/specimen/Hanalei",
-      "enum": [
-        "Hanalei"
-      ]
+      "const": "Hanalei"
     },
     {
       "title": "Hanalei Fill",
       "markdownDescription": "https://fonts.google.com/specimen/Hanalei+Fill",
-      "enum": [
-        "Hanalei Fill"
-      ]
+      "const": "Hanalei Fill"
     },
     {
       "title": "Handjet",
       "markdownDescription": "https://fonts.google.com/specimen/Handjet",
-      "enum": [
-        "Handjet"
-      ]
+      "const": "Handjet"
     },
     {
       "title": "Handlee",
       "markdownDescription": "https://fonts.google.com/specimen/Handlee",
-      "enum": [
-        "Handlee"
-      ]
+      "const": "Handlee"
     },
     {
       "title": "Hanken Grotesk",
       "markdownDescription": "https://fonts.google.com/specimen/Hanken+Grotesk",
-      "enum": [
-        "Hanken Grotesk"
-      ]
+      "const": "Hanken Grotesk"
     },
     {
       "title": "Hanuman",
       "markdownDescription": "https://fonts.google.com/specimen/Hanuman",
-      "enum": [
-        "Hanuman"
-      ]
+      "const": "Hanuman"
     },
     {
       "title": "Happy Monkey",
       "markdownDescription": "https://fonts.google.com/specimen/Happy+Monkey",
-      "enum": [
-        "Happy Monkey"
-      ]
+      "const": "Happy Monkey"
     },
     {
       "title": "Harmattan",
       "markdownDescription": "https://fonts.google.com/specimen/Harmattan",
-      "enum": [
-        "Harmattan"
-      ]
+      "const": "Harmattan"
     },
     {
       "title": "Headland One",
       "markdownDescription": "https://fonts.google.com/specimen/Headland+One",
-      "enum": [
-        "Headland One"
-      ]
+      "const": "Headland One"
     },
     {
       "title": "Heebo",
       "markdownDescription": "https://fonts.google.com/specimen/Heebo",
-      "enum": [
-        "Heebo"
-      ]
+      "const": "Heebo"
     },
     {
       "title": "Henny Penny",
       "markdownDescription": "https://fonts.google.com/specimen/Henny+Penny",
-      "enum": [
-        "Henny Penny"
-      ]
+      "const": "Henny Penny"
     },
     {
       "title": "Hepta Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Hepta+Slab",
-      "enum": [
-        "Hepta Slab"
-      ]
+      "const": "Hepta Slab"
     },
     {
       "title": "Herr Von Muellerhoff",
       "markdownDescription": "https://fonts.google.com/specimen/Herr+Von+Muellerhoff",
-      "enum": [
-        "Herr Von Muellerhoff"
-      ]
+      "const": "Herr Von Muellerhoff"
     },
     {
       "title": "Hi Melody",
       "markdownDescription": "https://fonts.google.com/specimen/Hi+Melody",
-      "enum": [
-        "Hi Melody"
-      ]
+      "const": "Hi Melody"
     },
     {
       "title": "Hina Mincho",
       "markdownDescription": "https://fonts.google.com/specimen/Hina+Mincho",
-      "enum": [
-        "Hina Mincho"
-      ]
+      "const": "Hina Mincho"
     },
     {
       "title": "Hind",
       "markdownDescription": "https://fonts.google.com/specimen/Hind",
-      "enum": [
-        "Hind"
-      ]
+      "const": "Hind"
     },
     {
       "title": "Hind Guntur",
       "markdownDescription": "https://fonts.google.com/specimen/Hind+Guntur",
-      "enum": [
-        "Hind Guntur"
-      ]
+      "const": "Hind Guntur"
     },
     {
       "title": "Hind Madurai",
       "markdownDescription": "https://fonts.google.com/specimen/Hind+Madurai",
-      "enum": [
-        "Hind Madurai"
-      ]
+      "const": "Hind Madurai"
     },
     {
       "title": "Hind Siliguri",
       "markdownDescription": "https://fonts.google.com/specimen/Hind+Siliguri",
-      "enum": [
-        "Hind Siliguri"
-      ]
+      "const": "Hind Siliguri"
     },
     {
       "title": "Hind Vadodara",
       "markdownDescription": "https://fonts.google.com/specimen/Hind+Vadodara",
-      "enum": [
-        "Hind Vadodara"
-      ]
+      "const": "Hind Vadodara"
     },
     {
       "title": "Holtwood One SC",
       "markdownDescription": "https://fonts.google.com/specimen/Holtwood+One+SC",
-      "enum": [
-        "Holtwood One SC"
-      ]
+      "const": "Holtwood One SC"
     },
     {
       "title": "Homemade Apple",
       "markdownDescription": "https://fonts.google.com/specimen/Homemade+Apple",
-      "enum": [
-        "Homemade Apple"
-      ]
+      "const": "Homemade Apple"
     },
     {
       "title": "Homenaje",
       "markdownDescription": "https://fonts.google.com/specimen/Homenaje",
-      "enum": [
-        "Homenaje"
-      ]
+      "const": "Homenaje"
     },
     {
       "title": "Hubballi",
       "markdownDescription": "https://fonts.google.com/specimen/Hubballi",
-      "enum": [
-        "Hubballi"
-      ]
+      "const": "Hubballi"
     },
     {
       "title": "Hurricane",
       "markdownDescription": "https://fonts.google.com/specimen/Hurricane",
-      "enum": [
-        "Hurricane"
-      ]
+      "const": "Hurricane"
     },
     {
       "title": "IBM Plex Mono",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Mono",
-      "enum": [
-        "IBM Plex Mono"
-      ]
+      "const": "IBM Plex Mono"
     },
     {
       "title": "IBM Plex Sans",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans",
-      "enum": [
-        "IBM Plex Sans"
-      ]
+      "const": "IBM Plex Sans"
     },
     {
       "title": "IBM Plex Sans Arabic",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Arabic",
-      "enum": [
-        "IBM Plex Sans Arabic"
-      ]
+      "const": "IBM Plex Sans Arabic"
     },
     {
       "title": "IBM Plex Sans Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Condensed",
-      "enum": [
-        "IBM Plex Sans Condensed"
-      ]
+      "const": "IBM Plex Sans Condensed"
     },
     {
       "title": "IBM Plex Sans Devanagari",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Devanagari",
-      "enum": [
-        "IBM Plex Sans Devanagari"
-      ]
+      "const": "IBM Plex Sans Devanagari"
     },
     {
       "title": "IBM Plex Sans Hebrew",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Hebrew",
-      "enum": [
-        "IBM Plex Sans Hebrew"
-      ]
+      "const": "IBM Plex Sans Hebrew"
     },
     {
       "title": "IBM Plex Sans JP",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+JP",
-      "enum": [
-        "IBM Plex Sans JP"
-      ]
+      "const": "IBM Plex Sans JP"
     },
     {
       "title": "IBM Plex Sans KR",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+KR",
-      "enum": [
-        "IBM Plex Sans KR"
-      ]
+      "const": "IBM Plex Sans KR"
     },
     {
       "title": "IBM Plex Sans Thai",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Thai",
-      "enum": [
-        "IBM Plex Sans Thai"
-      ]
+      "const": "IBM Plex Sans Thai"
     },
     {
       "title": "IBM Plex Sans Thai Looped",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Sans+Thai+Looped",
-      "enum": [
-        "IBM Plex Sans Thai Looped"
-      ]
+      "const": "IBM Plex Sans Thai Looped"
     },
     {
       "title": "IBM Plex Serif",
       "markdownDescription": "https://fonts.google.com/specimen/IBM+Plex+Serif",
-      "enum": [
-        "IBM Plex Serif"
-      ]
+      "const": "IBM Plex Serif"
     },
     {
       "title": "IM Fell DW Pica",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+DW+Pica",
-      "enum": [
-        "IM Fell DW Pica"
-      ]
+      "const": "IM Fell DW Pica"
     },
     {
       "title": "IM Fell DW Pica SC",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+DW+Pica+SC",
-      "enum": [
-        "IM Fell DW Pica SC"
-      ]
+      "const": "IM Fell DW Pica SC"
     },
     {
       "title": "IM Fell Double Pica",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+Double+Pica",
-      "enum": [
-        "IM Fell Double Pica"
-      ]
+      "const": "IM Fell Double Pica"
     },
     {
       "title": "IM Fell Double Pica SC",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+Double+Pica+SC",
-      "enum": [
-        "IM Fell Double Pica SC"
-      ]
+      "const": "IM Fell Double Pica SC"
     },
     {
       "title": "IM Fell English",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+English",
-      "enum": [
-        "IM Fell English"
-      ]
+      "const": "IM Fell English"
     },
     {
       "title": "IM Fell English SC",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+English+SC",
-      "enum": [
-        "IM Fell English SC"
-      ]
+      "const": "IM Fell English SC"
     },
     {
       "title": "IM Fell French Canon",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+French+Canon",
-      "enum": [
-        "IM Fell French Canon"
-      ]
+      "const": "IM Fell French Canon"
     },
     {
       "title": "IM Fell French Canon SC",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+French+Canon+SC",
-      "enum": [
-        "IM Fell French Canon SC"
-      ]
+      "const": "IM Fell French Canon SC"
     },
     {
       "title": "IM Fell Great Primer",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+Great+Primer",
-      "enum": [
-        "IM Fell Great Primer"
-      ]
+      "const": "IM Fell Great Primer"
     },
     {
       "title": "IM Fell Great Primer SC",
       "markdownDescription": "https://fonts.google.com/specimen/IM+Fell+Great+Primer+SC",
-      "enum": [
-        "IM Fell Great Primer SC"
-      ]
+      "const": "IM Fell Great Primer SC"
     },
     {
       "title": "Ibarra Real Nova",
       "markdownDescription": "https://fonts.google.com/specimen/Ibarra+Real+Nova",
-      "enum": [
-        "Ibarra Real Nova"
-      ]
+      "const": "Ibarra Real Nova"
     },
     {
       "title": "Iceberg",
       "markdownDescription": "https://fonts.google.com/specimen/Iceberg",
-      "enum": [
-        "Iceberg"
-      ]
+      "const": "Iceberg"
     },
     {
       "title": "Iceland",
       "markdownDescription": "https://fonts.google.com/specimen/Iceland",
-      "enum": [
-        "Iceland"
-      ]
+      "const": "Iceland"
     },
     {
       "title": "Imbue",
       "markdownDescription": "https://fonts.google.com/specimen/Imbue",
-      "enum": [
-        "Imbue"
-      ]
+      "const": "Imbue"
     },
     {
       "title": "Imperial Script",
       "markdownDescription": "https://fonts.google.com/specimen/Imperial+Script",
-      "enum": [
-        "Imperial Script"
-      ]
+      "const": "Imperial Script"
     },
     {
       "title": "Imprima",
       "markdownDescription": "https://fonts.google.com/specimen/Imprima",
-      "enum": [
-        "Imprima"
-      ]
+      "const": "Imprima"
     },
     {
       "title": "Inclusive Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Inclusive+Sans",
-      "enum": [
-        "Inclusive Sans"
-      ]
+      "const": "Inclusive Sans"
     },
     {
       "title": "Inconsolata",
       "markdownDescription": "https://fonts.google.com/specimen/Inconsolata",
-      "enum": [
-        "Inconsolata"
-      ]
+      "const": "Inconsolata"
     },
     {
       "title": "Inder",
       "markdownDescription": "https://fonts.google.com/specimen/Inder",
-      "enum": [
-        "Inder"
-      ]
+      "const": "Inder"
     },
     {
       "title": "Indie Flower",
       "markdownDescription": "https://fonts.google.com/specimen/Indie+Flower",
-      "enum": [
-        "Indie Flower"
-      ]
+      "const": "Indie Flower"
     },
     {
       "title": "Ingrid Darling",
       "markdownDescription": "https://fonts.google.com/specimen/Ingrid+Darling",
-      "enum": [
-        "Ingrid Darling"
-      ]
+      "const": "Ingrid Darling"
     },
     {
       "title": "Inika",
       "markdownDescription": "https://fonts.google.com/specimen/Inika",
-      "enum": [
-        "Inika"
-      ]
+      "const": "Inika"
     },
     {
       "title": "Inknut Antiqua",
       "markdownDescription": "https://fonts.google.com/specimen/Inknut+Antiqua",
-      "enum": [
-        "Inknut Antiqua"
-      ]
+      "const": "Inknut Antiqua"
     },
     {
       "title": "Inria Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Inria+Sans",
-      "enum": [
-        "Inria Sans"
-      ]
+      "const": "Inria Sans"
     },
     {
       "title": "Inria Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Inria+Serif",
-      "enum": [
-        "Inria Serif"
-      ]
+      "const": "Inria Serif"
     },
     {
       "title": "Inspiration",
       "markdownDescription": "https://fonts.google.com/specimen/Inspiration",
-      "enum": [
-        "Inspiration"
-      ]
+      "const": "Inspiration"
     },
     {
       "title": "Instrument Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Instrument+Sans",
-      "enum": [
-        "Instrument Sans"
-      ]
+      "const": "Instrument Sans"
     },
     {
       "title": "Instrument Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Instrument+Serif",
-      "enum": [
-        "Instrument Serif"
-      ]
+      "const": "Instrument Serif"
     },
     {
       "title": "Inter",
       "markdownDescription": "https://fonts.google.com/specimen/Inter",
-      "enum": [
-        "Inter"
-      ]
+      "const": "Inter"
     },
     {
       "title": "Inter Tight",
       "markdownDescription": "https://fonts.google.com/specimen/Inter+Tight",
-      "enum": [
-        "Inter Tight"
-      ]
+      "const": "Inter Tight"
     },
     {
       "title": "Irish Grover",
       "markdownDescription": "https://fonts.google.com/specimen/Irish+Grover",
-      "enum": [
-        "Irish Grover"
-      ]
+      "const": "Irish Grover"
     },
     {
       "title": "Island Moments",
       "markdownDescription": "https://fonts.google.com/specimen/Island+Moments",
-      "enum": [
-        "Island Moments"
-      ]
+      "const": "Island Moments"
     },
     {
       "title": "Istok Web",
       "markdownDescription": "https://fonts.google.com/specimen/Istok+Web",
-      "enum": [
-        "Istok Web"
-      ]
+      "const": "Istok Web"
     },
     {
       "title": "Italiana",
       "markdownDescription": "https://fonts.google.com/specimen/Italiana",
-      "enum": [
-        "Italiana"
-      ]
+      "const": "Italiana"
     },
     {
       "title": "Italianno",
       "markdownDescription": "https://fonts.google.com/specimen/Italianno",
-      "enum": [
-        "Italianno"
-      ]
+      "const": "Italianno"
     },
     {
       "title": "Itim",
       "markdownDescription": "https://fonts.google.com/specimen/Itim",
-      "enum": [
-        "Itim"
-      ]
+      "const": "Itim"
     },
     {
       "title": "Jacques Francois",
       "markdownDescription": "https://fonts.google.com/specimen/Jacques+Francois",
-      "enum": [
-        "Jacques Francois"
-      ]
+      "const": "Jacques Francois"
     },
     {
       "title": "Jacques Francois Shadow",
       "markdownDescription": "https://fonts.google.com/specimen/Jacques+Francois+Shadow",
-      "enum": [
-        "Jacques Francois Shadow"
-      ]
+      "const": "Jacques Francois Shadow"
     },
     {
       "title": "Jaldi",
       "markdownDescription": "https://fonts.google.com/specimen/Jaldi",
-      "enum": [
-        "Jaldi"
-      ]
+      "const": "Jaldi"
     },
     {
       "title": "JetBrains Mono",
       "markdownDescription": "https://fonts.google.com/specimen/JetBrains+Mono",
-      "enum": [
-        "JetBrains Mono"
-      ]
+      "const": "JetBrains Mono"
     },
     {
       "title": "Jim Nightshade",
       "markdownDescription": "https://fonts.google.com/specimen/Jim+Nightshade",
-      "enum": [
-        "Jim Nightshade"
-      ]
+      "const": "Jim Nightshade"
     },
     {
       "title": "Joan",
       "markdownDescription": "https://fonts.google.com/specimen/Joan",
-      "enum": [
-        "Joan"
-      ]
+      "const": "Joan"
     },
     {
       "title": "Jockey One",
       "markdownDescription": "https://fonts.google.com/specimen/Jockey+One",
-      "enum": [
-        "Jockey One"
-      ]
+      "const": "Jockey One"
     },
     {
       "title": "Jolly Lodger",
       "markdownDescription": "https://fonts.google.com/specimen/Jolly+Lodger",
-      "enum": [
-        "Jolly Lodger"
-      ]
+      "const": "Jolly Lodger"
     },
     {
       "title": "Jomhuria",
       "markdownDescription": "https://fonts.google.com/specimen/Jomhuria",
-      "enum": [
-        "Jomhuria"
-      ]
+      "const": "Jomhuria"
     },
     {
       "title": "Jomolhari",
       "markdownDescription": "https://fonts.google.com/specimen/Jomolhari",
-      "enum": [
-        "Jomolhari"
-      ]
+      "const": "Jomolhari"
     },
     {
       "title": "Josefin Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Josefin+Sans",
-      "enum": [
-        "Josefin Sans"
-      ]
+      "const": "Josefin Sans"
     },
     {
       "title": "Josefin Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Josefin+Slab",
-      "enum": [
-        "Josefin Slab"
-      ]
+      "const": "Josefin Slab"
     },
     {
       "title": "Jost",
       "markdownDescription": "https://fonts.google.com/specimen/Jost",
-      "enum": [
-        "Jost"
-      ]
+      "const": "Jost"
     },
     {
       "title": "Joti One",
       "markdownDescription": "https://fonts.google.com/specimen/Joti+One",
-      "enum": [
-        "Joti One"
-      ]
+      "const": "Joti One"
     },
     {
       "title": "Jua",
       "markdownDescription": "https://fonts.google.com/specimen/Jua",
-      "enum": [
-        "Jua"
-      ]
+      "const": "Jua"
     },
     {
       "title": "Judson",
       "markdownDescription": "https://fonts.google.com/specimen/Judson",
-      "enum": [
-        "Judson"
-      ]
+      "const": "Judson"
     },
     {
       "title": "Julee",
       "markdownDescription": "https://fonts.google.com/specimen/Julee",
-      "enum": [
-        "Julee"
-      ]
+      "const": "Julee"
     },
     {
       "title": "Julius Sans One",
       "markdownDescription": "https://fonts.google.com/specimen/Julius+Sans+One",
-      "enum": [
-        "Julius Sans One"
-      ]
+      "const": "Julius Sans One"
     },
     {
       "title": "Junge",
       "markdownDescription": "https://fonts.google.com/specimen/Junge",
-      "enum": [
-        "Junge"
-      ]
+      "const": "Junge"
     },
     {
       "title": "Jura",
       "markdownDescription": "https://fonts.google.com/specimen/Jura",
-      "enum": [
-        "Jura"
-      ]
+      "const": "Jura"
     },
     {
       "title": "Just Another Hand",
       "markdownDescription": "https://fonts.google.com/specimen/Just+Another+Hand",
-      "enum": [
-        "Just Another Hand"
-      ]
+      "const": "Just Another Hand"
     },
     {
       "title": "Just Me Again Down Here",
       "markdownDescription": "https://fonts.google.com/specimen/Just+Me+Again+Down+Here",
-      "enum": [
-        "Just Me Again Down Here"
-      ]
+      "const": "Just Me Again Down Here"
     },
     {
       "title": "K2D",
       "markdownDescription": "https://fonts.google.com/specimen/K2D",
-      "enum": [
-        "K2D"
-      ]
+      "const": "K2D"
     },
     {
       "title": "Kablammo",
       "markdownDescription": "https://fonts.google.com/specimen/Kablammo",
-      "enum": [
-        "Kablammo"
-      ]
+      "const": "Kablammo"
     },
     {
       "title": "Kadwa",
       "markdownDescription": "https://fonts.google.com/specimen/Kadwa",
-      "enum": [
-        "Kadwa"
-      ]
+      "const": "Kadwa"
     },
     {
       "title": "Kaisei Decol",
       "markdownDescription": "https://fonts.google.com/specimen/Kaisei+Decol",
-      "enum": [
-        "Kaisei Decol"
-      ]
+      "const": "Kaisei Decol"
     },
     {
       "title": "Kaisei HarunoUmi",
       "markdownDescription": "https://fonts.google.com/specimen/Kaisei+HarunoUmi",
-      "enum": [
-        "Kaisei HarunoUmi"
-      ]
+      "const": "Kaisei HarunoUmi"
     },
     {
       "title": "Kaisei Opti",
       "markdownDescription": "https://fonts.google.com/specimen/Kaisei+Opti",
-      "enum": [
-        "Kaisei Opti"
-      ]
+      "const": "Kaisei Opti"
     },
     {
       "title": "Kaisei Tokumin",
       "markdownDescription": "https://fonts.google.com/specimen/Kaisei+Tokumin",
-      "enum": [
-        "Kaisei Tokumin"
-      ]
+      "const": "Kaisei Tokumin"
     },
     {
       "title": "Kalam",
       "markdownDescription": "https://fonts.google.com/specimen/Kalam",
-      "enum": [
-        "Kalam"
-      ]
+      "const": "Kalam"
     },
     {
       "title": "Kameron",
       "markdownDescription": "https://fonts.google.com/specimen/Kameron",
-      "enum": [
-        "Kameron"
-      ]
+      "const": "Kameron"
     },
     {
       "title": "Kanit",
       "markdownDescription": "https://fonts.google.com/specimen/Kanit",
-      "enum": [
-        "Kanit"
-      ]
+      "const": "Kanit"
     },
     {
       "title": "Kantumruy Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Kantumruy+Pro",
-      "enum": [
-        "Kantumruy Pro"
-      ]
+      "const": "Kantumruy Pro"
     },
     {
       "title": "Karantina",
       "markdownDescription": "https://fonts.google.com/specimen/Karantina",
-      "enum": [
-        "Karantina"
-      ]
+      "const": "Karantina"
     },
     {
       "title": "Karla",
       "markdownDescription": "https://fonts.google.com/specimen/Karla",
-      "enum": [
-        "Karla"
-      ]
+      "const": "Karla"
     },
     {
       "title": "Karma",
       "markdownDescription": "https://fonts.google.com/specimen/Karma",
-      "enum": [
-        "Karma"
-      ]
+      "const": "Karma"
     },
     {
       "title": "Katibeh",
       "markdownDescription": "https://fonts.google.com/specimen/Katibeh",
-      "enum": [
-        "Katibeh"
-      ]
+      "const": "Katibeh"
     },
     {
       "title": "Kaushan Script",
       "markdownDescription": "https://fonts.google.com/specimen/Kaushan+Script",
-      "enum": [
-        "Kaushan Script"
-      ]
+      "const": "Kaushan Script"
     },
     {
       "title": "Kavivanar",
       "markdownDescription": "https://fonts.google.com/specimen/Kavivanar",
-      "enum": [
-        "Kavivanar"
-      ]
+      "const": "Kavivanar"
     },
     {
       "title": "Kavoon",
       "markdownDescription": "https://fonts.google.com/specimen/Kavoon",
-      "enum": [
-        "Kavoon"
-      ]
+      "const": "Kavoon"
     },
     {
       "title": "Kdam Thmor Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Kdam+Thmor+Pro",
-      "enum": [
-        "Kdam Thmor Pro"
-      ]
+      "const": "Kdam Thmor Pro"
     },
     {
       "title": "Keania One",
       "markdownDescription": "https://fonts.google.com/specimen/Keania+One",
-      "enum": [
-        "Keania One"
-      ]
+      "const": "Keania One"
     },
     {
       "title": "Kelly Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Kelly+Slab",
-      "enum": [
-        "Kelly Slab"
-      ]
+      "const": "Kelly Slab"
     },
     {
       "title": "Kenia",
       "markdownDescription": "https://fonts.google.com/specimen/Kenia",
-      "enum": [
-        "Kenia"
-      ]
+      "const": "Kenia"
     },
     {
       "title": "Khand",
       "markdownDescription": "https://fonts.google.com/specimen/Khand",
-      "enum": [
-        "Khand"
-      ]
+      "const": "Khand"
     },
     {
       "title": "Khmer",
       "markdownDescription": "https://fonts.google.com/specimen/Khmer",
-      "enum": [
-        "Khmer"
-      ]
+      "const": "Khmer"
     },
     {
       "title": "Khula",
       "markdownDescription": "https://fonts.google.com/specimen/Khula",
-      "enum": [
-        "Khula"
-      ]
+      "const": "Khula"
     },
     {
       "title": "Kings",
       "markdownDescription": "https://fonts.google.com/specimen/Kings",
-      "enum": [
-        "Kings"
-      ]
+      "const": "Kings"
     },
     {
       "title": "Kirang Haerang",
       "markdownDescription": "https://fonts.google.com/specimen/Kirang+Haerang",
-      "enum": [
-        "Kirang Haerang"
-      ]
+      "const": "Kirang Haerang"
     },
     {
       "title": "Kite One",
       "markdownDescription": "https://fonts.google.com/specimen/Kite+One",
-      "enum": [
-        "Kite One"
-      ]
+      "const": "Kite One"
     },
     {
       "title": "Kiwi Maru",
       "markdownDescription": "https://fonts.google.com/specimen/Kiwi+Maru",
-      "enum": [
-        "Kiwi Maru"
-      ]
+      "const": "Kiwi Maru"
     },
     {
       "title": "Klee One",
       "markdownDescription": "https://fonts.google.com/specimen/Klee+One",
-      "enum": [
-        "Klee One"
-      ]
+      "const": "Klee One"
     },
     {
       "title": "Knewave",
       "markdownDescription": "https://fonts.google.com/specimen/Knewave",
-      "enum": [
-        "Knewave"
-      ]
+      "const": "Knewave"
     },
     {
       "title": "KoHo",
       "markdownDescription": "https://fonts.google.com/specimen/KoHo",
-      "enum": [
-        "KoHo"
-      ]
+      "const": "KoHo"
     },
     {
       "title": "Kodchasan",
       "markdownDescription": "https://fonts.google.com/specimen/Kodchasan",
-      "enum": [
-        "Kodchasan"
-      ]
+      "const": "Kodchasan"
     },
     {
       "title": "Koh Santepheap",
       "markdownDescription": "https://fonts.google.com/specimen/Koh+Santepheap",
-      "enum": [
-        "Koh Santepheap"
-      ]
+      "const": "Koh Santepheap"
     },
     {
       "title": "Kolker Brush",
       "markdownDescription": "https://fonts.google.com/specimen/Kolker+Brush",
-      "enum": [
-        "Kolker Brush"
-      ]
+      "const": "Kolker Brush"
     },
     {
       "title": "Konkhmer Sleokchher",
       "markdownDescription": "https://fonts.google.com/specimen/Konkhmer+Sleokchher",
-      "enum": [
-        "Konkhmer Sleokchher"
-      ]
+      "const": "Konkhmer Sleokchher"
     },
     {
       "title": "Kosugi",
       "markdownDescription": "https://fonts.google.com/specimen/Kosugi",
-      "enum": [
-        "Kosugi"
-      ]
+      "const": "Kosugi"
     },
     {
       "title": "Kosugi Maru",
       "markdownDescription": "https://fonts.google.com/specimen/Kosugi+Maru",
-      "enum": [
-        "Kosugi Maru"
-      ]
+      "const": "Kosugi Maru"
     },
     {
       "title": "Kotta One",
       "markdownDescription": "https://fonts.google.com/specimen/Kotta+One",
-      "enum": [
-        "Kotta One"
-      ]
+      "const": "Kotta One"
     },
     {
       "title": "Koulen",
       "markdownDescription": "https://fonts.google.com/specimen/Koulen",
-      "enum": [
-        "Koulen"
-      ]
+      "const": "Koulen"
     },
     {
       "title": "Kranky",
       "markdownDescription": "https://fonts.google.com/specimen/Kranky",
-      "enum": [
-        "Kranky"
-      ]
+      "const": "Kranky"
     },
     {
       "title": "Kreon",
       "markdownDescription": "https://fonts.google.com/specimen/Kreon",
-      "enum": [
-        "Kreon"
-      ]
+      "const": "Kreon"
     },
     {
       "title": "Kristi",
       "markdownDescription": "https://fonts.google.com/specimen/Kristi",
-      "enum": [
-        "Kristi"
-      ]
+      "const": "Kristi"
     },
     {
       "title": "Krona One",
       "markdownDescription": "https://fonts.google.com/specimen/Krona+One",
-      "enum": [
-        "Krona One"
-      ]
+      "const": "Krona One"
     },
     {
       "title": "Krub",
       "markdownDescription": "https://fonts.google.com/specimen/Krub",
-      "enum": [
-        "Krub"
-      ]
+      "const": "Krub"
     },
     {
       "title": "Kufam",
       "markdownDescription": "https://fonts.google.com/specimen/Kufam",
-      "enum": [
-        "Kufam"
-      ]
+      "const": "Kufam"
     },
     {
       "title": "Kulim Park",
       "markdownDescription": "https://fonts.google.com/specimen/Kulim+Park",
-      "enum": [
-        "Kulim Park"
-      ]
+      "const": "Kulim Park"
     },
     {
       "title": "Kumar One",
       "markdownDescription": "https://fonts.google.com/specimen/Kumar+One",
-      "enum": [
-        "Kumar One"
-      ]
+      "const": "Kumar One"
     },
     {
       "title": "Kumar One Outline",
       "markdownDescription": "https://fonts.google.com/specimen/Kumar+One+Outline",
-      "enum": [
-        "Kumar One Outline"
-      ]
+      "const": "Kumar One Outline"
     },
     {
       "title": "Kumbh Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Kumbh+Sans",
-      "enum": [
-        "Kumbh Sans"
-      ]
+      "const": "Kumbh Sans"
     },
     {
       "title": "Kurale",
       "markdownDescription": "https://fonts.google.com/specimen/Kurale",
-      "enum": [
-        "Kurale"
-      ]
+      "const": "Kurale"
     },
     {
       "title": "La Belle Aurore",
       "markdownDescription": "https://fonts.google.com/specimen/La+Belle+Aurore",
-      "enum": [
-        "La Belle Aurore"
-      ]
+      "const": "La Belle Aurore"
     },
     {
       "title": "Labrada",
       "markdownDescription": "https://fonts.google.com/specimen/Labrada",
-      "enum": [
-        "Labrada"
-      ]
+      "const": "Labrada"
     },
     {
       "title": "Lacquer",
       "markdownDescription": "https://fonts.google.com/specimen/Lacquer",
-      "enum": [
-        "Lacquer"
-      ]
+      "const": "Lacquer"
     },
     {
       "title": "Laila",
       "markdownDescription": "https://fonts.google.com/specimen/Laila",
-      "enum": [
-        "Laila"
-      ]
+      "const": "Laila"
     },
     {
       "title": "Lakki Reddy",
       "markdownDescription": "https://fonts.google.com/specimen/Lakki+Reddy",
-      "enum": [
-        "Lakki Reddy"
-      ]
+      "const": "Lakki Reddy"
     },
     {
       "title": "Lalezar",
       "markdownDescription": "https://fonts.google.com/specimen/Lalezar",
-      "enum": [
-        "Lalezar"
-      ]
+      "const": "Lalezar"
     },
     {
       "title": "Lancelot",
       "markdownDescription": "https://fonts.google.com/specimen/Lancelot",
-      "enum": [
-        "Lancelot"
-      ]
+      "const": "Lancelot"
     },
     {
       "title": "Langar",
       "markdownDescription": "https://fonts.google.com/specimen/Langar",
-      "enum": [
-        "Langar"
-      ]
+      "const": "Langar"
     },
     {
       "title": "Lateef",
       "markdownDescription": "https://fonts.google.com/specimen/Lateef",
-      "enum": [
-        "Lateef"
-      ]
+      "const": "Lateef"
     },
     {
       "title": "Lato",
       "markdownDescription": "https://fonts.google.com/specimen/Lato",
-      "enum": [
-        "Lato"
-      ]
+      "const": "Lato"
     },
     {
       "title": "Lavishly Yours",
       "markdownDescription": "https://fonts.google.com/specimen/Lavishly+Yours",
-      "enum": [
-        "Lavishly Yours"
-      ]
+      "const": "Lavishly Yours"
     },
     {
       "title": "League Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/League+Gothic",
-      "enum": [
-        "League Gothic"
-      ]
+      "const": "League Gothic"
     },
     {
       "title": "League Script",
       "markdownDescription": "https://fonts.google.com/specimen/League+Script",
-      "enum": [
-        "League Script"
-      ]
+      "const": "League Script"
     },
     {
       "title": "League Spartan",
       "markdownDescription": "https://fonts.google.com/specimen/League+Spartan",
-      "enum": [
-        "League Spartan"
-      ]
+      "const": "League Spartan"
     },
     {
       "title": "Leckerli One",
       "markdownDescription": "https://fonts.google.com/specimen/Leckerli+One",
-      "enum": [
-        "Leckerli One"
-      ]
+      "const": "Leckerli One"
     },
     {
       "title": "Ledger",
       "markdownDescription": "https://fonts.google.com/specimen/Ledger",
-      "enum": [
-        "Ledger"
-      ]
+      "const": "Ledger"
     },
     {
       "title": "Lekton",
       "markdownDescription": "https://fonts.google.com/specimen/Lekton",
-      "enum": [
-        "Lekton"
-      ]
+      "const": "Lekton"
     },
     {
       "title": "Lemon",
       "markdownDescription": "https://fonts.google.com/specimen/Lemon",
-      "enum": [
-        "Lemon"
-      ]
+      "const": "Lemon"
     },
     {
       "title": "Lemonada",
       "markdownDescription": "https://fonts.google.com/specimen/Lemonada",
-      "enum": [
-        "Lemonada"
-      ]
+      "const": "Lemonada"
     },
     {
       "title": "Lexend",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend",
-      "enum": [
-        "Lexend"
-      ]
+      "const": "Lexend"
     },
     {
       "title": "Lexend Deca",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Deca",
-      "enum": [
-        "Lexend Deca"
-      ]
+      "const": "Lexend Deca"
     },
     {
       "title": "Lexend Exa",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Exa",
-      "enum": [
-        "Lexend Exa"
-      ]
+      "const": "Lexend Exa"
     },
     {
       "title": "Lexend Giga",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Giga",
-      "enum": [
-        "Lexend Giga"
-      ]
+      "const": "Lexend Giga"
     },
     {
       "title": "Lexend Mega",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Mega",
-      "enum": [
-        "Lexend Mega"
-      ]
+      "const": "Lexend Mega"
     },
     {
       "title": "Lexend Peta",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Peta",
-      "enum": [
-        "Lexend Peta"
-      ]
+      "const": "Lexend Peta"
     },
     {
       "title": "Lexend Tera",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Tera",
-      "enum": [
-        "Lexend Tera"
-      ]
+      "const": "Lexend Tera"
     },
     {
       "title": "Lexend Zetta",
       "markdownDescription": "https://fonts.google.com/specimen/Lexend+Zetta",
-      "enum": [
-        "Lexend Zetta"
-      ]
+      "const": "Lexend Zetta"
     },
     {
       "title": "Libre Barcode 128",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+128",
-      "enum": [
-        "Libre Barcode 128"
-      ]
+      "const": "Libre Barcode 128"
     },
     {
       "title": "Libre Barcode 128 Text",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+128+Text",
-      "enum": [
-        "Libre Barcode 128 Text"
-      ]
+      "const": "Libre Barcode 128 Text"
     },
     {
       "title": "Libre Barcode 39",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+39",
-      "enum": [
-        "Libre Barcode 39"
-      ]
+      "const": "Libre Barcode 39"
     },
     {
       "title": "Libre Barcode 39 Extended",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+39+Extended",
-      "enum": [
-        "Libre Barcode 39 Extended"
-      ]
+      "const": "Libre Barcode 39 Extended"
     },
     {
       "title": "Libre Barcode 39 Extended Text",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+39+Extended+Text",
-      "enum": [
-        "Libre Barcode 39 Extended Text"
-      ]
+      "const": "Libre Barcode 39 Extended Text"
     },
     {
       "title": "Libre Barcode 39 Text",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+39+Text",
-      "enum": [
-        "Libre Barcode 39 Text"
-      ]
+      "const": "Libre Barcode 39 Text"
     },
     {
       "title": "Libre Barcode EAN13 Text",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Barcode+EAN13+Text",
-      "enum": [
-        "Libre Barcode EAN13 Text"
-      ]
+      "const": "Libre Barcode EAN13 Text"
     },
     {
       "title": "Libre Baskerville",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Baskerville",
-      "enum": [
-        "Libre Baskerville"
-      ]
+      "const": "Libre Baskerville"
     },
     {
       "title": "Libre Bodoni",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Bodoni",
-      "enum": [
-        "Libre Bodoni"
-      ]
+      "const": "Libre Bodoni"
     },
     {
       "title": "Libre Caslon Display",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Caslon+Display",
-      "enum": [
-        "Libre Caslon Display"
-      ]
+      "const": "Libre Caslon Display"
     },
     {
       "title": "Libre Caslon Text",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Caslon+Text",
-      "enum": [
-        "Libre Caslon Text"
-      ]
+      "const": "Libre Caslon Text"
     },
     {
       "title": "Libre Franklin",
       "markdownDescription": "https://fonts.google.com/specimen/Libre+Franklin",
-      "enum": [
-        "Libre Franklin"
-      ]
+      "const": "Libre Franklin"
     },
     {
       "title": "Licorice",
       "markdownDescription": "https://fonts.google.com/specimen/Licorice",
-      "enum": [
-        "Licorice"
-      ]
+      "const": "Licorice"
     },
     {
       "title": "Life Savers",
       "markdownDescription": "https://fonts.google.com/specimen/Life+Savers",
-      "enum": [
-        "Life Savers"
-      ]
+      "const": "Life Savers"
     },
     {
       "title": "Lilita One",
       "markdownDescription": "https://fonts.google.com/specimen/Lilita+One",
-      "enum": [
-        "Lilita One"
-      ]
+      "const": "Lilita One"
     },
     {
       "title": "Lily Script One",
       "markdownDescription": "https://fonts.google.com/specimen/Lily+Script+One",
-      "enum": [
-        "Lily Script One"
-      ]
+      "const": "Lily Script One"
     },
     {
       "title": "Limelight",
       "markdownDescription": "https://fonts.google.com/specimen/Limelight",
-      "enum": [
-        "Limelight"
-      ]
+      "const": "Limelight"
     },
     {
       "title": "Linden Hill",
       "markdownDescription": "https://fonts.google.com/specimen/Linden+Hill",
-      "enum": [
-        "Linden Hill"
-      ]
+      "const": "Linden Hill"
     },
     {
       "title": "Lisu Bosa",
       "markdownDescription": "https://fonts.google.com/specimen/Lisu+Bosa",
-      "enum": [
-        "Lisu Bosa"
-      ]
+      "const": "Lisu Bosa"
     },
     {
       "title": "Literata",
       "markdownDescription": "https://fonts.google.com/specimen/Literata",
-      "enum": [
-        "Literata"
-      ]
+      "const": "Literata"
     },
     {
       "title": "Liu Jian Mao Cao",
       "markdownDescription": "https://fonts.google.com/specimen/Liu+Jian+Mao+Cao",
-      "enum": [
-        "Liu Jian Mao Cao"
-      ]
+      "const": "Liu Jian Mao Cao"
     },
     {
       "title": "Livvic",
       "markdownDescription": "https://fonts.google.com/specimen/Livvic",
-      "enum": [
-        "Livvic"
-      ]
+      "const": "Livvic"
     },
     {
       "title": "Lobster",
       "markdownDescription": "https://fonts.google.com/specimen/Lobster",
-      "enum": [
-        "Lobster"
-      ]
+      "const": "Lobster"
     },
     {
       "title": "Lobster Two",
       "markdownDescription": "https://fonts.google.com/specimen/Lobster+Two",
-      "enum": [
-        "Lobster Two"
-      ]
+      "const": "Lobster Two"
     },
     {
       "title": "Londrina Outline",
       "markdownDescription": "https://fonts.google.com/specimen/Londrina+Outline",
-      "enum": [
-        "Londrina Outline"
-      ]
+      "const": "Londrina Outline"
     },
     {
       "title": "Londrina Shadow",
       "markdownDescription": "https://fonts.google.com/specimen/Londrina+Shadow",
-      "enum": [
-        "Londrina Shadow"
-      ]
+      "const": "Londrina Shadow"
     },
     {
       "title": "Londrina Sketch",
       "markdownDescription": "https://fonts.google.com/specimen/Londrina+Sketch",
-      "enum": [
-        "Londrina Sketch"
-      ]
+      "const": "Londrina Sketch"
     },
     {
       "title": "Londrina Solid",
       "markdownDescription": "https://fonts.google.com/specimen/Londrina+Solid",
-      "enum": [
-        "Londrina Solid"
-      ]
+      "const": "Londrina Solid"
     },
     {
       "title": "Long Cang",
       "markdownDescription": "https://fonts.google.com/specimen/Long+Cang",
-      "enum": [
-        "Long Cang"
-      ]
+      "const": "Long Cang"
     },
     {
       "title": "Lora",
       "markdownDescription": "https://fonts.google.com/specimen/Lora",
-      "enum": [
-        "Lora"
-      ]
+      "const": "Lora"
     },
     {
       "title": "Love Light",
       "markdownDescription": "https://fonts.google.com/specimen/Love+Light",
-      "enum": [
-        "Love Light"
-      ]
+      "const": "Love Light"
     },
     {
       "title": "Love Ya Like A Sister",
       "markdownDescription": "https://fonts.google.com/specimen/Love+Ya+Like+A+Sister",
-      "enum": [
-        "Love Ya Like A Sister"
-      ]
+      "const": "Love Ya Like A Sister"
     },
     {
       "title": "Loved by the King",
       "markdownDescription": "https://fonts.google.com/specimen/Loved+by+the+King",
-      "enum": [
-        "Loved by the King"
-      ]
+      "const": "Loved by the King"
     },
     {
       "title": "Lovers Quarrel",
       "markdownDescription": "https://fonts.google.com/specimen/Lovers+Quarrel",
-      "enum": [
-        "Lovers Quarrel"
-      ]
+      "const": "Lovers Quarrel"
     },
     {
       "title": "Luckiest Guy",
       "markdownDescription": "https://fonts.google.com/specimen/Luckiest+Guy",
-      "enum": [
-        "Luckiest Guy"
-      ]
+      "const": "Luckiest Guy"
     },
     {
       "title": "Lugrasimo",
       "markdownDescription": "https://fonts.google.com/specimen/Lugrasimo",
-      "enum": [
-        "Lugrasimo"
-      ]
+      "const": "Lugrasimo"
     },
     {
       "title": "Lumanosimo",
       "markdownDescription": "https://fonts.google.com/specimen/Lumanosimo",
-      "enum": [
-        "Lumanosimo"
-      ]
+      "const": "Lumanosimo"
     },
     {
       "title": "Lunasima",
       "markdownDescription": "https://fonts.google.com/specimen/Lunasima",
-      "enum": [
-        "Lunasima"
-      ]
+      "const": "Lunasima"
     },
     {
       "title": "Lusitana",
       "markdownDescription": "https://fonts.google.com/specimen/Lusitana",
-      "enum": [
-        "Lusitana"
-      ]
+      "const": "Lusitana"
     },
     {
       "title": "Lustria",
       "markdownDescription": "https://fonts.google.com/specimen/Lustria",
-      "enum": [
-        "Lustria"
-      ]
+      "const": "Lustria"
     },
     {
       "title": "Luxurious Roman",
       "markdownDescription": "https://fonts.google.com/specimen/Luxurious+Roman",
-      "enum": [
-        "Luxurious Roman"
-      ]
+      "const": "Luxurious Roman"
     },
     {
       "title": "Luxurious Script",
       "markdownDescription": "https://fonts.google.com/specimen/Luxurious+Script",
-      "enum": [
-        "Luxurious Script"
-      ]
+      "const": "Luxurious Script"
     },
     {
       "title": "M PLUS 1",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+1",
-      "enum": [
-        "M PLUS 1"
-      ]
+      "const": "M PLUS 1"
     },
     {
       "title": "M PLUS 1 Code",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+1+Code",
-      "enum": [
-        "M PLUS 1 Code"
-      ]
+      "const": "M PLUS 1 Code"
     },
     {
       "title": "M PLUS 1p",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+1p",
-      "enum": [
-        "M PLUS 1p"
-      ]
+      "const": "M PLUS 1p"
     },
     {
       "title": "M PLUS 2",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+2",
-      "enum": [
-        "M PLUS 2"
-      ]
+      "const": "M PLUS 2"
     },
     {
       "title": "M PLUS Code Latin",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+Code+Latin",
-      "enum": [
-        "M PLUS Code Latin"
-      ]
+      "const": "M PLUS Code Latin"
     },
     {
       "title": "M PLUS Rounded 1c",
       "markdownDescription": "https://fonts.google.com/specimen/M+PLUS+Rounded+1c",
-      "enum": [
-        "M PLUS Rounded 1c"
-      ]
+      "const": "M PLUS Rounded 1c"
     },
     {
       "title": "Ma Shan Zheng",
       "markdownDescription": "https://fonts.google.com/specimen/Ma+Shan+Zheng",
-      "enum": [
-        "Ma Shan Zheng"
-      ]
+      "const": "Ma Shan Zheng"
     },
     {
       "title": "Macondo",
       "markdownDescription": "https://fonts.google.com/specimen/Macondo",
-      "enum": [
-        "Macondo"
-      ]
+      "const": "Macondo"
     },
     {
       "title": "Macondo Swash Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Macondo+Swash+Caps",
-      "enum": [
-        "Macondo Swash Caps"
-      ]
+      "const": "Macondo Swash Caps"
     },
     {
       "title": "Mada",
       "markdownDescription": "https://fonts.google.com/specimen/Mada",
-      "enum": [
-        "Mada"
-      ]
+      "const": "Mada"
     },
     {
       "title": "Magra",
       "markdownDescription": "https://fonts.google.com/specimen/Magra",
-      "enum": [
-        "Magra"
-      ]
+      "const": "Magra"
     },
     {
       "title": "Maiden Orange",
       "markdownDescription": "https://fonts.google.com/specimen/Maiden+Orange",
-      "enum": [
-        "Maiden Orange"
-      ]
+      "const": "Maiden Orange"
     },
     {
       "title": "Maitree",
       "markdownDescription": "https://fonts.google.com/specimen/Maitree",
-      "enum": [
-        "Maitree"
-      ]
+      "const": "Maitree"
     },
     {
       "title": "Major Mono Display",
       "markdownDescription": "https://fonts.google.com/specimen/Major+Mono+Display",
-      "enum": [
-        "Major Mono Display"
-      ]
+      "const": "Major Mono Display"
     },
     {
       "title": "Mako",
       "markdownDescription": "https://fonts.google.com/specimen/Mako",
-      "enum": [
-        "Mako"
-      ]
+      "const": "Mako"
     },
     {
       "title": "Mali",
       "markdownDescription": "https://fonts.google.com/specimen/Mali",
-      "enum": [
-        "Mali"
-      ]
+      "const": "Mali"
     },
     {
       "title": "Mallanna",
       "markdownDescription": "https://fonts.google.com/specimen/Mallanna",
-      "enum": [
-        "Mallanna"
-      ]
+      "const": "Mallanna"
     },
     {
       "title": "Mandali",
       "markdownDescription": "https://fonts.google.com/specimen/Mandali",
-      "enum": [
-        "Mandali"
-      ]
+      "const": "Mandali"
     },
     {
       "title": "Manjari",
       "markdownDescription": "https://fonts.google.com/specimen/Manjari",
-      "enum": [
-        "Manjari"
-      ]
+      "const": "Manjari"
     },
     {
       "title": "Manrope",
       "markdownDescription": "https://fonts.google.com/specimen/Manrope",
-      "enum": [
-        "Manrope"
-      ]
+      "const": "Manrope"
     },
     {
       "title": "Mansalva",
       "markdownDescription": "https://fonts.google.com/specimen/Mansalva",
-      "enum": [
-        "Mansalva"
-      ]
+      "const": "Mansalva"
     },
     {
       "title": "Manuale",
       "markdownDescription": "https://fonts.google.com/specimen/Manuale",
-      "enum": [
-        "Manuale"
-      ]
+      "const": "Manuale"
     },
     {
       "title": "Marcellus",
       "markdownDescription": "https://fonts.google.com/specimen/Marcellus",
-      "enum": [
-        "Marcellus"
-      ]
+      "const": "Marcellus"
     },
     {
       "title": "Marcellus SC",
       "markdownDescription": "https://fonts.google.com/specimen/Marcellus+SC",
-      "enum": [
-        "Marcellus SC"
-      ]
+      "const": "Marcellus SC"
     },
     {
       "title": "Marck Script",
       "markdownDescription": "https://fonts.google.com/specimen/Marck+Script",
-      "enum": [
-        "Marck Script"
-      ]
+      "const": "Marck Script"
     },
     {
       "title": "Margarine",
       "markdownDescription": "https://fonts.google.com/specimen/Margarine",
-      "enum": [
-        "Margarine"
-      ]
+      "const": "Margarine"
     },
     {
       "title": "Marhey",
       "markdownDescription": "https://fonts.google.com/specimen/Marhey",
-      "enum": [
-        "Marhey"
-      ]
+      "const": "Marhey"
     },
     {
       "title": "Markazi Text",
       "markdownDescription": "https://fonts.google.com/specimen/Markazi+Text",
-      "enum": [
-        "Markazi Text"
-      ]
+      "const": "Markazi Text"
     },
     {
       "title": "Marko One",
       "markdownDescription": "https://fonts.google.com/specimen/Marko+One",
-      "enum": [
-        "Marko One"
-      ]
+      "const": "Marko One"
     },
     {
       "title": "Marmelad",
       "markdownDescription": "https://fonts.google.com/specimen/Marmelad",
-      "enum": [
-        "Marmelad"
-      ]
+      "const": "Marmelad"
     },
     {
       "title": "Martel",
       "markdownDescription": "https://fonts.google.com/specimen/Martel",
-      "enum": [
-        "Martel"
-      ]
+      "const": "Martel"
     },
     {
       "title": "Martel Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Martel+Sans",
-      "enum": [
-        "Martel Sans"
-      ]
+      "const": "Martel Sans"
     },
     {
       "title": "Martian Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Martian+Mono",
-      "enum": [
-        "Martian Mono"
-      ]
+      "const": "Martian Mono"
     },
     {
       "title": "Marvel",
       "markdownDescription": "https://fonts.google.com/specimen/Marvel",
-      "enum": [
-        "Marvel"
-      ]
+      "const": "Marvel"
     },
     {
       "title": "Mate",
       "markdownDescription": "https://fonts.google.com/specimen/Mate",
-      "enum": [
-        "Mate"
-      ]
+      "const": "Mate"
     },
     {
       "title": "Mate SC",
       "markdownDescription": "https://fonts.google.com/specimen/Mate+SC",
-      "enum": [
-        "Mate SC"
-      ]
+      "const": "Mate SC"
     },
     {
       "title": "Material Icons",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Icons",
-      "enum": [
-        "Material Icons"
-      ]
+      "const": "Material Icons"
     },
     {
       "title": "Material Icons Outlined",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Icons+Outlined",
-      "enum": [
-        "Material Icons Outlined"
-      ]
+      "const": "Material Icons Outlined"
     },
     {
       "title": "Material Icons Round",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Icons+Round",
-      "enum": [
-        "Material Icons Round"
-      ]
+      "const": "Material Icons Round"
     },
     {
       "title": "Material Icons Sharp",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Icons+Sharp",
-      "enum": [
-        "Material Icons Sharp"
-      ]
+      "const": "Material Icons Sharp"
     },
     {
       "title": "Material Icons Two Tone",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Icons+Two+Tone",
-      "enum": [
-        "Material Icons Two Tone"
-      ]
+      "const": "Material Icons Two Tone"
     },
     {
       "title": "Material Symbols Outlined",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Symbols+Outlined",
-      "enum": [
-        "Material Symbols Outlined"
-      ]
+      "const": "Material Symbols Outlined"
     },
     {
       "title": "Material Symbols Rounded",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Symbols+Rounded",
-      "enum": [
-        "Material Symbols Rounded"
-      ]
+      "const": "Material Symbols Rounded"
     },
     {
       "title": "Material Symbols Sharp",
       "markdownDescription": "https://fonts.google.com/specimen/Material+Symbols+Sharp",
-      "enum": [
-        "Material Symbols Sharp"
-      ]
+      "const": "Material Symbols Sharp"
     },
     {
       "title": "Maven Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Maven+Pro",
-      "enum": [
-        "Maven Pro"
-      ]
+      "const": "Maven Pro"
     },
     {
       "title": "McLaren",
       "markdownDescription": "https://fonts.google.com/specimen/McLaren",
-      "enum": [
-        "McLaren"
-      ]
+      "const": "McLaren"
     },
     {
       "title": "Mea Culpa",
       "markdownDescription": "https://fonts.google.com/specimen/Mea+Culpa",
-      "enum": [
-        "Mea Culpa"
-      ]
+      "const": "Mea Culpa"
     },
     {
       "title": "Meddon",
       "markdownDescription": "https://fonts.google.com/specimen/Meddon",
-      "enum": [
-        "Meddon"
-      ]
+      "const": "Meddon"
     },
     {
       "title": "MedievalSharp",
       "markdownDescription": "https://fonts.google.com/specimen/MedievalSharp",
-      "enum": [
-        "MedievalSharp"
-      ]
+      "const": "MedievalSharp"
     },
     {
       "title": "Medula One",
       "markdownDescription": "https://fonts.google.com/specimen/Medula+One",
-      "enum": [
-        "Medula One"
-      ]
+      "const": "Medula One"
     },
     {
       "title": "Meera Inimai",
       "markdownDescription": "https://fonts.google.com/specimen/Meera+Inimai",
-      "enum": [
-        "Meera Inimai"
-      ]
+      "const": "Meera Inimai"
     },
     {
       "title": "Megrim",
       "markdownDescription": "https://fonts.google.com/specimen/Megrim",
-      "enum": [
-        "Megrim"
-      ]
+      "const": "Megrim"
     },
     {
       "title": "Meie Script",
       "markdownDescription": "https://fonts.google.com/specimen/Meie+Script",
-      "enum": [
-        "Meie Script"
-      ]
+      "const": "Meie Script"
     },
     {
       "title": "Meow Script",
       "markdownDescription": "https://fonts.google.com/specimen/Meow+Script",
-      "enum": [
-        "Meow Script"
-      ]
+      "const": "Meow Script"
     },
     {
       "title": "Merienda",
       "markdownDescription": "https://fonts.google.com/specimen/Merienda",
-      "enum": [
-        "Merienda"
-      ]
+      "const": "Merienda"
     },
     {
       "title": "Merriweather",
       "markdownDescription": "https://fonts.google.com/specimen/Merriweather",
-      "enum": [
-        "Merriweather"
-      ]
+      "const": "Merriweather"
     },
     {
       "title": "Merriweather Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Merriweather+Sans",
-      "enum": [
-        "Merriweather Sans"
-      ]
+      "const": "Merriweather Sans"
     },
     {
       "title": "Metal",
       "markdownDescription": "https://fonts.google.com/specimen/Metal",
-      "enum": [
-        "Metal"
-      ]
+      "const": "Metal"
     },
     {
       "title": "Metal Mania",
       "markdownDescription": "https://fonts.google.com/specimen/Metal+Mania",
-      "enum": [
-        "Metal Mania"
-      ]
+      "const": "Metal Mania"
     },
     {
       "title": "Metamorphous",
       "markdownDescription": "https://fonts.google.com/specimen/Metamorphous",
-      "enum": [
-        "Metamorphous"
-      ]
+      "const": "Metamorphous"
     },
     {
       "title": "Metrophobic",
       "markdownDescription": "https://fonts.google.com/specimen/Metrophobic",
-      "enum": [
-        "Metrophobic"
-      ]
+      "const": "Metrophobic"
     },
     {
       "title": "Michroma",
       "markdownDescription": "https://fonts.google.com/specimen/Michroma",
-      "enum": [
-        "Michroma"
-      ]
+      "const": "Michroma"
     },
     {
       "title": "Milonga",
       "markdownDescription": "https://fonts.google.com/specimen/Milonga",
-      "enum": [
-        "Milonga"
-      ]
+      "const": "Milonga"
     },
     {
       "title": "Miltonian",
       "markdownDescription": "https://fonts.google.com/specimen/Miltonian",
-      "enum": [
-        "Miltonian"
-      ]
+      "const": "Miltonian"
     },
     {
       "title": "Miltonian Tattoo",
       "markdownDescription": "https://fonts.google.com/specimen/Miltonian+Tattoo",
-      "enum": [
-        "Miltonian Tattoo"
-      ]
+      "const": "Miltonian Tattoo"
     },
     {
       "title": "Mina",
       "markdownDescription": "https://fonts.google.com/specimen/Mina",
-      "enum": [
-        "Mina"
-      ]
+      "const": "Mina"
     },
     {
       "title": "Mingzat",
       "markdownDescription": "https://fonts.google.com/specimen/Mingzat",
-      "enum": [
-        "Mingzat"
-      ]
+      "const": "Mingzat"
     },
     {
       "title": "Miniver",
       "markdownDescription": "https://fonts.google.com/specimen/Miniver",
-      "enum": [
-        "Miniver"
-      ]
+      "const": "Miniver"
     },
     {
       "title": "Miriam Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Miriam+Libre",
-      "enum": [
-        "Miriam Libre"
-      ]
+      "const": "Miriam Libre"
     },
     {
       "title": "Mirza",
       "markdownDescription": "https://fonts.google.com/specimen/Mirza",
-      "enum": [
-        "Mirza"
-      ]
+      "const": "Mirza"
     },
     {
       "title": "Miss Fajardose",
       "markdownDescription": "https://fonts.google.com/specimen/Miss+Fajardose",
-      "enum": [
-        "Miss Fajardose"
-      ]
+      "const": "Miss Fajardose"
     },
     {
       "title": "Mitr",
       "markdownDescription": "https://fonts.google.com/specimen/Mitr",
-      "enum": [
-        "Mitr"
-      ]
+      "const": "Mitr"
     },
     {
       "title": "Mochiy Pop One",
       "markdownDescription": "https://fonts.google.com/specimen/Mochiy+Pop+One",
-      "enum": [
-        "Mochiy Pop One"
-      ]
+      "const": "Mochiy Pop One"
     },
     {
       "title": "Mochiy Pop P One",
       "markdownDescription": "https://fonts.google.com/specimen/Mochiy+Pop+P+One",
-      "enum": [
-        "Mochiy Pop P One"
-      ]
+      "const": "Mochiy Pop P One"
     },
     {
       "title": "Modak",
       "markdownDescription": "https://fonts.google.com/specimen/Modak",
-      "enum": [
-        "Modak"
-      ]
+      "const": "Modak"
     },
     {
       "title": "Modern Antiqua",
       "markdownDescription": "https://fonts.google.com/specimen/Modern+Antiqua",
-      "enum": [
-        "Modern Antiqua"
-      ]
+      "const": "Modern Antiqua"
     },
     {
       "title": "Mogra",
       "markdownDescription": "https://fonts.google.com/specimen/Mogra",
-      "enum": [
-        "Mogra"
-      ]
+      "const": "Mogra"
     },
     {
       "title": "Mohave",
       "markdownDescription": "https://fonts.google.com/specimen/Mohave",
-      "enum": [
-        "Mohave"
-      ]
+      "const": "Mohave"
     },
     {
       "title": "Moirai One",
       "markdownDescription": "https://fonts.google.com/specimen/Moirai+One",
-      "enum": [
-        "Moirai One"
-      ]
+      "const": "Moirai One"
     },
     {
       "title": "Molengo",
       "markdownDescription": "https://fonts.google.com/specimen/Molengo",
-      "enum": [
-        "Molengo"
-      ]
+      "const": "Molengo"
     },
     {
       "title": "Molle",
       "markdownDescription": "https://fonts.google.com/specimen/Molle",
-      "enum": [
-        "Molle"
-      ]
+      "const": "Molle"
     },
     {
       "title": "Monda",
       "markdownDescription": "https://fonts.google.com/specimen/Monda",
-      "enum": [
-        "Monda"
-      ]
+      "const": "Monda"
     },
     {
       "title": "Monofett",
       "markdownDescription": "https://fonts.google.com/specimen/Monofett",
-      "enum": [
-        "Monofett"
-      ]
+      "const": "Monofett"
     },
     {
       "title": "Monomaniac One",
       "markdownDescription": "https://fonts.google.com/specimen/Monomaniac+One",
-      "enum": [
-        "Monomaniac One"
-      ]
+      "const": "Monomaniac One"
     },
     {
       "title": "Monoton",
       "markdownDescription": "https://fonts.google.com/specimen/Monoton",
-      "enum": [
-        "Monoton"
-      ]
+      "const": "Monoton"
     },
     {
       "title": "Monsieur La Doulaise",
       "markdownDescription": "https://fonts.google.com/specimen/Monsieur+La+Doulaise",
-      "enum": [
-        "Monsieur La Doulaise"
-      ]
+      "const": "Monsieur La Doulaise"
     },
     {
       "title": "Montaga",
       "markdownDescription": "https://fonts.google.com/specimen/Montaga",
-      "enum": [
-        "Montaga"
-      ]
+      "const": "Montaga"
     },
     {
       "title": "Montagu Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Montagu+Slab",
-      "enum": [
-        "Montagu Slab"
-      ]
+      "const": "Montagu Slab"
     },
     {
       "title": "MonteCarlo",
       "markdownDescription": "https://fonts.google.com/specimen/MonteCarlo",
-      "enum": [
-        "MonteCarlo"
-      ]
+      "const": "MonteCarlo"
     },
     {
       "title": "Montez",
       "markdownDescription": "https://fonts.google.com/specimen/Montez",
-      "enum": [
-        "Montez"
-      ]
+      "const": "Montez"
     },
     {
       "title": "Montserrat",
       "markdownDescription": "https://fonts.google.com/specimen/Montserrat",
-      "enum": [
-        "Montserrat"
-      ]
+      "const": "Montserrat"
     },
     {
       "title": "Montserrat Alternates",
       "markdownDescription": "https://fonts.google.com/specimen/Montserrat+Alternates",
-      "enum": [
-        "Montserrat Alternates"
-      ]
+      "const": "Montserrat Alternates"
     },
     {
       "title": "Montserrat Subrayada",
       "markdownDescription": "https://fonts.google.com/specimen/Montserrat+Subrayada",
-      "enum": [
-        "Montserrat Subrayada"
-      ]
+      "const": "Montserrat Subrayada"
     },
     {
       "title": "Moo Lah Lah",
       "markdownDescription": "https://fonts.google.com/specimen/Moo+Lah+Lah",
-      "enum": [
-        "Moo Lah Lah"
-      ]
+      "const": "Moo Lah Lah"
     },
     {
       "title": "Mooli",
       "markdownDescription": "https://fonts.google.com/specimen/Mooli",
-      "enum": [
-        "Mooli"
-      ]
+      "const": "Mooli"
     },
     {
       "title": "Moon Dance",
       "markdownDescription": "https://fonts.google.com/specimen/Moon+Dance",
-      "enum": [
-        "Moon Dance"
-      ]
+      "const": "Moon Dance"
     },
     {
       "title": "Moul",
       "markdownDescription": "https://fonts.google.com/specimen/Moul",
-      "enum": [
-        "Moul"
-      ]
+      "const": "Moul"
     },
     {
       "title": "Moulpali",
       "markdownDescription": "https://fonts.google.com/specimen/Moulpali",
-      "enum": [
-        "Moulpali"
-      ]
+      "const": "Moulpali"
     },
     {
       "title": "Mountains of Christmas",
       "markdownDescription": "https://fonts.google.com/specimen/Mountains+of+Christmas",
-      "enum": [
-        "Mountains of Christmas"
-      ]
+      "const": "Mountains of Christmas"
     },
     {
       "title": "Mouse Memoirs",
       "markdownDescription": "https://fonts.google.com/specimen/Mouse+Memoirs",
-      "enum": [
-        "Mouse Memoirs"
-      ]
+      "const": "Mouse Memoirs"
     },
     {
       "title": "Mr Bedfort",
       "markdownDescription": "https://fonts.google.com/specimen/Mr+Bedfort",
-      "enum": [
-        "Mr Bedfort"
-      ]
+      "const": "Mr Bedfort"
     },
     {
       "title": "Mr Dafoe",
       "markdownDescription": "https://fonts.google.com/specimen/Mr+Dafoe",
-      "enum": [
-        "Mr Dafoe"
-      ]
+      "const": "Mr Dafoe"
     },
     {
       "title": "Mr De Haviland",
       "markdownDescription": "https://fonts.google.com/specimen/Mr+De+Haviland",
-      "enum": [
-        "Mr De Haviland"
-      ]
+      "const": "Mr De Haviland"
     },
     {
       "title": "Mrs Saint Delafield",
       "markdownDescription": "https://fonts.google.com/specimen/Mrs+Saint+Delafield",
-      "enum": [
-        "Mrs Saint Delafield"
-      ]
+      "const": "Mrs Saint Delafield"
     },
     {
       "title": "Mrs Sheppards",
       "markdownDescription": "https://fonts.google.com/specimen/Mrs+Sheppards",
-      "enum": [
-        "Mrs Sheppards"
-      ]
+      "const": "Mrs Sheppards"
     },
     {
       "title": "Ms Madi",
       "markdownDescription": "https://fonts.google.com/specimen/Ms+Madi",
-      "enum": [
-        "Ms Madi"
-      ]
+      "const": "Ms Madi"
     },
     {
       "title": "Mukta",
       "markdownDescription": "https://fonts.google.com/specimen/Mukta",
-      "enum": [
-        "Mukta"
-      ]
+      "const": "Mukta"
     },
     {
       "title": "Mukta Mahee",
       "markdownDescription": "https://fonts.google.com/specimen/Mukta+Mahee",
-      "enum": [
-        "Mukta Mahee"
-      ]
+      "const": "Mukta Mahee"
     },
     {
       "title": "Mukta Malar",
       "markdownDescription": "https://fonts.google.com/specimen/Mukta+Malar",
-      "enum": [
-        "Mukta Malar"
-      ]
+      "const": "Mukta Malar"
     },
     {
       "title": "Mukta Vaani",
       "markdownDescription": "https://fonts.google.com/specimen/Mukta+Vaani",
-      "enum": [
-        "Mukta Vaani"
-      ]
+      "const": "Mukta Vaani"
     },
     {
       "title": "Mulish",
       "markdownDescription": "https://fonts.google.com/specimen/Mulish",
-      "enum": [
-        "Mulish"
-      ]
+      "const": "Mulish"
     },
     {
       "title": "Murecho",
       "markdownDescription": "https://fonts.google.com/specimen/Murecho",
-      "enum": [
-        "Murecho"
-      ]
+      "const": "Murecho"
     },
     {
       "title": "MuseoModerno",
       "markdownDescription": "https://fonts.google.com/specimen/MuseoModerno",
-      "enum": [
-        "MuseoModerno"
-      ]
+      "const": "MuseoModerno"
     },
     {
       "title": "My Soul",
       "markdownDescription": "https://fonts.google.com/specimen/My+Soul",
-      "enum": [
-        "My Soul"
-      ]
+      "const": "My Soul"
     },
     {
       "title": "Mynerve",
       "markdownDescription": "https://fonts.google.com/specimen/Mynerve",
-      "enum": [
-        "Mynerve"
-      ]
+      "const": "Mynerve"
     },
     {
       "title": "Mystery Quest",
       "markdownDescription": "https://fonts.google.com/specimen/Mystery+Quest",
-      "enum": [
-        "Mystery Quest"
-      ]
+      "const": "Mystery Quest"
     },
     {
       "title": "NTR",
       "markdownDescription": "https://fonts.google.com/specimen/NTR",
-      "enum": [
-        "NTR"
-      ]
+      "const": "NTR"
     },
     {
       "title": "Nabla",
       "markdownDescription": "https://fonts.google.com/specimen/Nabla",
-      "enum": [
-        "Nabla"
-      ]
+      "const": "Nabla"
     },
     {
       "title": "Nanum Brush Script",
       "markdownDescription": "https://fonts.google.com/specimen/Nanum+Brush+Script",
-      "enum": [
-        "Nanum Brush Script"
-      ]
+      "const": "Nanum Brush Script"
     },
     {
       "title": "Nanum Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Nanum+Gothic",
-      "enum": [
-        "Nanum Gothic"
-      ]
+      "const": "Nanum Gothic"
     },
     {
       "title": "Nanum Gothic Coding",
       "markdownDescription": "https://fonts.google.com/specimen/Nanum+Gothic+Coding",
-      "enum": [
-        "Nanum Gothic Coding"
-      ]
+      "const": "Nanum Gothic Coding"
     },
     {
       "title": "Nanum Myeongjo",
       "markdownDescription": "https://fonts.google.com/specimen/Nanum+Myeongjo",
-      "enum": [
-        "Nanum Myeongjo"
-      ]
+      "const": "Nanum Myeongjo"
     },
     {
       "title": "Nanum Pen Script",
       "markdownDescription": "https://fonts.google.com/specimen/Nanum+Pen+Script",
-      "enum": [
-        "Nanum Pen Script"
-      ]
+      "const": "Nanum Pen Script"
     },
     {
       "title": "Narnoor",
       "markdownDescription": "https://fonts.google.com/specimen/Narnoor",
-      "enum": [
-        "Narnoor"
-      ]
+      "const": "Narnoor"
     },
     {
       "title": "Neonderthaw",
       "markdownDescription": "https://fonts.google.com/specimen/Neonderthaw",
-      "enum": [
-        "Neonderthaw"
-      ]
+      "const": "Neonderthaw"
     },
     {
       "title": "Nerko One",
       "markdownDescription": "https://fonts.google.com/specimen/Nerko+One",
-      "enum": [
-        "Nerko One"
-      ]
+      "const": "Nerko One"
     },
     {
       "title": "Neucha",
       "markdownDescription": "https://fonts.google.com/specimen/Neucha",
-      "enum": [
-        "Neucha"
-      ]
+      "const": "Neucha"
     },
     {
       "title": "Neuton",
       "markdownDescription": "https://fonts.google.com/specimen/Neuton",
-      "enum": [
-        "Neuton"
-      ]
+      "const": "Neuton"
     },
     {
       "title": "New Rocker",
       "markdownDescription": "https://fonts.google.com/specimen/New+Rocker",
-      "enum": [
-        "New Rocker"
-      ]
+      "const": "New Rocker"
     },
     {
       "title": "New Tegomin",
       "markdownDescription": "https://fonts.google.com/specimen/New+Tegomin",
-      "enum": [
-        "New Tegomin"
-      ]
+      "const": "New Tegomin"
     },
     {
       "title": "News Cycle",
       "markdownDescription": "https://fonts.google.com/specimen/News+Cycle",
-      "enum": [
-        "News Cycle"
-      ]
+      "const": "News Cycle"
     },
     {
       "title": "Newsreader",
       "markdownDescription": "https://fonts.google.com/specimen/Newsreader",
-      "enum": [
-        "Newsreader"
-      ]
+      "const": "Newsreader"
     },
     {
       "title": "Niconne",
       "markdownDescription": "https://fonts.google.com/specimen/Niconne",
-      "enum": [
-        "Niconne"
-      ]
+      "const": "Niconne"
     },
     {
       "title": "Niramit",
       "markdownDescription": "https://fonts.google.com/specimen/Niramit",
-      "enum": [
-        "Niramit"
-      ]
+      "const": "Niramit"
     },
     {
       "title": "Nixie One",
       "markdownDescription": "https://fonts.google.com/specimen/Nixie+One",
-      "enum": [
-        "Nixie One"
-      ]
+      "const": "Nixie One"
     },
     {
       "title": "Nobile",
       "markdownDescription": "https://fonts.google.com/specimen/Nobile",
-      "enum": [
-        "Nobile"
-      ]
+      "const": "Nobile"
     },
     {
       "title": "Nokora",
       "markdownDescription": "https://fonts.google.com/specimen/Nokora",
-      "enum": [
-        "Nokora"
-      ]
+      "const": "Nokora"
     },
     {
       "title": "Norican",
       "markdownDescription": "https://fonts.google.com/specimen/Norican",
-      "enum": [
-        "Norican"
-      ]
+      "const": "Norican"
     },
     {
       "title": "Nosifer",
       "markdownDescription": "https://fonts.google.com/specimen/Nosifer",
-      "enum": [
-        "Nosifer"
-      ]
+      "const": "Nosifer"
     },
     {
       "title": "Notable",
       "markdownDescription": "https://fonts.google.com/specimen/Notable",
-      "enum": [
-        "Notable"
-      ]
+      "const": "Notable"
     },
     {
       "title": "Nothing You Could Do",
       "markdownDescription": "https://fonts.google.com/specimen/Nothing+You+Could+Do",
-      "enum": [
-        "Nothing You Could Do"
-      ]
+      "const": "Nothing You Could Do"
     },
     {
       "title": "Noticia Text",
       "markdownDescription": "https://fonts.google.com/specimen/Noticia+Text",
-      "enum": [
-        "Noticia Text"
-      ]
+      "const": "Noticia Text"
     },
     {
       "title": "Noto Color Emoji",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Color+Emoji",
-      "enum": [
-        "Noto Color Emoji"
-      ]
+      "const": "Noto Color Emoji"
     },
     {
       "title": "Noto Emoji",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Emoji",
-      "enum": [
-        "Noto Emoji"
-      ]
+      "const": "Noto Emoji"
     },
     {
       "title": "Noto Kufi Arabic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Kufi+Arabic",
-      "enum": [
-        "Noto Kufi Arabic"
-      ]
+      "const": "Noto Kufi Arabic"
     },
     {
       "title": "Noto Music",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Music",
-      "enum": [
-        "Noto Music"
-      ]
+      "const": "Noto Music"
     },
     {
       "title": "Noto Naskh Arabic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Naskh+Arabic",
-      "enum": [
-        "Noto Naskh Arabic"
-      ]
+      "const": "Noto Naskh Arabic"
     },
     {
       "title": "Noto Nastaliq Urdu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Nastaliq+Urdu",
-      "enum": [
-        "Noto Nastaliq Urdu"
-      ]
+      "const": "Noto Nastaliq Urdu"
     },
     {
       "title": "Noto Rashi Hebrew",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Rashi+Hebrew",
-      "enum": [
-        "Noto Rashi Hebrew"
-      ]
+      "const": "Noto Rashi Hebrew"
     },
     {
       "title": "Noto Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans",
-      "enum": [
-        "Noto Sans"
-      ]
+      "const": "Noto Sans"
     },
     {
       "title": "Noto Sans Adlam",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Adlam",
-      "enum": [
-        "Noto Sans Adlam"
-      ]
+      "const": "Noto Sans Adlam"
     },
     {
       "title": "Noto Sans Adlam Unjoined",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Adlam+Unjoined",
-      "enum": [
-        "Noto Sans Adlam Unjoined"
-      ]
+      "const": "Noto Sans Adlam Unjoined"
     },
     {
       "title": "Noto Sans Anatolian Hieroglyphs",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Anatolian+Hieroglyphs",
-      "enum": [
-        "Noto Sans Anatolian Hieroglyphs"
-      ]
+      "const": "Noto Sans Anatolian Hieroglyphs"
     },
     {
       "title": "Noto Sans Arabic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Arabic",
-      "enum": [
-        "Noto Sans Arabic"
-      ]
+      "const": "Noto Sans Arabic"
     },
     {
       "title": "Noto Sans Armenian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Armenian",
-      "enum": [
-        "Noto Sans Armenian"
-      ]
+      "const": "Noto Sans Armenian"
     },
     {
       "title": "Noto Sans Avestan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Avestan",
-      "enum": [
-        "Noto Sans Avestan"
-      ]
+      "const": "Noto Sans Avestan"
     },
     {
       "title": "Noto Sans Balinese",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Balinese",
-      "enum": [
-        "Noto Sans Balinese"
-      ]
+      "const": "Noto Sans Balinese"
     },
     {
       "title": "Noto Sans Bamum",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Bamum",
-      "enum": [
-        "Noto Sans Bamum"
-      ]
+      "const": "Noto Sans Bamum"
     },
     {
       "title": "Noto Sans Bassa Vah",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Bassa+Vah",
-      "enum": [
-        "Noto Sans Bassa Vah"
-      ]
+      "const": "Noto Sans Bassa Vah"
     },
     {
       "title": "Noto Sans Batak",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Batak",
-      "enum": [
-        "Noto Sans Batak"
-      ]
+      "const": "Noto Sans Batak"
     },
     {
       "title": "Noto Sans Bengali",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Bengali",
-      "enum": [
-        "Noto Sans Bengali"
-      ]
+      "const": "Noto Sans Bengali"
     },
     {
       "title": "Noto Sans Bhaiksuki",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Bhaiksuki",
-      "enum": [
-        "Noto Sans Bhaiksuki"
-      ]
+      "const": "Noto Sans Bhaiksuki"
     },
     {
       "title": "Noto Sans Brahmi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Brahmi",
-      "enum": [
-        "Noto Sans Brahmi"
-      ]
+      "const": "Noto Sans Brahmi"
     },
     {
       "title": "Noto Sans Buginese",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Buginese",
-      "enum": [
-        "Noto Sans Buginese"
-      ]
+      "const": "Noto Sans Buginese"
     },
     {
       "title": "Noto Sans Buhid",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Buhid",
-      "enum": [
-        "Noto Sans Buhid"
-      ]
+      "const": "Noto Sans Buhid"
     },
     {
       "title": "Noto Sans Canadian Aboriginal",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Canadian+Aboriginal",
-      "enum": [
-        "Noto Sans Canadian Aboriginal"
-      ]
+      "const": "Noto Sans Canadian Aboriginal"
     },
     {
       "title": "Noto Sans Carian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Carian",
-      "enum": [
-        "Noto Sans Carian"
-      ]
+      "const": "Noto Sans Carian"
     },
     {
       "title": "Noto Sans Caucasian Albanian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Caucasian+Albanian",
-      "enum": [
-        "Noto Sans Caucasian Albanian"
-      ]
+      "const": "Noto Sans Caucasian Albanian"
     },
     {
       "title": "Noto Sans Chakma",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Chakma",
-      "enum": [
-        "Noto Sans Chakma"
-      ]
+      "const": "Noto Sans Chakma"
     },
     {
       "title": "Noto Sans Cham",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Cham",
-      "enum": [
-        "Noto Sans Cham"
-      ]
+      "const": "Noto Sans Cham"
     },
     {
       "title": "Noto Sans Cherokee",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Cherokee",
-      "enum": [
-        "Noto Sans Cherokee"
-      ]
+      "const": "Noto Sans Cherokee"
     },
     {
       "title": "Noto Sans Chorasmian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Chorasmian",
-      "enum": [
-        "Noto Sans Chorasmian"
-      ]
+      "const": "Noto Sans Chorasmian"
     },
     {
       "title": "Noto Sans Coptic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Coptic",
-      "enum": [
-        "Noto Sans Coptic"
-      ]
+      "const": "Noto Sans Coptic"
     },
     {
       "title": "Noto Sans Cuneiform",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Cuneiform",
-      "enum": [
-        "Noto Sans Cuneiform"
-      ]
+      "const": "Noto Sans Cuneiform"
     },
     {
       "title": "Noto Sans Cypriot",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Cypriot",
-      "enum": [
-        "Noto Sans Cypriot"
-      ]
+      "const": "Noto Sans Cypriot"
     },
     {
       "title": "Noto Sans Cypro Minoan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Cypro+Minoan",
-      "enum": [
-        "Noto Sans Cypro Minoan"
-      ]
+      "const": "Noto Sans Cypro Minoan"
     },
     {
       "title": "Noto Sans Deseret",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Deseret",
-      "enum": [
-        "Noto Sans Deseret"
-      ]
+      "const": "Noto Sans Deseret"
     },
     {
       "title": "Noto Sans Devanagari",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Devanagari",
-      "enum": [
-        "Noto Sans Devanagari"
-      ]
+      "const": "Noto Sans Devanagari"
     },
     {
       "title": "Noto Sans Display",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Display",
-      "enum": [
-        "Noto Sans Display"
-      ]
+      "const": "Noto Sans Display"
     },
     {
       "title": "Noto Sans Duployan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Duployan",
-      "enum": [
-        "Noto Sans Duployan"
-      ]
+      "const": "Noto Sans Duployan"
     },
     {
       "title": "Noto Sans Egyptian Hieroglyphs",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Egyptian+Hieroglyphs",
-      "enum": [
-        "Noto Sans Egyptian Hieroglyphs"
-      ]
+      "const": "Noto Sans Egyptian Hieroglyphs"
     },
     {
       "title": "Noto Sans Elbasan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Elbasan",
-      "enum": [
-        "Noto Sans Elbasan"
-      ]
+      "const": "Noto Sans Elbasan"
     },
     {
       "title": "Noto Sans Elymaic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Elymaic",
-      "enum": [
-        "Noto Sans Elymaic"
-      ]
+      "const": "Noto Sans Elymaic"
     },
     {
       "title": "Noto Sans Ethiopic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Ethiopic",
-      "enum": [
-        "Noto Sans Ethiopic"
-      ]
+      "const": "Noto Sans Ethiopic"
     },
     {
       "title": "Noto Sans Georgian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Georgian",
-      "enum": [
-        "Noto Sans Georgian"
-      ]
+      "const": "Noto Sans Georgian"
     },
     {
       "title": "Noto Sans Glagolitic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Glagolitic",
-      "enum": [
-        "Noto Sans Glagolitic"
-      ]
+      "const": "Noto Sans Glagolitic"
     },
     {
       "title": "Noto Sans Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Gothic",
-      "enum": [
-        "Noto Sans Gothic"
-      ]
+      "const": "Noto Sans Gothic"
     },
     {
       "title": "Noto Sans Grantha",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Grantha",
-      "enum": [
-        "Noto Sans Grantha"
-      ]
+      "const": "Noto Sans Grantha"
     },
     {
       "title": "Noto Sans Gujarati",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Gujarati",
-      "enum": [
-        "Noto Sans Gujarati"
-      ]
+      "const": "Noto Sans Gujarati"
     },
     {
       "title": "Noto Sans Gunjala Gondi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Gunjala+Gondi",
-      "enum": [
-        "Noto Sans Gunjala Gondi"
-      ]
+      "const": "Noto Sans Gunjala Gondi"
     },
     {
       "title": "Noto Sans Gurmukhi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Gurmukhi",
-      "enum": [
-        "Noto Sans Gurmukhi"
-      ]
+      "const": "Noto Sans Gurmukhi"
     },
     {
       "title": "Noto Sans HK",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+HK",
-      "enum": [
-        "Noto Sans HK"
-      ]
+      "const": "Noto Sans HK"
     },
     {
       "title": "Noto Sans Hanifi Rohingya",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Hanifi+Rohingya",
-      "enum": [
-        "Noto Sans Hanifi Rohingya"
-      ]
+      "const": "Noto Sans Hanifi Rohingya"
     },
     {
       "title": "Noto Sans Hanunoo",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Hanunoo",
-      "enum": [
-        "Noto Sans Hanunoo"
-      ]
+      "const": "Noto Sans Hanunoo"
     },
     {
       "title": "Noto Sans Hatran",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Hatran",
-      "enum": [
-        "Noto Sans Hatran"
-      ]
+      "const": "Noto Sans Hatran"
     },
     {
       "title": "Noto Sans Hebrew",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Hebrew",
-      "enum": [
-        "Noto Sans Hebrew"
-      ]
+      "const": "Noto Sans Hebrew"
     },
     {
       "title": "Noto Sans Imperial Aramaic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Imperial+Aramaic",
-      "enum": [
-        "Noto Sans Imperial Aramaic"
-      ]
+      "const": "Noto Sans Imperial Aramaic"
     },
     {
       "title": "Noto Sans Indic Siyaq Numbers",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Indic+Siyaq+Numbers",
-      "enum": [
-        "Noto Sans Indic Siyaq Numbers"
-      ]
+      "const": "Noto Sans Indic Siyaq Numbers"
     },
     {
       "title": "Noto Sans Inscriptional Pahlavi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Inscriptional+Pahlavi",
-      "enum": [
-        "Noto Sans Inscriptional Pahlavi"
-      ]
+      "const": "Noto Sans Inscriptional Pahlavi"
     },
     {
       "title": "Noto Sans Inscriptional Parthian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Inscriptional+Parthian",
-      "enum": [
-        "Noto Sans Inscriptional Parthian"
-      ]
+      "const": "Noto Sans Inscriptional Parthian"
     },
     {
       "title": "Noto Sans JP",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+JP",
-      "enum": [
-        "Noto Sans JP"
-      ]
+      "const": "Noto Sans JP"
     },
     {
       "title": "Noto Sans Javanese",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Javanese",
-      "enum": [
-        "Noto Sans Javanese"
-      ]
+      "const": "Noto Sans Javanese"
     },
     {
       "title": "Noto Sans KR",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+KR",
-      "enum": [
-        "Noto Sans KR"
-      ]
+      "const": "Noto Sans KR"
     },
     {
       "title": "Noto Sans Kaithi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Kaithi",
-      "enum": [
-        "Noto Sans Kaithi"
-      ]
+      "const": "Noto Sans Kaithi"
     },
     {
       "title": "Noto Sans Kannada",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Kannada",
-      "enum": [
-        "Noto Sans Kannada"
-      ]
+      "const": "Noto Sans Kannada"
     },
     {
       "title": "Noto Sans Kayah Li",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Kayah+Li",
-      "enum": [
-        "Noto Sans Kayah Li"
-      ]
+      "const": "Noto Sans Kayah Li"
     },
     {
       "title": "Noto Sans Kharoshthi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Kharoshthi",
-      "enum": [
-        "Noto Sans Kharoshthi"
-      ]
+      "const": "Noto Sans Kharoshthi"
     },
     {
       "title": "Noto Sans Khmer",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Khmer",
-      "enum": [
-        "Noto Sans Khmer"
-      ]
+      "const": "Noto Sans Khmer"
     },
     {
       "title": "Noto Sans Khojki",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Khojki",
-      "enum": [
-        "Noto Sans Khojki"
-      ]
+      "const": "Noto Sans Khojki"
     },
     {
       "title": "Noto Sans Khudawadi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Khudawadi",
-      "enum": [
-        "Noto Sans Khudawadi"
-      ]
+      "const": "Noto Sans Khudawadi"
     },
     {
       "title": "Noto Sans Lao",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lao",
-      "enum": [
-        "Noto Sans Lao"
-      ]
+      "const": "Noto Sans Lao"
     },
     {
       "title": "Noto Sans Lao Looped",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lao+Looped",
-      "enum": [
-        "Noto Sans Lao Looped"
-      ]
+      "const": "Noto Sans Lao Looped"
     },
     {
       "title": "Noto Sans Lepcha",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lepcha",
-      "enum": [
-        "Noto Sans Lepcha"
-      ]
+      "const": "Noto Sans Lepcha"
     },
     {
       "title": "Noto Sans Limbu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Limbu",
-      "enum": [
-        "Noto Sans Limbu"
-      ]
+      "const": "Noto Sans Limbu"
     },
     {
       "title": "Noto Sans Linear A",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Linear+A",
-      "enum": [
-        "Noto Sans Linear A"
-      ]
+      "const": "Noto Sans Linear A"
     },
     {
       "title": "Noto Sans Linear B",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Linear+B",
-      "enum": [
-        "Noto Sans Linear B"
-      ]
+      "const": "Noto Sans Linear B"
     },
     {
       "title": "Noto Sans Lisu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lisu",
-      "enum": [
-        "Noto Sans Lisu"
-      ]
+      "const": "Noto Sans Lisu"
     },
     {
       "title": "Noto Sans Lycian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lycian",
-      "enum": [
-        "Noto Sans Lycian"
-      ]
+      "const": "Noto Sans Lycian"
     },
     {
       "title": "Noto Sans Lydian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Lydian",
-      "enum": [
-        "Noto Sans Lydian"
-      ]
+      "const": "Noto Sans Lydian"
     },
     {
       "title": "Noto Sans Mahajani",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mahajani",
-      "enum": [
-        "Noto Sans Mahajani"
-      ]
+      "const": "Noto Sans Mahajani"
     },
     {
       "title": "Noto Sans Malayalam",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Malayalam",
-      "enum": [
-        "Noto Sans Malayalam"
-      ]
+      "const": "Noto Sans Malayalam"
     },
     {
       "title": "Noto Sans Mandaic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mandaic",
-      "enum": [
-        "Noto Sans Mandaic"
-      ]
+      "const": "Noto Sans Mandaic"
     },
     {
       "title": "Noto Sans Manichaean",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Manichaean",
-      "enum": [
-        "Noto Sans Manichaean"
-      ]
+      "const": "Noto Sans Manichaean"
     },
     {
       "title": "Noto Sans Marchen",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Marchen",
-      "enum": [
-        "Noto Sans Marchen"
-      ]
+      "const": "Noto Sans Marchen"
     },
     {
       "title": "Noto Sans Masaram Gondi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Masaram+Gondi",
-      "enum": [
-        "Noto Sans Masaram Gondi"
-      ]
+      "const": "Noto Sans Masaram Gondi"
     },
     {
       "title": "Noto Sans Math",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Math",
-      "enum": [
-        "Noto Sans Math"
-      ]
+      "const": "Noto Sans Math"
     },
     {
       "title": "Noto Sans Mayan Numerals",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mayan+Numerals",
-      "enum": [
-        "Noto Sans Mayan Numerals"
-      ]
+      "const": "Noto Sans Mayan Numerals"
     },
     {
       "title": "Noto Sans Medefaidrin",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Medefaidrin",
-      "enum": [
-        "Noto Sans Medefaidrin"
-      ]
+      "const": "Noto Sans Medefaidrin"
     },
     {
       "title": "Noto Sans Meetei Mayek",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Meetei+Mayek",
-      "enum": [
-        "Noto Sans Meetei Mayek"
-      ]
+      "const": "Noto Sans Meetei Mayek"
     },
     {
       "title": "Noto Sans Mende Kikakui",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mende+Kikakui",
-      "enum": [
-        "Noto Sans Mende Kikakui"
-      ]
+      "const": "Noto Sans Mende Kikakui"
     },
     {
       "title": "Noto Sans Meroitic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Meroitic",
-      "enum": [
-        "Noto Sans Meroitic"
-      ]
+      "const": "Noto Sans Meroitic"
     },
     {
       "title": "Noto Sans Miao",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Miao",
-      "enum": [
-        "Noto Sans Miao"
-      ]
+      "const": "Noto Sans Miao"
     },
     {
       "title": "Noto Sans Modi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Modi",
-      "enum": [
-        "Noto Sans Modi"
-      ]
+      "const": "Noto Sans Modi"
     },
     {
       "title": "Noto Sans Mongolian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mongolian",
-      "enum": [
-        "Noto Sans Mongolian"
-      ]
+      "const": "Noto Sans Mongolian"
     },
     {
       "title": "Noto Sans Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mono",
-      "enum": [
-        "Noto Sans Mono"
-      ]
+      "const": "Noto Sans Mono"
     },
     {
       "title": "Noto Sans Mro",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Mro",
-      "enum": [
-        "Noto Sans Mro"
-      ]
+      "const": "Noto Sans Mro"
     },
     {
       "title": "Noto Sans Multani",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Multani",
-      "enum": [
-        "Noto Sans Multani"
-      ]
+      "const": "Noto Sans Multani"
     },
     {
       "title": "Noto Sans Myanmar",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Myanmar",
-      "enum": [
-        "Noto Sans Myanmar"
-      ]
+      "const": "Noto Sans Myanmar"
     },
     {
       "title": "Noto Sans NKo",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+NKo",
-      "enum": [
-        "Noto Sans NKo"
-      ]
+      "const": "Noto Sans NKo"
     },
     {
       "title": "Noto Sans NKo Unjoined",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+NKo+Unjoined",
-      "enum": [
-        "Noto Sans NKo Unjoined"
-      ]
+      "const": "Noto Sans NKo Unjoined"
     },
     {
       "title": "Noto Sans Nabataean",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Nabataean",
-      "enum": [
-        "Noto Sans Nabataean"
-      ]
+      "const": "Noto Sans Nabataean"
     },
     {
       "title": "Noto Sans Nag Mundari",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Nag+Mundari",
-      "enum": [
-        "Noto Sans Nag Mundari"
-      ]
+      "const": "Noto Sans Nag Mundari"
     },
     {
       "title": "Noto Sans Nandinagari",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Nandinagari",
-      "enum": [
-        "Noto Sans Nandinagari"
-      ]
+      "const": "Noto Sans Nandinagari"
     },
     {
       "title": "Noto Sans New Tai Lue",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+New+Tai+Lue",
-      "enum": [
-        "Noto Sans New Tai Lue"
-      ]
+      "const": "Noto Sans New Tai Lue"
     },
     {
       "title": "Noto Sans Newa",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Newa",
-      "enum": [
-        "Noto Sans Newa"
-      ]
+      "const": "Noto Sans Newa"
     },
     {
       "title": "Noto Sans Nushu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Nushu",
-      "enum": [
-        "Noto Sans Nushu"
-      ]
+      "const": "Noto Sans Nushu"
     },
     {
       "title": "Noto Sans Ogham",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Ogham",
-      "enum": [
-        "Noto Sans Ogham"
-      ]
+      "const": "Noto Sans Ogham"
     },
     {
       "title": "Noto Sans Ol Chiki",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Ol+Chiki",
-      "enum": [
-        "Noto Sans Ol Chiki"
-      ]
+      "const": "Noto Sans Ol Chiki"
     },
     {
       "title": "Noto Sans Old Hungarian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Hungarian",
-      "enum": [
-        "Noto Sans Old Hungarian"
-      ]
+      "const": "Noto Sans Old Hungarian"
     },
     {
       "title": "Noto Sans Old Italic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Italic",
-      "enum": [
-        "Noto Sans Old Italic"
-      ]
+      "const": "Noto Sans Old Italic"
     },
     {
       "title": "Noto Sans Old North Arabian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+North+Arabian",
-      "enum": [
-        "Noto Sans Old North Arabian"
-      ]
+      "const": "Noto Sans Old North Arabian"
     },
     {
       "title": "Noto Sans Old Permic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Permic",
-      "enum": [
-        "Noto Sans Old Permic"
-      ]
+      "const": "Noto Sans Old Permic"
     },
     {
       "title": "Noto Sans Old Persian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Persian",
-      "enum": [
-        "Noto Sans Old Persian"
-      ]
+      "const": "Noto Sans Old Persian"
     },
     {
       "title": "Noto Sans Old Sogdian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Sogdian",
-      "enum": [
-        "Noto Sans Old Sogdian"
-      ]
+      "const": "Noto Sans Old Sogdian"
     },
     {
       "title": "Noto Sans Old South Arabian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+South+Arabian",
-      "enum": [
-        "Noto Sans Old South Arabian"
-      ]
+      "const": "Noto Sans Old South Arabian"
     },
     {
       "title": "Noto Sans Old Turkic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Old+Turkic",
-      "enum": [
-        "Noto Sans Old Turkic"
-      ]
+      "const": "Noto Sans Old Turkic"
     },
     {
       "title": "Noto Sans Oriya",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Oriya",
-      "enum": [
-        "Noto Sans Oriya"
-      ]
+      "const": "Noto Sans Oriya"
     },
     {
       "title": "Noto Sans Osage",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Osage",
-      "enum": [
-        "Noto Sans Osage"
-      ]
+      "const": "Noto Sans Osage"
     },
     {
       "title": "Noto Sans Osmanya",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Osmanya",
-      "enum": [
-        "Noto Sans Osmanya"
-      ]
+      "const": "Noto Sans Osmanya"
     },
     {
       "title": "Noto Sans Pahawh Hmong",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Pahawh+Hmong",
-      "enum": [
-        "Noto Sans Pahawh Hmong"
-      ]
+      "const": "Noto Sans Pahawh Hmong"
     },
     {
       "title": "Noto Sans Palmyrene",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Palmyrene",
-      "enum": [
-        "Noto Sans Palmyrene"
-      ]
+      "const": "Noto Sans Palmyrene"
     },
     {
       "title": "Noto Sans Pau Cin Hau",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Pau+Cin+Hau",
-      "enum": [
-        "Noto Sans Pau Cin Hau"
-      ]
+      "const": "Noto Sans Pau Cin Hau"
     },
     {
       "title": "Noto Sans Phags Pa",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Phags+Pa",
-      "enum": [
-        "Noto Sans Phags Pa"
-      ]
+      "const": "Noto Sans Phags Pa"
     },
     {
       "title": "Noto Sans Phoenician",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Phoenician",
-      "enum": [
-        "Noto Sans Phoenician"
-      ]
+      "const": "Noto Sans Phoenician"
     },
     {
       "title": "Noto Sans Psalter Pahlavi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Psalter+Pahlavi",
-      "enum": [
-        "Noto Sans Psalter Pahlavi"
-      ]
+      "const": "Noto Sans Psalter Pahlavi"
     },
     {
       "title": "Noto Sans Rejang",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Rejang",
-      "enum": [
-        "Noto Sans Rejang"
-      ]
+      "const": "Noto Sans Rejang"
     },
     {
       "title": "Noto Sans Runic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Runic",
-      "enum": [
-        "Noto Sans Runic"
-      ]
+      "const": "Noto Sans Runic"
     },
     {
       "title": "Noto Sans SC",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+SC",
-      "enum": [
-        "Noto Sans SC"
-      ]
+      "const": "Noto Sans SC"
     },
     {
       "title": "Noto Sans Samaritan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Samaritan",
-      "enum": [
-        "Noto Sans Samaritan"
-      ]
+      "const": "Noto Sans Samaritan"
     },
     {
       "title": "Noto Sans Saurashtra",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Saurashtra",
-      "enum": [
-        "Noto Sans Saurashtra"
-      ]
+      "const": "Noto Sans Saurashtra"
     },
     {
       "title": "Noto Sans Sharada",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Sharada",
-      "enum": [
-        "Noto Sans Sharada"
-      ]
+      "const": "Noto Sans Sharada"
     },
     {
       "title": "Noto Sans Shavian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Shavian",
-      "enum": [
-        "Noto Sans Shavian"
-      ]
+      "const": "Noto Sans Shavian"
     },
     {
       "title": "Noto Sans Siddham",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Siddham",
-      "enum": [
-        "Noto Sans Siddham"
-      ]
+      "const": "Noto Sans Siddham"
     },
     {
       "title": "Noto Sans SignWriting",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+SignWriting",
-      "enum": [
-        "Noto Sans SignWriting"
-      ]
+      "const": "Noto Sans SignWriting"
     },
     {
       "title": "Noto Sans Sinhala",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Sinhala",
-      "enum": [
-        "Noto Sans Sinhala"
-      ]
+      "const": "Noto Sans Sinhala"
     },
     {
       "title": "Noto Sans Sogdian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Sogdian",
-      "enum": [
-        "Noto Sans Sogdian"
-      ]
+      "const": "Noto Sans Sogdian"
     },
     {
       "title": "Noto Sans Sora Sompeng",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Sora+Sompeng",
-      "enum": [
-        "Noto Sans Sora Sompeng"
-      ]
+      "const": "Noto Sans Sora Sompeng"
     },
     {
       "title": "Noto Sans Soyombo",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Soyombo",
-      "enum": [
-        "Noto Sans Soyombo"
-      ]
+      "const": "Noto Sans Soyombo"
     },
     {
       "title": "Noto Sans Sundanese",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Sundanese",
-      "enum": [
-        "Noto Sans Sundanese"
-      ]
+      "const": "Noto Sans Sundanese"
     },
     {
       "title": "Noto Sans Syloti Nagri",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Syloti+Nagri",
-      "enum": [
-        "Noto Sans Syloti Nagri"
-      ]
+      "const": "Noto Sans Syloti Nagri"
     },
     {
       "title": "Noto Sans Symbols",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Symbols",
-      "enum": [
-        "Noto Sans Symbols"
-      ]
+      "const": "Noto Sans Symbols"
     },
     {
       "title": "Noto Sans Symbols 2",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Symbols+2",
-      "enum": [
-        "Noto Sans Symbols 2"
-      ]
+      "const": "Noto Sans Symbols 2"
     },
     {
       "title": "Noto Sans Syriac",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Syriac",
-      "enum": [
-        "Noto Sans Syriac"
-      ]
+      "const": "Noto Sans Syriac"
     },
     {
       "title": "Noto Sans Syriac Eastern",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Syriac+Eastern",
-      "enum": [
-        "Noto Sans Syriac Eastern"
-      ]
+      "const": "Noto Sans Syriac Eastern"
     },
     {
       "title": "Noto Sans TC",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+TC",
-      "enum": [
-        "Noto Sans TC"
-      ]
+      "const": "Noto Sans TC"
     },
     {
       "title": "Noto Sans Tagalog",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tagalog",
-      "enum": [
-        "Noto Sans Tagalog"
-      ]
+      "const": "Noto Sans Tagalog"
     },
     {
       "title": "Noto Sans Tagbanwa",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tagbanwa",
-      "enum": [
-        "Noto Sans Tagbanwa"
-      ]
+      "const": "Noto Sans Tagbanwa"
     },
     {
       "title": "Noto Sans Tai Le",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tai+Le",
-      "enum": [
-        "Noto Sans Tai Le"
-      ]
+      "const": "Noto Sans Tai Le"
     },
     {
       "title": "Noto Sans Tai Tham",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tai+Tham",
-      "enum": [
-        "Noto Sans Tai Tham"
-      ]
+      "const": "Noto Sans Tai Tham"
     },
     {
       "title": "Noto Sans Tai Viet",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tai+Viet",
-      "enum": [
-        "Noto Sans Tai Viet"
-      ]
+      "const": "Noto Sans Tai Viet"
     },
     {
       "title": "Noto Sans Takri",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Takri",
-      "enum": [
-        "Noto Sans Takri"
-      ]
+      "const": "Noto Sans Takri"
     },
     {
       "title": "Noto Sans Tamil",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tamil",
-      "enum": [
-        "Noto Sans Tamil"
-      ]
+      "const": "Noto Sans Tamil"
     },
     {
       "title": "Noto Sans Tamil Supplement",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tamil+Supplement",
-      "enum": [
-        "Noto Sans Tamil Supplement"
-      ]
+      "const": "Noto Sans Tamil Supplement"
     },
     {
       "title": "Noto Sans Tangsa",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tangsa",
-      "enum": [
-        "Noto Sans Tangsa"
-      ]
+      "const": "Noto Sans Tangsa"
     },
     {
       "title": "Noto Sans Telugu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Telugu",
-      "enum": [
-        "Noto Sans Telugu"
-      ]
+      "const": "Noto Sans Telugu"
     },
     {
       "title": "Noto Sans Thaana",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Thaana",
-      "enum": [
-        "Noto Sans Thaana"
-      ]
+      "const": "Noto Sans Thaana"
     },
     {
       "title": "Noto Sans Thai",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Thai",
-      "enum": [
-        "Noto Sans Thai"
-      ]
+      "const": "Noto Sans Thai"
     },
     {
       "title": "Noto Sans Thai Looped",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Thai+Looped",
-      "enum": [
-        "Noto Sans Thai Looped"
-      ]
+      "const": "Noto Sans Thai Looped"
     },
     {
       "title": "Noto Sans Tifinagh",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tifinagh",
-      "enum": [
-        "Noto Sans Tifinagh"
-      ]
+      "const": "Noto Sans Tifinagh"
     },
     {
       "title": "Noto Sans Tirhuta",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Tirhuta",
-      "enum": [
-        "Noto Sans Tirhuta"
-      ]
+      "const": "Noto Sans Tirhuta"
     },
     {
       "title": "Noto Sans Ugaritic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Ugaritic",
-      "enum": [
-        "Noto Sans Ugaritic"
-      ]
+      "const": "Noto Sans Ugaritic"
     },
     {
       "title": "Noto Sans Vai",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Vai",
-      "enum": [
-        "Noto Sans Vai"
-      ]
+      "const": "Noto Sans Vai"
     },
     {
       "title": "Noto Sans Vithkuqi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Vithkuqi",
-      "enum": [
-        "Noto Sans Vithkuqi"
-      ]
+      "const": "Noto Sans Vithkuqi"
     },
     {
       "title": "Noto Sans Wancho",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Wancho",
-      "enum": [
-        "Noto Sans Wancho"
-      ]
+      "const": "Noto Sans Wancho"
     },
     {
       "title": "Noto Sans Warang Citi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Warang+Citi",
-      "enum": [
-        "Noto Sans Warang Citi"
-      ]
+      "const": "Noto Sans Warang Citi"
     },
     {
       "title": "Noto Sans Yi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Yi",
-      "enum": [
-        "Noto Sans Yi"
-      ]
+      "const": "Noto Sans Yi"
     },
     {
       "title": "Noto Sans Zanabazar Square",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Sans+Zanabazar+Square",
-      "enum": [
-        "Noto Sans Zanabazar Square"
-      ]
+      "const": "Noto Sans Zanabazar Square"
     },
     {
       "title": "Noto Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif",
-      "enum": [
-        "Noto Serif"
-      ]
+      "const": "Noto Serif"
     },
     {
       "title": "Noto Serif Ahom",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Ahom",
-      "enum": [
-        "Noto Serif Ahom"
-      ]
+      "const": "Noto Serif Ahom"
     },
     {
       "title": "Noto Serif Armenian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Armenian",
-      "enum": [
-        "Noto Serif Armenian"
-      ]
+      "const": "Noto Serif Armenian"
     },
     {
       "title": "Noto Serif Balinese",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Balinese",
-      "enum": [
-        "Noto Serif Balinese"
-      ]
+      "const": "Noto Serif Balinese"
     },
     {
       "title": "Noto Serif Bengali",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Bengali",
-      "enum": [
-        "Noto Serif Bengali"
-      ]
+      "const": "Noto Serif Bengali"
     },
     {
       "title": "Noto Serif Devanagari",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Devanagari",
-      "enum": [
-        "Noto Serif Devanagari"
-      ]
+      "const": "Noto Serif Devanagari"
     },
     {
       "title": "Noto Serif Display",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Display",
-      "enum": [
-        "Noto Serif Display"
-      ]
+      "const": "Noto Serif Display"
     },
     {
       "title": "Noto Serif Dogra",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Dogra",
-      "enum": [
-        "Noto Serif Dogra"
-      ]
+      "const": "Noto Serif Dogra"
     },
     {
       "title": "Noto Serif Ethiopic",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Ethiopic",
-      "enum": [
-        "Noto Serif Ethiopic"
-      ]
+      "const": "Noto Serif Ethiopic"
     },
     {
       "title": "Noto Serif Georgian",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Georgian",
-      "enum": [
-        "Noto Serif Georgian"
-      ]
+      "const": "Noto Serif Georgian"
     },
     {
       "title": "Noto Serif Grantha",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Grantha",
-      "enum": [
-        "Noto Serif Grantha"
-      ]
+      "const": "Noto Serif Grantha"
     },
     {
       "title": "Noto Serif Gujarati",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Gujarati",
-      "enum": [
-        "Noto Serif Gujarati"
-      ]
+      "const": "Noto Serif Gujarati"
     },
     {
       "title": "Noto Serif Gurmukhi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Gurmukhi",
-      "enum": [
-        "Noto Serif Gurmukhi"
-      ]
+      "const": "Noto Serif Gurmukhi"
     },
     {
       "title": "Noto Serif HK",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+HK",
-      "enum": [
-        "Noto Serif HK"
-      ]
+      "const": "Noto Serif HK"
     },
     {
       "title": "Noto Serif Hebrew",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Hebrew",
-      "enum": [
-        "Noto Serif Hebrew"
-      ]
+      "const": "Noto Serif Hebrew"
     },
     {
       "title": "Noto Serif JP",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+JP",
-      "enum": [
-        "Noto Serif JP"
-      ]
+      "const": "Noto Serif JP"
     },
     {
       "title": "Noto Serif KR",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+KR",
-      "enum": [
-        "Noto Serif KR"
-      ]
+      "const": "Noto Serif KR"
     },
     {
       "title": "Noto Serif Kannada",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Kannada",
-      "enum": [
-        "Noto Serif Kannada"
-      ]
+      "const": "Noto Serif Kannada"
     },
     {
       "title": "Noto Serif Khitan Small Script",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Khitan+Small+Script",
-      "enum": [
-        "Noto Serif Khitan Small Script"
-      ]
+      "const": "Noto Serif Khitan Small Script"
     },
     {
       "title": "Noto Serif Khmer",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Khmer",
-      "enum": [
-        "Noto Serif Khmer"
-      ]
+      "const": "Noto Serif Khmer"
     },
     {
       "title": "Noto Serif Khojki",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Khojki",
-      "enum": [
-        "Noto Serif Khojki"
-      ]
+      "const": "Noto Serif Khojki"
     },
     {
       "title": "Noto Serif Lao",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Lao",
-      "enum": [
-        "Noto Serif Lao"
-      ]
+      "const": "Noto Serif Lao"
     },
     {
       "title": "Noto Serif Makasar",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Makasar",
-      "enum": [
-        "Noto Serif Makasar"
-      ]
+      "const": "Noto Serif Makasar"
     },
     {
       "title": "Noto Serif Malayalam",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Malayalam",
-      "enum": [
-        "Noto Serif Malayalam"
-      ]
+      "const": "Noto Serif Malayalam"
     },
     {
       "title": "Noto Serif Myanmar",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Myanmar",
-      "enum": [
-        "Noto Serif Myanmar"
-      ]
+      "const": "Noto Serif Myanmar"
     },
     {
       "title": "Noto Serif NP Hmong",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+NP+Hmong",
-      "enum": [
-        "Noto Serif NP Hmong"
-      ]
+      "const": "Noto Serif NP Hmong"
     },
     {
       "title": "Noto Serif Oriya",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Oriya",
-      "enum": [
-        "Noto Serif Oriya"
-      ]
+      "const": "Noto Serif Oriya"
     },
     {
       "title": "Noto Serif Ottoman Siyaq",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Ottoman+Siyaq",
-      "enum": [
-        "Noto Serif Ottoman Siyaq"
-      ]
+      "const": "Noto Serif Ottoman Siyaq"
     },
     {
       "title": "Noto Serif SC",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+SC",
-      "enum": [
-        "Noto Serif SC"
-      ]
+      "const": "Noto Serif SC"
     },
     {
       "title": "Noto Serif Sinhala",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Sinhala",
-      "enum": [
-        "Noto Serif Sinhala"
-      ]
+      "const": "Noto Serif Sinhala"
     },
     {
       "title": "Noto Serif TC",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+TC",
-      "enum": [
-        "Noto Serif TC"
-      ]
+      "const": "Noto Serif TC"
     },
     {
       "title": "Noto Serif Tamil",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Tamil",
-      "enum": [
-        "Noto Serif Tamil"
-      ]
+      "const": "Noto Serif Tamil"
     },
     {
       "title": "Noto Serif Tangut",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Tangut",
-      "enum": [
-        "Noto Serif Tangut"
-      ]
+      "const": "Noto Serif Tangut"
     },
     {
       "title": "Noto Serif Telugu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Telugu",
-      "enum": [
-        "Noto Serif Telugu"
-      ]
+      "const": "Noto Serif Telugu"
     },
     {
       "title": "Noto Serif Thai",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Thai",
-      "enum": [
-        "Noto Serif Thai"
-      ]
+      "const": "Noto Serif Thai"
     },
     {
       "title": "Noto Serif Tibetan",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Tibetan",
-      "enum": [
-        "Noto Serif Tibetan"
-      ]
+      "const": "Noto Serif Tibetan"
     },
     {
       "title": "Noto Serif Toto",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Toto",
-      "enum": [
-        "Noto Serif Toto"
-      ]
+      "const": "Noto Serif Toto"
     },
     {
       "title": "Noto Serif Vithkuqi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Vithkuqi",
-      "enum": [
-        "Noto Serif Vithkuqi"
-      ]
+      "const": "Noto Serif Vithkuqi"
     },
     {
       "title": "Noto Serif Yezidi",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Serif+Yezidi",
-      "enum": [
-        "Noto Serif Yezidi"
-      ]
+      "const": "Noto Serif Yezidi"
     },
     {
       "title": "Noto Traditional Nushu",
       "markdownDescription": "https://fonts.google.com/specimen/Noto+Traditional+Nushu",
-      "enum": [
-        "Noto Traditional Nushu"
-      ]
+      "const": "Noto Traditional Nushu"
     },
     {
       "title": "Nova Cut",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Cut",
-      "enum": [
-        "Nova Cut"
-      ]
+      "const": "Nova Cut"
     },
     {
       "title": "Nova Flat",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Flat",
-      "enum": [
-        "Nova Flat"
-      ]
+      "const": "Nova Flat"
     },
     {
       "title": "Nova Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Mono",
-      "enum": [
-        "Nova Mono"
-      ]
+      "const": "Nova Mono"
     },
     {
       "title": "Nova Oval",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Oval",
-      "enum": [
-        "Nova Oval"
-      ]
+      "const": "Nova Oval"
     },
     {
       "title": "Nova Round",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Round",
-      "enum": [
-        "Nova Round"
-      ]
+      "const": "Nova Round"
     },
     {
       "title": "Nova Script",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Script",
-      "enum": [
-        "Nova Script"
-      ]
+      "const": "Nova Script"
     },
     {
       "title": "Nova Slim",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Slim",
-      "enum": [
-        "Nova Slim"
-      ]
+      "const": "Nova Slim"
     },
     {
       "title": "Nova Square",
       "markdownDescription": "https://fonts.google.com/specimen/Nova+Square",
-      "enum": [
-        "Nova Square"
-      ]
+      "const": "Nova Square"
     },
     {
       "title": "Numans",
       "markdownDescription": "https://fonts.google.com/specimen/Numans",
-      "enum": [
-        "Numans"
-      ]
+      "const": "Numans"
     },
     {
       "title": "Nunito",
       "markdownDescription": "https://fonts.google.com/specimen/Nunito",
-      "enum": [
-        "Nunito"
-      ]
+      "const": "Nunito"
     },
     {
       "title": "Nunito Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Nunito+Sans",
-      "enum": [
-        "Nunito Sans"
-      ]
+      "const": "Nunito Sans"
     },
     {
       "title": "Nuosu SIL",
       "markdownDescription": "https://fonts.google.com/specimen/Nuosu+SIL",
-      "enum": [
-        "Nuosu SIL"
-      ]
+      "const": "Nuosu SIL"
     },
     {
       "title": "Odibee Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Odibee+Sans",
-      "enum": [
-        "Odibee Sans"
-      ]
+      "const": "Odibee Sans"
     },
     {
       "title": "Odor Mean Chey",
       "markdownDescription": "https://fonts.google.com/specimen/Odor+Mean+Chey",
-      "enum": [
-        "Odor Mean Chey"
-      ]
+      "const": "Odor Mean Chey"
     },
     {
       "title": "Offside",
       "markdownDescription": "https://fonts.google.com/specimen/Offside",
-      "enum": [
-        "Offside"
-      ]
+      "const": "Offside"
     },
     {
       "title": "Oi",
       "markdownDescription": "https://fonts.google.com/specimen/Oi",
-      "enum": [
-        "Oi"
-      ]
+      "const": "Oi"
     },
     {
       "title": "Old Standard TT",
       "markdownDescription": "https://fonts.google.com/specimen/Old+Standard+TT",
-      "enum": [
-        "Old Standard TT"
-      ]
+      "const": "Old Standard TT"
     },
     {
       "title": "Oldenburg",
       "markdownDescription": "https://fonts.google.com/specimen/Oldenburg",
-      "enum": [
-        "Oldenburg"
-      ]
+      "const": "Oldenburg"
     },
     {
       "title": "Ole",
       "markdownDescription": "https://fonts.google.com/specimen/Ole",
-      "enum": [
-        "Ole"
-      ]
+      "const": "Ole"
     },
     {
       "title": "Oleo Script",
       "markdownDescription": "https://fonts.google.com/specimen/Oleo+Script",
-      "enum": [
-        "Oleo Script"
-      ]
+      "const": "Oleo Script"
     },
     {
       "title": "Oleo Script Swash Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Oleo+Script+Swash+Caps",
-      "enum": [
-        "Oleo Script Swash Caps"
-      ]
+      "const": "Oleo Script Swash Caps"
     },
     {
       "title": "Onest",
       "markdownDescription": "https://fonts.google.com/specimen/Onest",
-      "enum": [
-        "Onest"
-      ]
+      "const": "Onest"
     },
     {
       "title": "Oooh Baby",
       "markdownDescription": "https://fonts.google.com/specimen/Oooh+Baby",
-      "enum": [
-        "Oooh Baby"
-      ]
+      "const": "Oooh Baby"
     },
     {
       "title": "Open Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Open+Sans",
-      "enum": [
-        "Open Sans"
-      ]
+      "const": "Open Sans"
     },
     {
       "title": "Oranienbaum",
       "markdownDescription": "https://fonts.google.com/specimen/Oranienbaum",
-      "enum": [
-        "Oranienbaum"
-      ]
+      "const": "Oranienbaum"
     },
     {
       "title": "Orbit",
       "markdownDescription": "https://fonts.google.com/specimen/Orbit",
-      "enum": [
-        "Orbit"
-      ]
+      "const": "Orbit"
     },
     {
       "title": "Orbitron",
       "markdownDescription": "https://fonts.google.com/specimen/Orbitron",
-      "enum": [
-        "Orbitron"
-      ]
+      "const": "Orbitron"
     },
     {
       "title": "Oregano",
       "markdownDescription": "https://fonts.google.com/specimen/Oregano",
-      "enum": [
-        "Oregano"
-      ]
+      "const": "Oregano"
     },
     {
       "title": "Orelega One",
       "markdownDescription": "https://fonts.google.com/specimen/Orelega+One",
-      "enum": [
-        "Orelega One"
-      ]
+      "const": "Orelega One"
     },
     {
       "title": "Orienta",
       "markdownDescription": "https://fonts.google.com/specimen/Orienta",
-      "enum": [
-        "Orienta"
-      ]
+      "const": "Orienta"
     },
     {
       "title": "Original Surfer",
       "markdownDescription": "https://fonts.google.com/specimen/Original+Surfer",
-      "enum": [
-        "Original Surfer"
-      ]
+      "const": "Original Surfer"
     },
     {
       "title": "Oswald",
       "markdownDescription": "https://fonts.google.com/specimen/Oswald",
-      "enum": [
-        "Oswald"
-      ]
+      "const": "Oswald"
     },
     {
       "title": "Outfit",
       "markdownDescription": "https://fonts.google.com/specimen/Outfit",
-      "enum": [
-        "Outfit"
-      ]
+      "const": "Outfit"
     },
     {
       "title": "Over the Rainbow",
       "markdownDescription": "https://fonts.google.com/specimen/Over+the+Rainbow",
-      "enum": [
-        "Over the Rainbow"
-      ]
+      "const": "Over the Rainbow"
     },
     {
       "title": "Overlock",
       "markdownDescription": "https://fonts.google.com/specimen/Overlock",
-      "enum": [
-        "Overlock"
-      ]
+      "const": "Overlock"
     },
     {
       "title": "Overlock SC",
       "markdownDescription": "https://fonts.google.com/specimen/Overlock+SC",
-      "enum": [
-        "Overlock SC"
-      ]
+      "const": "Overlock SC"
     },
     {
       "title": "Overpass",
       "markdownDescription": "https://fonts.google.com/specimen/Overpass",
-      "enum": [
-        "Overpass"
-      ]
+      "const": "Overpass"
     },
     {
       "title": "Overpass Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Overpass+Mono",
-      "enum": [
-        "Overpass Mono"
-      ]
+      "const": "Overpass Mono"
     },
     {
       "title": "Ovo",
       "markdownDescription": "https://fonts.google.com/specimen/Ovo",
-      "enum": [
-        "Ovo"
-      ]
+      "const": "Ovo"
     },
     {
       "title": "Oxanium",
       "markdownDescription": "https://fonts.google.com/specimen/Oxanium",
-      "enum": [
-        "Oxanium"
-      ]
+      "const": "Oxanium"
     },
     {
       "title": "Oxygen",
       "markdownDescription": "https://fonts.google.com/specimen/Oxygen",
-      "enum": [
-        "Oxygen"
-      ]
+      "const": "Oxygen"
     },
     {
       "title": "Oxygen Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Oxygen+Mono",
-      "enum": [
-        "Oxygen Mono"
-      ]
+      "const": "Oxygen Mono"
     },
     {
       "title": "PT Mono",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Mono",
-      "enum": [
-        "PT Mono"
-      ]
+      "const": "PT Mono"
     },
     {
       "title": "PT Sans",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Sans",
-      "enum": [
-        "PT Sans"
-      ]
+      "const": "PT Sans"
     },
     {
       "title": "PT Sans Caption",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Sans+Caption",
-      "enum": [
-        "PT Sans Caption"
-      ]
+      "const": "PT Sans Caption"
     },
     {
       "title": "PT Sans Narrow",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Sans+Narrow",
-      "enum": [
-        "PT Sans Narrow"
-      ]
+      "const": "PT Sans Narrow"
     },
     {
       "title": "PT Serif",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Serif",
-      "enum": [
-        "PT Serif"
-      ]
+      "const": "PT Serif"
     },
     {
       "title": "PT Serif Caption",
       "markdownDescription": "https://fonts.google.com/specimen/PT+Serif+Caption",
-      "enum": [
-        "PT Serif Caption"
-      ]
+      "const": "PT Serif Caption"
     },
     {
       "title": "Pacifico",
       "markdownDescription": "https://fonts.google.com/specimen/Pacifico",
-      "enum": [
-        "Pacifico"
-      ]
+      "const": "Pacifico"
     },
     {
       "title": "Padauk",
       "markdownDescription": "https://fonts.google.com/specimen/Padauk",
-      "enum": [
-        "Padauk"
-      ]
+      "const": "Padauk"
     },
     {
       "title": "Padyakke Expanded One",
       "markdownDescription": "https://fonts.google.com/specimen/Padyakke+Expanded+One",
-      "enum": [
-        "Padyakke Expanded One"
-      ]
+      "const": "Padyakke Expanded One"
     },
     {
       "title": "Palanquin",
       "markdownDescription": "https://fonts.google.com/specimen/Palanquin",
-      "enum": [
-        "Palanquin"
-      ]
+      "const": "Palanquin"
     },
     {
       "title": "Palanquin Dark",
       "markdownDescription": "https://fonts.google.com/specimen/Palanquin+Dark",
-      "enum": [
-        "Palanquin Dark"
-      ]
+      "const": "Palanquin Dark"
     },
     {
       "title": "Palette Mosaic",
       "markdownDescription": "https://fonts.google.com/specimen/Palette+Mosaic",
-      "enum": [
-        "Palette Mosaic"
-      ]
+      "const": "Palette Mosaic"
     },
     {
       "title": "Pangolin",
       "markdownDescription": "https://fonts.google.com/specimen/Pangolin",
-      "enum": [
-        "Pangolin"
-      ]
+      "const": "Pangolin"
     },
     {
       "title": "Paprika",
       "markdownDescription": "https://fonts.google.com/specimen/Paprika",
-      "enum": [
-        "Paprika"
-      ]
+      "const": "Paprika"
     },
     {
       "title": "Parisienne",
       "markdownDescription": "https://fonts.google.com/specimen/Parisienne",
-      "enum": [
-        "Parisienne"
-      ]
+      "const": "Parisienne"
     },
     {
       "title": "Passero One",
       "markdownDescription": "https://fonts.google.com/specimen/Passero+One",
-      "enum": [
-        "Passero One"
-      ]
+      "const": "Passero One"
     },
     {
       "title": "Passion One",
       "markdownDescription": "https://fonts.google.com/specimen/Passion+One",
-      "enum": [
-        "Passion One"
-      ]
+      "const": "Passion One"
     },
     {
       "title": "Passions Conflict",
       "markdownDescription": "https://fonts.google.com/specimen/Passions+Conflict",
-      "enum": [
-        "Passions Conflict"
-      ]
+      "const": "Passions Conflict"
     },
     {
       "title": "Pathway Extreme",
       "markdownDescription": "https://fonts.google.com/specimen/Pathway+Extreme",
-      "enum": [
-        "Pathway Extreme"
-      ]
+      "const": "Pathway Extreme"
     },
     {
       "title": "Pathway Gothic One",
       "markdownDescription": "https://fonts.google.com/specimen/Pathway+Gothic+One",
-      "enum": [
-        "Pathway Gothic One"
-      ]
+      "const": "Pathway Gothic One"
     },
     {
       "title": "Patrick Hand",
       "markdownDescription": "https://fonts.google.com/specimen/Patrick+Hand",
-      "enum": [
-        "Patrick Hand"
-      ]
+      "const": "Patrick Hand"
     },
     {
       "title": "Patrick Hand SC",
       "markdownDescription": "https://fonts.google.com/specimen/Patrick+Hand+SC",
-      "enum": [
-        "Patrick Hand SC"
-      ]
+      "const": "Patrick Hand SC"
     },
     {
       "title": "Pattaya",
       "markdownDescription": "https://fonts.google.com/specimen/Pattaya",
-      "enum": [
-        "Pattaya"
-      ]
+      "const": "Pattaya"
     },
     {
       "title": "Patua One",
       "markdownDescription": "https://fonts.google.com/specimen/Patua+One",
-      "enum": [
-        "Patua One"
-      ]
+      "const": "Patua One"
     },
     {
       "title": "Pavanam",
       "markdownDescription": "https://fonts.google.com/specimen/Pavanam",
-      "enum": [
-        "Pavanam"
-      ]
+      "const": "Pavanam"
     },
     {
       "title": "Paytone One",
       "markdownDescription": "https://fonts.google.com/specimen/Paytone+One",
-      "enum": [
-        "Paytone One"
-      ]
+      "const": "Paytone One"
     },
     {
       "title": "Peddana",
       "markdownDescription": "https://fonts.google.com/specimen/Peddana",
-      "enum": [
-        "Peddana"
-      ]
+      "const": "Peddana"
     },
     {
       "title": "Peralta",
       "markdownDescription": "https://fonts.google.com/specimen/Peralta",
-      "enum": [
-        "Peralta"
-      ]
+      "const": "Peralta"
     },
     {
       "title": "Permanent Marker",
       "markdownDescription": "https://fonts.google.com/specimen/Permanent+Marker",
-      "enum": [
-        "Permanent Marker"
-      ]
+      "const": "Permanent Marker"
     },
     {
       "title": "Petemoss",
       "markdownDescription": "https://fonts.google.com/specimen/Petemoss",
-      "enum": [
-        "Petemoss"
-      ]
+      "const": "Petemoss"
     },
     {
       "title": "Petit Formal Script",
       "markdownDescription": "https://fonts.google.com/specimen/Petit+Formal+Script",
-      "enum": [
-        "Petit Formal Script"
-      ]
+      "const": "Petit Formal Script"
     },
     {
       "title": "Petrona",
       "markdownDescription": "https://fonts.google.com/specimen/Petrona",
-      "enum": [
-        "Petrona"
-      ]
+      "const": "Petrona"
     },
     {
       "title": "Philosopher",
       "markdownDescription": "https://fonts.google.com/specimen/Philosopher",
-      "enum": [
-        "Philosopher"
-      ]
+      "const": "Philosopher"
     },
     {
       "title": "Phudu",
       "markdownDescription": "https://fonts.google.com/specimen/Phudu",
-      "enum": [
-        "Phudu"
-      ]
+      "const": "Phudu"
     },
     {
       "title": "Piazzolla",
       "markdownDescription": "https://fonts.google.com/specimen/Piazzolla",
-      "enum": [
-        "Piazzolla"
-      ]
+      "const": "Piazzolla"
     },
     {
       "title": "Piedra",
       "markdownDescription": "https://fonts.google.com/specimen/Piedra",
-      "enum": [
-        "Piedra"
-      ]
+      "const": "Piedra"
     },
     {
       "title": "Pinyon Script",
       "markdownDescription": "https://fonts.google.com/specimen/Pinyon+Script",
-      "enum": [
-        "Pinyon Script"
-      ]
+      "const": "Pinyon Script"
     },
     {
       "title": "Pirata One",
       "markdownDescription": "https://fonts.google.com/specimen/Pirata+One",
-      "enum": [
-        "Pirata One"
-      ]
+      "const": "Pirata One"
     },
     {
       "title": "Pixelify Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Pixelify+Sans",
-      "enum": [
-        "Pixelify Sans"
-      ]
+      "const": "Pixelify Sans"
     },
     {
       "title": "Plaster",
       "markdownDescription": "https://fonts.google.com/specimen/Plaster",
-      "enum": [
-        "Plaster"
-      ]
+      "const": "Plaster"
     },
     {
       "title": "Play",
       "markdownDescription": "https://fonts.google.com/specimen/Play",
-      "enum": [
-        "Play"
-      ]
+      "const": "Play"
     },
     {
       "title": "Playball",
       "markdownDescription": "https://fonts.google.com/specimen/Playball",
-      "enum": [
-        "Playball"
-      ]
+      "const": "Playball"
     },
     {
       "title": "Playfair",
       "markdownDescription": "https://fonts.google.com/specimen/Playfair",
-      "enum": [
-        "Playfair"
-      ]
+      "const": "Playfair"
     },
     {
       "title": "Playfair Display",
       "markdownDescription": "https://fonts.google.com/specimen/Playfair+Display",
-      "enum": [
-        "Playfair Display"
-      ]
+      "const": "Playfair Display"
     },
     {
       "title": "Playfair Display SC",
       "markdownDescription": "https://fonts.google.com/specimen/Playfair+Display+SC",
-      "enum": [
-        "Playfair Display SC"
-      ]
+      "const": "Playfair Display SC"
     },
     {
       "title": "Playpen Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Playpen+Sans",
-      "enum": [
-        "Playpen Sans"
-      ]
+      "const": "Playpen Sans"
     },
     {
       "title": "Plus Jakarta Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Plus+Jakarta+Sans",
-      "enum": [
-        "Plus Jakarta Sans"
-      ]
+      "const": "Plus Jakarta Sans"
     },
     {
       "title": "Podkova",
       "markdownDescription": "https://fonts.google.com/specimen/Podkova",
-      "enum": [
-        "Podkova"
-      ]
+      "const": "Podkova"
     },
     {
       "title": "Poiret One",
       "markdownDescription": "https://fonts.google.com/specimen/Poiret+One",
-      "enum": [
-        "Poiret One"
-      ]
+      "const": "Poiret One"
     },
     {
       "title": "Poller One",
       "markdownDescription": "https://fonts.google.com/specimen/Poller+One",
-      "enum": [
-        "Poller One"
-      ]
+      "const": "Poller One"
     },
     {
       "title": "Poltawski Nowy",
       "markdownDescription": "https://fonts.google.com/specimen/Poltawski+Nowy",
-      "enum": [
-        "Poltawski Nowy"
-      ]
+      "const": "Poltawski Nowy"
     },
     {
       "title": "Poly",
       "markdownDescription": "https://fonts.google.com/specimen/Poly",
-      "enum": [
-        "Poly"
-      ]
+      "const": "Poly"
     },
     {
       "title": "Pompiere",
       "markdownDescription": "https://fonts.google.com/specimen/Pompiere",
-      "enum": [
-        "Pompiere"
-      ]
+      "const": "Pompiere"
     },
     {
       "title": "Pontano Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Pontano+Sans",
-      "enum": [
-        "Pontano Sans"
-      ]
+      "const": "Pontano Sans"
     },
     {
       "title": "Poor Story",
       "markdownDescription": "https://fonts.google.com/specimen/Poor+Story",
-      "enum": [
-        "Poor Story"
-      ]
+      "const": "Poor Story"
     },
     {
       "title": "Poppins",
       "markdownDescription": "https://fonts.google.com/specimen/Poppins",
-      "enum": [
-        "Poppins"
-      ]
+      "const": "Poppins"
     },
     {
       "title": "Port Lligat Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Port+Lligat+Sans",
-      "enum": [
-        "Port Lligat Sans"
-      ]
+      "const": "Port Lligat Sans"
     },
     {
       "title": "Port Lligat Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Port+Lligat+Slab",
-      "enum": [
-        "Port Lligat Slab"
-      ]
+      "const": "Port Lligat Slab"
     },
     {
       "title": "Potta One",
       "markdownDescription": "https://fonts.google.com/specimen/Potta+One",
-      "enum": [
-        "Potta One"
-      ]
+      "const": "Potta One"
     },
     {
       "title": "Pragati Narrow",
       "markdownDescription": "https://fonts.google.com/specimen/Pragati+Narrow",
-      "enum": [
-        "Pragati Narrow"
-      ]
+      "const": "Pragati Narrow"
     },
     {
       "title": "Praise",
       "markdownDescription": "https://fonts.google.com/specimen/Praise",
-      "enum": [
-        "Praise"
-      ]
+      "const": "Praise"
     },
     {
       "title": "Prata",
       "markdownDescription": "https://fonts.google.com/specimen/Prata",
-      "enum": [
-        "Prata"
-      ]
+      "const": "Prata"
     },
     {
       "title": "Preahvihear",
       "markdownDescription": "https://fonts.google.com/specimen/Preahvihear",
-      "enum": [
-        "Preahvihear"
-      ]
+      "const": "Preahvihear"
     },
     {
       "title": "Press Start 2P",
       "markdownDescription": "https://fonts.google.com/specimen/Press+Start+2P",
-      "enum": [
-        "Press Start 2P"
-      ]
+      "const": "Press Start 2P"
     },
     {
       "title": "Pridi",
       "markdownDescription": "https://fonts.google.com/specimen/Pridi",
-      "enum": [
-        "Pridi"
-      ]
+      "const": "Pridi"
     },
     {
       "title": "Princess Sofia",
       "markdownDescription": "https://fonts.google.com/specimen/Princess+Sofia",
-      "enum": [
-        "Princess Sofia"
-      ]
+      "const": "Princess Sofia"
     },
     {
       "title": "Prociono",
       "markdownDescription": "https://fonts.google.com/specimen/Prociono",
-      "enum": [
-        "Prociono"
-      ]
+      "const": "Prociono"
     },
     {
       "title": "Prompt",
       "markdownDescription": "https://fonts.google.com/specimen/Prompt",
-      "enum": [
-        "Prompt"
-      ]
+      "const": "Prompt"
     },
     {
       "title": "Prosto One",
       "markdownDescription": "https://fonts.google.com/specimen/Prosto+One",
-      "enum": [
-        "Prosto One"
-      ]
+      "const": "Prosto One"
     },
     {
       "title": "Proza Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Proza+Libre",
-      "enum": [
-        "Proza Libre"
-      ]
+      "const": "Proza Libre"
     },
     {
       "title": "Public Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Public+Sans",
-      "enum": [
-        "Public Sans"
-      ]
+      "const": "Public Sans"
     },
     {
       "title": "Puppies Play",
       "markdownDescription": "https://fonts.google.com/specimen/Puppies+Play",
-      "enum": [
-        "Puppies Play"
-      ]
+      "const": "Puppies Play"
     },
     {
       "title": "Puritan",
       "markdownDescription": "https://fonts.google.com/specimen/Puritan",
-      "enum": [
-        "Puritan"
-      ]
+      "const": "Puritan"
     },
     {
       "title": "Purple Purse",
       "markdownDescription": "https://fonts.google.com/specimen/Purple+Purse",
-      "enum": [
-        "Purple Purse"
-      ]
+      "const": "Purple Purse"
     },
     {
       "title": "Qahiri",
       "markdownDescription": "https://fonts.google.com/specimen/Qahiri",
-      "enum": [
-        "Qahiri"
-      ]
+      "const": "Qahiri"
     },
     {
       "title": "Quando",
       "markdownDescription": "https://fonts.google.com/specimen/Quando",
-      "enum": [
-        "Quando"
-      ]
+      "const": "Quando"
     },
     {
       "title": "Quantico",
       "markdownDescription": "https://fonts.google.com/specimen/Quantico",
-      "enum": [
-        "Quantico"
-      ]
+      "const": "Quantico"
     },
     {
       "title": "Quattrocento",
       "markdownDescription": "https://fonts.google.com/specimen/Quattrocento",
-      "enum": [
-        "Quattrocento"
-      ]
+      "const": "Quattrocento"
     },
     {
       "title": "Quattrocento Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Quattrocento+Sans",
-      "enum": [
-        "Quattrocento Sans"
-      ]
+      "const": "Quattrocento Sans"
     },
     {
       "title": "Questrial",
       "markdownDescription": "https://fonts.google.com/specimen/Questrial",
-      "enum": [
-        "Questrial"
-      ]
+      "const": "Questrial"
     },
     {
       "title": "Quicksand",
       "markdownDescription": "https://fonts.google.com/specimen/Quicksand",
-      "enum": [
-        "Quicksand"
-      ]
+      "const": "Quicksand"
     },
     {
       "title": "Quintessential",
       "markdownDescription": "https://fonts.google.com/specimen/Quintessential",
-      "enum": [
-        "Quintessential"
-      ]
+      "const": "Quintessential"
     },
     {
       "title": "Qwigley",
       "markdownDescription": "https://fonts.google.com/specimen/Qwigley",
-      "enum": [
-        "Qwigley"
-      ]
+      "const": "Qwigley"
     },
     {
       "title": "Qwitcher Grypen",
       "markdownDescription": "https://fonts.google.com/specimen/Qwitcher+Grypen",
-      "enum": [
-        "Qwitcher Grypen"
-      ]
+      "const": "Qwitcher Grypen"
     },
     {
       "title": "REM",
       "markdownDescription": "https://fonts.google.com/specimen/REM",
-      "enum": [
-        "REM"
-      ]
+      "const": "REM"
     },
     {
       "title": "Racing Sans One",
       "markdownDescription": "https://fonts.google.com/specimen/Racing+Sans+One",
-      "enum": [
-        "Racing Sans One"
-      ]
+      "const": "Racing Sans One"
     },
     {
       "title": "Radio Canada",
       "markdownDescription": "https://fonts.google.com/specimen/Radio+Canada",
-      "enum": [
-        "Radio Canada"
-      ]
+      "const": "Radio Canada"
     },
     {
       "title": "Radley",
       "markdownDescription": "https://fonts.google.com/specimen/Radley",
-      "enum": [
-        "Radley"
-      ]
+      "const": "Radley"
     },
     {
       "title": "Rajdhani",
       "markdownDescription": "https://fonts.google.com/specimen/Rajdhani",
-      "enum": [
-        "Rajdhani"
-      ]
+      "const": "Rajdhani"
     },
     {
       "title": "Rakkas",
       "markdownDescription": "https://fonts.google.com/specimen/Rakkas",
-      "enum": [
-        "Rakkas"
-      ]
+      "const": "Rakkas"
     },
     {
       "title": "Raleway",
       "markdownDescription": "https://fonts.google.com/specimen/Raleway",
-      "enum": [
-        "Raleway"
-      ]
+      "const": "Raleway"
     },
     {
       "title": "Raleway Dots",
       "markdownDescription": "https://fonts.google.com/specimen/Raleway+Dots",
-      "enum": [
-        "Raleway Dots"
-      ]
+      "const": "Raleway Dots"
     },
     {
       "title": "Ramabhadra",
       "markdownDescription": "https://fonts.google.com/specimen/Ramabhadra",
-      "enum": [
-        "Ramabhadra"
-      ]
+      "const": "Ramabhadra"
     },
     {
       "title": "Ramaraja",
       "markdownDescription": "https://fonts.google.com/specimen/Ramaraja",
-      "enum": [
-        "Ramaraja"
-      ]
+      "const": "Ramaraja"
     },
     {
       "title": "Rambla",
       "markdownDescription": "https://fonts.google.com/specimen/Rambla",
-      "enum": [
-        "Rambla"
-      ]
+      "const": "Rambla"
     },
     {
       "title": "Rammetto One",
       "markdownDescription": "https://fonts.google.com/specimen/Rammetto+One",
-      "enum": [
-        "Rammetto One"
-      ]
+      "const": "Rammetto One"
     },
     {
       "title": "Rampart One",
       "markdownDescription": "https://fonts.google.com/specimen/Rampart+One",
-      "enum": [
-        "Rampart One"
-      ]
+      "const": "Rampart One"
     },
     {
       "title": "Ranchers",
       "markdownDescription": "https://fonts.google.com/specimen/Ranchers",
-      "enum": [
-        "Ranchers"
-      ]
+      "const": "Ranchers"
     },
     {
       "title": "Rancho",
       "markdownDescription": "https://fonts.google.com/specimen/Rancho",
-      "enum": [
-        "Rancho"
-      ]
+      "const": "Rancho"
     },
     {
       "title": "Ranga",
       "markdownDescription": "https://fonts.google.com/specimen/Ranga",
-      "enum": [
-        "Ranga"
-      ]
+      "const": "Ranga"
     },
     {
       "title": "Rasa",
       "markdownDescription": "https://fonts.google.com/specimen/Rasa",
-      "enum": [
-        "Rasa"
-      ]
+      "const": "Rasa"
     },
     {
       "title": "Rationale",
       "markdownDescription": "https://fonts.google.com/specimen/Rationale",
-      "enum": [
-        "Rationale"
-      ]
+      "const": "Rationale"
     },
     {
       "title": "Ravi Prakash",
       "markdownDescription": "https://fonts.google.com/specimen/Ravi+Prakash",
-      "enum": [
-        "Ravi Prakash"
-      ]
+      "const": "Ravi Prakash"
     },
     {
       "title": "Readex Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Readex+Pro",
-      "enum": [
-        "Readex Pro"
-      ]
+      "const": "Readex Pro"
     },
     {
       "title": "Recursive",
       "markdownDescription": "https://fonts.google.com/specimen/Recursive",
-      "enum": [
-        "Recursive"
-      ]
+      "const": "Recursive"
     },
     {
       "title": "Red Hat Display",
       "markdownDescription": "https://fonts.google.com/specimen/Red+Hat+Display",
-      "enum": [
-        "Red Hat Display"
-      ]
+      "const": "Red Hat Display"
     },
     {
       "title": "Red Hat Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Red+Hat+Mono",
-      "enum": [
-        "Red Hat Mono"
-      ]
+      "const": "Red Hat Mono"
     },
     {
       "title": "Red Hat Text",
       "markdownDescription": "https://fonts.google.com/specimen/Red+Hat+Text",
-      "enum": [
-        "Red Hat Text"
-      ]
+      "const": "Red Hat Text"
     },
     {
       "title": "Red Rose",
       "markdownDescription": "https://fonts.google.com/specimen/Red+Rose",
-      "enum": [
-        "Red Rose"
-      ]
+      "const": "Red Rose"
     },
     {
       "title": "Redacted",
       "markdownDescription": "https://fonts.google.com/specimen/Redacted",
-      "enum": [
-        "Redacted"
-      ]
+      "const": "Redacted"
     },
     {
       "title": "Redacted Script",
       "markdownDescription": "https://fonts.google.com/specimen/Redacted+Script",
-      "enum": [
-        "Redacted Script"
-      ]
+      "const": "Redacted Script"
     },
     {
       "title": "Redressed",
       "markdownDescription": "https://fonts.google.com/specimen/Redressed",
-      "enum": [
-        "Redressed"
-      ]
+      "const": "Redressed"
     },
     {
       "title": "Reem Kufi",
       "markdownDescription": "https://fonts.google.com/specimen/Reem+Kufi",
-      "enum": [
-        "Reem Kufi"
-      ]
+      "const": "Reem Kufi"
     },
     {
       "title": "Reem Kufi Fun",
       "markdownDescription": "https://fonts.google.com/specimen/Reem+Kufi+Fun",
-      "enum": [
-        "Reem Kufi Fun"
-      ]
+      "const": "Reem Kufi Fun"
     },
     {
       "title": "Reem Kufi Ink",
       "markdownDescription": "https://fonts.google.com/specimen/Reem+Kufi+Ink",
-      "enum": [
-        "Reem Kufi Ink"
-      ]
+      "const": "Reem Kufi Ink"
     },
     {
       "title": "Reenie Beanie",
       "markdownDescription": "https://fonts.google.com/specimen/Reenie+Beanie",
-      "enum": [
-        "Reenie Beanie"
-      ]
+      "const": "Reenie Beanie"
     },
     {
       "title": "Reggae One",
       "markdownDescription": "https://fonts.google.com/specimen/Reggae+One",
-      "enum": [
-        "Reggae One"
-      ]
+      "const": "Reggae One"
     },
     {
       "title": "Revalia",
       "markdownDescription": "https://fonts.google.com/specimen/Revalia",
-      "enum": [
-        "Revalia"
-      ]
+      "const": "Revalia"
     },
     {
       "title": "Rhodium Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Rhodium+Libre",
-      "enum": [
-        "Rhodium Libre"
-      ]
+      "const": "Rhodium Libre"
     },
     {
       "title": "Ribeye",
       "markdownDescription": "https://fonts.google.com/specimen/Ribeye",
-      "enum": [
-        "Ribeye"
-      ]
+      "const": "Ribeye"
     },
     {
       "title": "Ribeye Marrow",
       "markdownDescription": "https://fonts.google.com/specimen/Ribeye+Marrow",
-      "enum": [
-        "Ribeye Marrow"
-      ]
+      "const": "Ribeye Marrow"
     },
     {
       "title": "Righteous",
       "markdownDescription": "https://fonts.google.com/specimen/Righteous",
-      "enum": [
-        "Righteous"
-      ]
+      "const": "Righteous"
     },
     {
       "title": "Risque",
       "markdownDescription": "https://fonts.google.com/specimen/Risque",
-      "enum": [
-        "Risque"
-      ]
+      "const": "Risque"
     },
     {
       "title": "Road Rage",
       "markdownDescription": "https://fonts.google.com/specimen/Road+Rage",
-      "enum": [
-        "Road Rage"
-      ]
+      "const": "Road Rage"
     },
     {
       "title": "Roboto",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto",
-      "enum": [
-        "Roboto"
-      ]
+      "const": "Roboto"
     },
     {
       "title": "Roboto Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto+Condensed",
-      "enum": [
-        "Roboto Condensed"
-      ]
+      "const": "Roboto Condensed"
     },
     {
       "title": "Roboto Flex",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto+Flex",
-      "enum": [
-        "Roboto Flex"
-      ]
+      "const": "Roboto Flex"
     },
     {
       "title": "Roboto Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto+Mono",
-      "enum": [
-        "Roboto Mono"
-      ]
+      "const": "Roboto Mono"
     },
     {
       "title": "Roboto Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto+Serif",
-      "enum": [
-        "Roboto Serif"
-      ]
+      "const": "Roboto Serif"
     },
     {
       "title": "Roboto Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Roboto+Slab",
-      "enum": [
-        "Roboto Slab"
-      ]
+      "const": "Roboto Slab"
     },
     {
       "title": "Rochester",
       "markdownDescription": "https://fonts.google.com/specimen/Rochester",
-      "enum": [
-        "Rochester"
-      ]
+      "const": "Rochester"
     },
     {
       "title": "Rock 3D",
       "markdownDescription": "https://fonts.google.com/specimen/Rock+3D",
-      "enum": [
-        "Rock 3D"
-      ]
+      "const": "Rock 3D"
     },
     {
       "title": "Rock Salt",
       "markdownDescription": "https://fonts.google.com/specimen/Rock+Salt",
-      "enum": [
-        "Rock Salt"
-      ]
+      "const": "Rock Salt"
     },
     {
       "title": "RocknRoll One",
       "markdownDescription": "https://fonts.google.com/specimen/RocknRoll+One",
-      "enum": [
-        "RocknRoll One"
-      ]
+      "const": "RocknRoll One"
     },
     {
       "title": "Rokkitt",
       "markdownDescription": "https://fonts.google.com/specimen/Rokkitt",
-      "enum": [
-        "Rokkitt"
-      ]
+      "const": "Rokkitt"
     },
     {
       "title": "Romanesco",
       "markdownDescription": "https://fonts.google.com/specimen/Romanesco",
-      "enum": [
-        "Romanesco"
-      ]
+      "const": "Romanesco"
     },
     {
       "title": "Ropa Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Ropa+Sans",
-      "enum": [
-        "Ropa Sans"
-      ]
+      "const": "Ropa Sans"
     },
     {
       "title": "Rosario",
       "markdownDescription": "https://fonts.google.com/specimen/Rosario",
-      "enum": [
-        "Rosario"
-      ]
+      "const": "Rosario"
     },
     {
       "title": "Rosarivo",
       "markdownDescription": "https://fonts.google.com/specimen/Rosarivo",
-      "enum": [
-        "Rosarivo"
-      ]
+      "const": "Rosarivo"
     },
     {
       "title": "Rouge Script",
       "markdownDescription": "https://fonts.google.com/specimen/Rouge+Script",
-      "enum": [
-        "Rouge Script"
-      ]
+      "const": "Rouge Script"
     },
     {
       "title": "Rowdies",
       "markdownDescription": "https://fonts.google.com/specimen/Rowdies",
-      "enum": [
-        "Rowdies"
-      ]
+      "const": "Rowdies"
     },
     {
       "title": "Rozha One",
       "markdownDescription": "https://fonts.google.com/specimen/Rozha+One",
-      "enum": [
-        "Rozha One"
-      ]
+      "const": "Rozha One"
     },
     {
       "title": "Rubik",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik",
-      "enum": [
-        "Rubik"
-      ]
+      "const": "Rubik"
     },
     {
       "title": "Rubik 80s Fade",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+80s+Fade",
-      "enum": [
-        "Rubik 80s Fade"
-      ]
+      "const": "Rubik 80s Fade"
     },
     {
       "title": "Rubik Beastly",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Beastly",
-      "enum": [
-        "Rubik Beastly"
-      ]
+      "const": "Rubik Beastly"
     },
     {
       "title": "Rubik Bubbles",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Bubbles",
-      "enum": [
-        "Rubik Bubbles"
-      ]
+      "const": "Rubik Bubbles"
     },
     {
       "title": "Rubik Burned",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Burned",
-      "enum": [
-        "Rubik Burned"
-      ]
+      "const": "Rubik Burned"
     },
     {
       "title": "Rubik Dirt",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Dirt",
-      "enum": [
-        "Rubik Dirt"
-      ]
+      "const": "Rubik Dirt"
     },
     {
       "title": "Rubik Distressed",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Distressed",
-      "enum": [
-        "Rubik Distressed"
-      ]
+      "const": "Rubik Distressed"
     },
     {
       "title": "Rubik Gemstones",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Gemstones",
-      "enum": [
-        "Rubik Gemstones"
-      ]
+      "const": "Rubik Gemstones"
     },
     {
       "title": "Rubik Glitch",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Glitch",
-      "enum": [
-        "Rubik Glitch"
-      ]
+      "const": "Rubik Glitch"
     },
     {
       "title": "Rubik Iso",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Iso",
-      "enum": [
-        "Rubik Iso"
-      ]
+      "const": "Rubik Iso"
     },
     {
       "title": "Rubik Marker Hatch",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Marker+Hatch",
-      "enum": [
-        "Rubik Marker Hatch"
-      ]
+      "const": "Rubik Marker Hatch"
     },
     {
       "title": "Rubik Maze",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Maze",
-      "enum": [
-        "Rubik Maze"
-      ]
+      "const": "Rubik Maze"
     },
     {
       "title": "Rubik Microbe",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Microbe",
-      "enum": [
-        "Rubik Microbe"
-      ]
+      "const": "Rubik Microbe"
     },
     {
       "title": "Rubik Mono One",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Mono+One",
-      "enum": [
-        "Rubik Mono One"
-      ]
+      "const": "Rubik Mono One"
     },
     {
       "title": "Rubik Moonrocks",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Moonrocks",
-      "enum": [
-        "Rubik Moonrocks"
-      ]
+      "const": "Rubik Moonrocks"
     },
     {
       "title": "Rubik Pixels",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Pixels",
-      "enum": [
-        "Rubik Pixels"
-      ]
+      "const": "Rubik Pixels"
     },
     {
       "title": "Rubik Puddles",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Puddles",
-      "enum": [
-        "Rubik Puddles"
-      ]
+      "const": "Rubik Puddles"
     },
     {
       "title": "Rubik Spray Paint",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Spray+Paint",
-      "enum": [
-        "Rubik Spray Paint"
-      ]
+      "const": "Rubik Spray Paint"
     },
     {
       "title": "Rubik Storm",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Storm",
-      "enum": [
-        "Rubik Storm"
-      ]
+      "const": "Rubik Storm"
     },
     {
       "title": "Rubik Vinyl",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Vinyl",
-      "enum": [
-        "Rubik Vinyl"
-      ]
+      "const": "Rubik Vinyl"
     },
     {
       "title": "Rubik Wet Paint",
       "markdownDescription": "https://fonts.google.com/specimen/Rubik+Wet+Paint",
-      "enum": [
-        "Rubik Wet Paint"
-      ]
+      "const": "Rubik Wet Paint"
     },
     {
       "title": "Ruda",
       "markdownDescription": "https://fonts.google.com/specimen/Ruda",
-      "enum": [
-        "Ruda"
-      ]
+      "const": "Ruda"
     },
     {
       "title": "Rufina",
       "markdownDescription": "https://fonts.google.com/specimen/Rufina",
-      "enum": [
-        "Rufina"
-      ]
+      "const": "Rufina"
     },
     {
       "title": "Ruge Boogie",
       "markdownDescription": "https://fonts.google.com/specimen/Ruge+Boogie",
-      "enum": [
-        "Ruge Boogie"
-      ]
+      "const": "Ruge Boogie"
     },
     {
       "title": "Ruluko",
       "markdownDescription": "https://fonts.google.com/specimen/Ruluko",
-      "enum": [
-        "Ruluko"
-      ]
+      "const": "Ruluko"
     },
     {
       "title": "Rum Raisin",
       "markdownDescription": "https://fonts.google.com/specimen/Rum+Raisin",
-      "enum": [
-        "Rum Raisin"
-      ]
+      "const": "Rum Raisin"
     },
     {
       "title": "Ruslan Display",
       "markdownDescription": "https://fonts.google.com/specimen/Ruslan+Display",
-      "enum": [
-        "Ruslan Display"
-      ]
+      "const": "Ruslan Display"
     },
     {
       "title": "Russo One",
       "markdownDescription": "https://fonts.google.com/specimen/Russo+One",
-      "enum": [
-        "Russo One"
-      ]
+      "const": "Russo One"
     },
     {
       "title": "Ruthie",
       "markdownDescription": "https://fonts.google.com/specimen/Ruthie",
-      "enum": [
-        "Ruthie"
-      ]
+      "const": "Ruthie"
     },
     {
       "title": "Ruwudu",
       "markdownDescription": "https://fonts.google.com/specimen/Ruwudu",
-      "enum": [
-        "Ruwudu"
-      ]
+      "const": "Ruwudu"
     },
     {
       "title": "Rye",
       "markdownDescription": "https://fonts.google.com/specimen/Rye",
-      "enum": [
-        "Rye"
-      ]
+      "const": "Rye"
     },
     {
       "title": "STIX Two Text",
       "markdownDescription": "https://fonts.google.com/specimen/STIX+Two+Text",
-      "enum": [
-        "STIX Two Text"
-      ]
+      "const": "STIX Two Text"
     },
     {
       "title": "Sacramento",
       "markdownDescription": "https://fonts.google.com/specimen/Sacramento",
-      "enum": [
-        "Sacramento"
-      ]
+      "const": "Sacramento"
     },
     {
       "title": "Sahitya",
       "markdownDescription": "https://fonts.google.com/specimen/Sahitya",
-      "enum": [
-        "Sahitya"
-      ]
+      "const": "Sahitya"
     },
     {
       "title": "Sail",
       "markdownDescription": "https://fonts.google.com/specimen/Sail",
-      "enum": [
-        "Sail"
-      ]
+      "const": "Sail"
     },
     {
       "title": "Saira",
       "markdownDescription": "https://fonts.google.com/specimen/Saira",
-      "enum": [
-        "Saira"
-      ]
+      "const": "Saira"
     },
     {
       "title": "Saira Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Saira+Condensed",
-      "enum": [
-        "Saira Condensed"
-      ]
+      "const": "Saira Condensed"
     },
     {
       "title": "Saira Extra Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Saira+Extra+Condensed",
-      "enum": [
-        "Saira Extra Condensed"
-      ]
+      "const": "Saira Extra Condensed"
     },
     {
       "title": "Saira Semi Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Saira+Semi+Condensed",
-      "enum": [
-        "Saira Semi Condensed"
-      ]
+      "const": "Saira Semi Condensed"
     },
     {
       "title": "Saira Stencil One",
       "markdownDescription": "https://fonts.google.com/specimen/Saira+Stencil+One",
-      "enum": [
-        "Saira Stencil One"
-      ]
+      "const": "Saira Stencil One"
     },
     {
       "title": "Salsa",
       "markdownDescription": "https://fonts.google.com/specimen/Salsa",
-      "enum": [
-        "Salsa"
-      ]
+      "const": "Salsa"
     },
     {
       "title": "Sanchez",
       "markdownDescription": "https://fonts.google.com/specimen/Sanchez",
-      "enum": [
-        "Sanchez"
-      ]
+      "const": "Sanchez"
     },
     {
       "title": "Sancreek",
       "markdownDescription": "https://fonts.google.com/specimen/Sancreek",
-      "enum": [
-        "Sancreek"
-      ]
+      "const": "Sancreek"
     },
     {
       "title": "Sansita",
       "markdownDescription": "https://fonts.google.com/specimen/Sansita",
-      "enum": [
-        "Sansita"
-      ]
+      "const": "Sansita"
     },
     {
       "title": "Sansita Swashed",
       "markdownDescription": "https://fonts.google.com/specimen/Sansita+Swashed",
-      "enum": [
-        "Sansita Swashed"
-      ]
+      "const": "Sansita Swashed"
     },
     {
       "title": "Sarabun",
       "markdownDescription": "https://fonts.google.com/specimen/Sarabun",
-      "enum": [
-        "Sarabun"
-      ]
+      "const": "Sarabun"
     },
     {
       "title": "Sarala",
       "markdownDescription": "https://fonts.google.com/specimen/Sarala",
-      "enum": [
-        "Sarala"
-      ]
+      "const": "Sarala"
     },
     {
       "title": "Sarina",
       "markdownDescription": "https://fonts.google.com/specimen/Sarina",
-      "enum": [
-        "Sarina"
-      ]
+      "const": "Sarina"
     },
     {
       "title": "Sarpanch",
       "markdownDescription": "https://fonts.google.com/specimen/Sarpanch",
-      "enum": [
-        "Sarpanch"
-      ]
+      "const": "Sarpanch"
     },
     {
       "title": "Sassy Frass",
       "markdownDescription": "https://fonts.google.com/specimen/Sassy+Frass",
-      "enum": [
-        "Sassy Frass"
-      ]
+      "const": "Sassy Frass"
     },
     {
       "title": "Satisfy",
       "markdownDescription": "https://fonts.google.com/specimen/Satisfy",
-      "enum": [
-        "Satisfy"
-      ]
+      "const": "Satisfy"
     },
     {
       "title": "Sawarabi Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Sawarabi+Gothic",
-      "enum": [
-        "Sawarabi Gothic"
-      ]
+      "const": "Sawarabi Gothic"
     },
     {
       "title": "Sawarabi Mincho",
       "markdownDescription": "https://fonts.google.com/specimen/Sawarabi+Mincho",
-      "enum": [
-        "Sawarabi Mincho"
-      ]
+      "const": "Sawarabi Mincho"
     },
     {
       "title": "Scada",
       "markdownDescription": "https://fonts.google.com/specimen/Scada",
-      "enum": [
-        "Scada"
-      ]
+      "const": "Scada"
     },
     {
       "title": "Scheherazade New",
       "markdownDescription": "https://fonts.google.com/specimen/Scheherazade+New",
-      "enum": [
-        "Scheherazade New"
-      ]
+      "const": "Scheherazade New"
     },
     {
       "title": "Schibsted Grotesk",
       "markdownDescription": "https://fonts.google.com/specimen/Schibsted+Grotesk",
-      "enum": [
-        "Schibsted Grotesk"
-      ]
+      "const": "Schibsted Grotesk"
     },
     {
       "title": "Schoolbell",
       "markdownDescription": "https://fonts.google.com/specimen/Schoolbell",
-      "enum": [
-        "Schoolbell"
-      ]
+      "const": "Schoolbell"
     },
     {
       "title": "Scope One",
       "markdownDescription": "https://fonts.google.com/specimen/Scope+One",
-      "enum": [
-        "Scope One"
-      ]
+      "const": "Scope One"
     },
     {
       "title": "Seaweed Script",
       "markdownDescription": "https://fonts.google.com/specimen/Seaweed+Script",
-      "enum": [
-        "Seaweed Script"
-      ]
+      "const": "Seaweed Script"
     },
     {
       "title": "Secular One",
       "markdownDescription": "https://fonts.google.com/specimen/Secular+One",
-      "enum": [
-        "Secular One"
-      ]
+      "const": "Secular One"
     },
     {
       "title": "Sedgwick Ave",
       "markdownDescription": "https://fonts.google.com/specimen/Sedgwick+Ave",
-      "enum": [
-        "Sedgwick Ave"
-      ]
+      "const": "Sedgwick Ave"
     },
     {
       "title": "Sedgwick Ave Display",
       "markdownDescription": "https://fonts.google.com/specimen/Sedgwick+Ave+Display",
-      "enum": [
-        "Sedgwick Ave Display"
-      ]
+      "const": "Sedgwick Ave Display"
     },
     {
       "title": "Sen",
       "markdownDescription": "https://fonts.google.com/specimen/Sen",
-      "enum": [
-        "Sen"
-      ]
+      "const": "Sen"
     },
     {
       "title": "Send Flowers",
       "markdownDescription": "https://fonts.google.com/specimen/Send+Flowers",
-      "enum": [
-        "Send Flowers"
-      ]
+      "const": "Send Flowers"
     },
     {
       "title": "Sevillana",
       "markdownDescription": "https://fonts.google.com/specimen/Sevillana",
-      "enum": [
-        "Sevillana"
-      ]
+      "const": "Sevillana"
     },
     {
       "title": "Seymour One",
       "markdownDescription": "https://fonts.google.com/specimen/Seymour+One",
-      "enum": [
-        "Seymour One"
-      ]
+      "const": "Seymour One"
     },
     {
       "title": "Shadows Into Light",
       "markdownDescription": "https://fonts.google.com/specimen/Shadows+Into+Light",
-      "enum": [
-        "Shadows Into Light"
-      ]
+      "const": "Shadows Into Light"
     },
     {
       "title": "Shadows Into Light Two",
       "markdownDescription": "https://fonts.google.com/specimen/Shadows+Into+Light+Two",
-      "enum": [
-        "Shadows Into Light Two"
-      ]
+      "const": "Shadows Into Light Two"
     },
     {
       "title": "Shalimar",
       "markdownDescription": "https://fonts.google.com/specimen/Shalimar",
-      "enum": [
-        "Shalimar"
-      ]
+      "const": "Shalimar"
     },
     {
       "title": "Shantell Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Shantell+Sans",
-      "enum": [
-        "Shantell Sans"
-      ]
+      "const": "Shantell Sans"
     },
     {
       "title": "Shanti",
       "markdownDescription": "https://fonts.google.com/specimen/Shanti",
-      "enum": [
-        "Shanti"
-      ]
+      "const": "Shanti"
     },
     {
       "title": "Share",
       "markdownDescription": "https://fonts.google.com/specimen/Share",
-      "enum": [
-        "Share"
-      ]
+      "const": "Share"
     },
     {
       "title": "Share Tech",
       "markdownDescription": "https://fonts.google.com/specimen/Share+Tech",
-      "enum": [
-        "Share Tech"
-      ]
+      "const": "Share Tech"
     },
     {
       "title": "Share Tech Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Share+Tech+Mono",
-      "enum": [
-        "Share Tech Mono"
-      ]
+      "const": "Share Tech Mono"
     },
     {
       "title": "Shippori Antique",
       "markdownDescription": "https://fonts.google.com/specimen/Shippori+Antique",
-      "enum": [
-        "Shippori Antique"
-      ]
+      "const": "Shippori Antique"
     },
     {
       "title": "Shippori Antique B1",
       "markdownDescription": "https://fonts.google.com/specimen/Shippori+Antique+B1",
-      "enum": [
-        "Shippori Antique B1"
-      ]
+      "const": "Shippori Antique B1"
     },
     {
       "title": "Shippori Mincho",
       "markdownDescription": "https://fonts.google.com/specimen/Shippori+Mincho",
-      "enum": [
-        "Shippori Mincho"
-      ]
+      "const": "Shippori Mincho"
     },
     {
       "title": "Shippori Mincho B1",
       "markdownDescription": "https://fonts.google.com/specimen/Shippori+Mincho+B1",
-      "enum": [
-        "Shippori Mincho B1"
-      ]
+      "const": "Shippori Mincho B1"
     },
     {
       "title": "Shizuru",
       "markdownDescription": "https://fonts.google.com/specimen/Shizuru",
-      "enum": [
-        "Shizuru"
-      ]
+      "const": "Shizuru"
     },
     {
       "title": "Shojumaru",
       "markdownDescription": "https://fonts.google.com/specimen/Shojumaru",
-      "enum": [
-        "Shojumaru"
-      ]
+      "const": "Shojumaru"
     },
     {
       "title": "Short Stack",
       "markdownDescription": "https://fonts.google.com/specimen/Short+Stack",
-      "enum": [
-        "Short Stack"
-      ]
+      "const": "Short Stack"
     },
     {
       "title": "Shrikhand",
       "markdownDescription": "https://fonts.google.com/specimen/Shrikhand",
-      "enum": [
-        "Shrikhand"
-      ]
+      "const": "Shrikhand"
     },
     {
       "title": "Siemreap",
       "markdownDescription": "https://fonts.google.com/specimen/Siemreap",
-      "enum": [
-        "Siemreap"
-      ]
+      "const": "Siemreap"
     },
     {
       "title": "Sigmar",
       "markdownDescription": "https://fonts.google.com/specimen/Sigmar",
-      "enum": [
-        "Sigmar"
-      ]
+      "const": "Sigmar"
     },
     {
       "title": "Sigmar One",
       "markdownDescription": "https://fonts.google.com/specimen/Sigmar+One",
-      "enum": [
-        "Sigmar One"
-      ]
+      "const": "Sigmar One"
     },
     {
       "title": "Signika",
       "markdownDescription": "https://fonts.google.com/specimen/Signika",
-      "enum": [
-        "Signika"
-      ]
+      "const": "Signika"
     },
     {
       "title": "Signika Negative",
       "markdownDescription": "https://fonts.google.com/specimen/Signika+Negative",
-      "enum": [
-        "Signika Negative"
-      ]
+      "const": "Signika Negative"
     },
     {
       "title": "Silkscreen",
       "markdownDescription": "https://fonts.google.com/specimen/Silkscreen",
-      "enum": [
-        "Silkscreen"
-      ]
+      "const": "Silkscreen"
     },
     {
       "title": "Simonetta",
       "markdownDescription": "https://fonts.google.com/specimen/Simonetta",
-      "enum": [
-        "Simonetta"
-      ]
+      "const": "Simonetta"
     },
     {
       "title": "Single Day",
       "markdownDescription": "https://fonts.google.com/specimen/Single+Day",
-      "enum": [
-        "Single Day"
-      ]
+      "const": "Single Day"
     },
     {
       "title": "Sintony",
       "markdownDescription": "https://fonts.google.com/specimen/Sintony",
-      "enum": [
-        "Sintony"
-      ]
+      "const": "Sintony"
     },
     {
       "title": "Sirin Stencil",
       "markdownDescription": "https://fonts.google.com/specimen/Sirin+Stencil",
-      "enum": [
-        "Sirin Stencil"
-      ]
+      "const": "Sirin Stencil"
     },
     {
       "title": "Six Caps",
       "markdownDescription": "https://fonts.google.com/specimen/Six+Caps",
-      "enum": [
-        "Six Caps"
-      ]
+      "const": "Six Caps"
     },
     {
       "title": "Skranji",
       "markdownDescription": "https://fonts.google.com/specimen/Skranji",
-      "enum": [
-        "Skranji"
-      ]
+      "const": "Skranji"
     },
     {
       "title": "Slabo 13px",
       "markdownDescription": "https://fonts.google.com/specimen/Slabo+13px",
-      "enum": [
-        "Slabo 13px"
-      ]
+      "const": "Slabo 13px"
     },
     {
       "title": "Slabo 27px",
       "markdownDescription": "https://fonts.google.com/specimen/Slabo+27px",
-      "enum": [
-        "Slabo 27px"
-      ]
+      "const": "Slabo 27px"
     },
     {
       "title": "Slackey",
       "markdownDescription": "https://fonts.google.com/specimen/Slackey",
-      "enum": [
-        "Slackey"
-      ]
+      "const": "Slackey"
     },
     {
       "title": "Slackside One",
       "markdownDescription": "https://fonts.google.com/specimen/Slackside+One",
-      "enum": [
-        "Slackside One"
-      ]
+      "const": "Slackside One"
     },
     {
       "title": "Smokum",
       "markdownDescription": "https://fonts.google.com/specimen/Smokum",
-      "enum": [
-        "Smokum"
-      ]
+      "const": "Smokum"
     },
     {
       "title": "Smooch",
       "markdownDescription": "https://fonts.google.com/specimen/Smooch",
-      "enum": [
-        "Smooch"
-      ]
+      "const": "Smooch"
     },
     {
       "title": "Smooch Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Smooch+Sans",
-      "enum": [
-        "Smooch Sans"
-      ]
+      "const": "Smooch Sans"
     },
     {
       "title": "Smythe",
       "markdownDescription": "https://fonts.google.com/specimen/Smythe",
-      "enum": [
-        "Smythe"
-      ]
+      "const": "Smythe"
     },
     {
       "title": "Sniglet",
       "markdownDescription": "https://fonts.google.com/specimen/Sniglet",
-      "enum": [
-        "Sniglet"
-      ]
+      "const": "Sniglet"
     },
     {
       "title": "Snippet",
       "markdownDescription": "https://fonts.google.com/specimen/Snippet",
-      "enum": [
-        "Snippet"
-      ]
+      "const": "Snippet"
     },
     {
       "title": "Snowburst One",
       "markdownDescription": "https://fonts.google.com/specimen/Snowburst+One",
-      "enum": [
-        "Snowburst One"
-      ]
+      "const": "Snowburst One"
     },
     {
       "title": "Sofadi One",
       "markdownDescription": "https://fonts.google.com/specimen/Sofadi+One",
-      "enum": [
-        "Sofadi One"
-      ]
+      "const": "Sofadi One"
     },
     {
       "title": "Sofia",
       "markdownDescription": "https://fonts.google.com/specimen/Sofia",
-      "enum": [
-        "Sofia"
-      ]
+      "const": "Sofia"
     },
     {
       "title": "Sofia Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Sofia+Sans",
-      "enum": [
-        "Sofia Sans"
-      ]
+      "const": "Sofia Sans"
     },
     {
       "title": "Sofia Sans Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Sofia+Sans+Condensed",
-      "enum": [
-        "Sofia Sans Condensed"
-      ]
+      "const": "Sofia Sans Condensed"
     },
     {
       "title": "Sofia Sans Extra Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Sofia+Sans+Extra+Condensed",
-      "enum": [
-        "Sofia Sans Extra Condensed"
-      ]
+      "const": "Sofia Sans Extra Condensed"
     },
     {
       "title": "Sofia Sans Semi Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Sofia+Sans+Semi+Condensed",
-      "enum": [
-        "Sofia Sans Semi Condensed"
-      ]
+      "const": "Sofia Sans Semi Condensed"
     },
     {
       "title": "Solitreo",
       "markdownDescription": "https://fonts.google.com/specimen/Solitreo",
-      "enum": [
-        "Solitreo"
-      ]
+      "const": "Solitreo"
     },
     {
       "title": "Solway",
       "markdownDescription": "https://fonts.google.com/specimen/Solway",
-      "enum": [
-        "Solway"
-      ]
+      "const": "Solway"
     },
     {
       "title": "Sometype Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Sometype+Mono",
-      "enum": [
-        "Sometype Mono"
-      ]
+      "const": "Sometype Mono"
     },
     {
       "title": "Song Myung",
       "markdownDescription": "https://fonts.google.com/specimen/Song+Myung",
-      "enum": [
-        "Song Myung"
-      ]
+      "const": "Song Myung"
     },
     {
       "title": "Sono",
       "markdownDescription": "https://fonts.google.com/specimen/Sono",
-      "enum": [
-        "Sono"
-      ]
+      "const": "Sono"
     },
     {
       "title": "Sonsie One",
       "markdownDescription": "https://fonts.google.com/specimen/Sonsie+One",
-      "enum": [
-        "Sonsie One"
-      ]
+      "const": "Sonsie One"
     },
     {
       "title": "Sora",
       "markdownDescription": "https://fonts.google.com/specimen/Sora",
-      "enum": [
-        "Sora"
-      ]
+      "const": "Sora"
     },
     {
       "title": "Sorts Mill Goudy",
       "markdownDescription": "https://fonts.google.com/specimen/Sorts+Mill+Goudy",
-      "enum": [
-        "Sorts Mill Goudy"
-      ]
+      "const": "Sorts Mill Goudy"
     },
     {
       "title": "Source Code Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Source+Code+Pro",
-      "enum": [
-        "Source Code Pro"
-      ]
+      "const": "Source Code Pro"
     },
     {
       "title": "Source Sans 3",
       "markdownDescription": "https://fonts.google.com/specimen/Source+Sans+3",
-      "enum": [
-        "Source Sans 3"
-      ]
+      "const": "Source Sans 3"
     },
     {
       "title": "Source Serif 4",
       "markdownDescription": "https://fonts.google.com/specimen/Source+Serif+4",
-      "enum": [
-        "Source Serif 4"
-      ]
+      "const": "Source Serif 4"
     },
     {
       "title": "Space Grotesk",
       "markdownDescription": "https://fonts.google.com/specimen/Space+Grotesk",
-      "enum": [
-        "Space Grotesk"
-      ]
+      "const": "Space Grotesk"
     },
     {
       "title": "Space Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Space+Mono",
-      "enum": [
-        "Space Mono"
-      ]
+      "const": "Space Mono"
     },
     {
       "title": "Special Elite",
       "markdownDescription": "https://fonts.google.com/specimen/Special+Elite",
-      "enum": [
-        "Special Elite"
-      ]
+      "const": "Special Elite"
     },
     {
       "title": "Spectral",
       "markdownDescription": "https://fonts.google.com/specimen/Spectral",
-      "enum": [
-        "Spectral"
-      ]
+      "const": "Spectral"
     },
     {
       "title": "Spectral SC",
       "markdownDescription": "https://fonts.google.com/specimen/Spectral+SC",
-      "enum": [
-        "Spectral SC"
-      ]
+      "const": "Spectral SC"
     },
     {
       "title": "Spicy Rice",
       "markdownDescription": "https://fonts.google.com/specimen/Spicy+Rice",
-      "enum": [
-        "Spicy Rice"
-      ]
+      "const": "Spicy Rice"
     },
     {
       "title": "Spinnaker",
       "markdownDescription": "https://fonts.google.com/specimen/Spinnaker",
-      "enum": [
-        "Spinnaker"
-      ]
+      "const": "Spinnaker"
     },
     {
       "title": "Spirax",
       "markdownDescription": "https://fonts.google.com/specimen/Spirax",
-      "enum": [
-        "Spirax"
-      ]
+      "const": "Spirax"
     },
     {
       "title": "Splash",
       "markdownDescription": "https://fonts.google.com/specimen/Splash",
-      "enum": [
-        "Splash"
-      ]
+      "const": "Splash"
     },
     {
       "title": "Spline Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Spline+Sans",
-      "enum": [
-        "Spline Sans"
-      ]
+      "const": "Spline Sans"
     },
     {
       "title": "Spline Sans Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Spline+Sans+Mono",
-      "enum": [
-        "Spline Sans Mono"
-      ]
+      "const": "Spline Sans Mono"
     },
     {
       "title": "Squada One",
       "markdownDescription": "https://fonts.google.com/specimen/Squada+One",
-      "enum": [
-        "Squada One"
-      ]
+      "const": "Squada One"
     },
     {
       "title": "Square Peg",
       "markdownDescription": "https://fonts.google.com/specimen/Square+Peg",
-      "enum": [
-        "Square Peg"
-      ]
+      "const": "Square Peg"
     },
     {
       "title": "Sree Krushnadevaraya",
       "markdownDescription": "https://fonts.google.com/specimen/Sree+Krushnadevaraya",
-      "enum": [
-        "Sree Krushnadevaraya"
-      ]
+      "const": "Sree Krushnadevaraya"
     },
     {
       "title": "Sriracha",
       "markdownDescription": "https://fonts.google.com/specimen/Sriracha",
-      "enum": [
-        "Sriracha"
-      ]
+      "const": "Sriracha"
     },
     {
       "title": "Srisakdi",
       "markdownDescription": "https://fonts.google.com/specimen/Srisakdi",
-      "enum": [
-        "Srisakdi"
-      ]
+      "const": "Srisakdi"
     },
     {
       "title": "Staatliches",
       "markdownDescription": "https://fonts.google.com/specimen/Staatliches",
-      "enum": [
-        "Staatliches"
-      ]
+      "const": "Staatliches"
     },
     {
       "title": "Stalemate",
       "markdownDescription": "https://fonts.google.com/specimen/Stalemate",
-      "enum": [
-        "Stalemate"
-      ]
+      "const": "Stalemate"
     },
     {
       "title": "Stalinist One",
       "markdownDescription": "https://fonts.google.com/specimen/Stalinist+One",
-      "enum": [
-        "Stalinist One"
-      ]
+      "const": "Stalinist One"
     },
     {
       "title": "Stardos Stencil",
       "markdownDescription": "https://fonts.google.com/specimen/Stardos+Stencil",
-      "enum": [
-        "Stardos Stencil"
-      ]
+      "const": "Stardos Stencil"
     },
     {
       "title": "Stick",
       "markdownDescription": "https://fonts.google.com/specimen/Stick",
-      "enum": [
-        "Stick"
-      ]
+      "const": "Stick"
     },
     {
       "title": "Stick No Bills",
       "markdownDescription": "https://fonts.google.com/specimen/Stick+No+Bills",
-      "enum": [
-        "Stick No Bills"
-      ]
+      "const": "Stick No Bills"
     },
     {
       "title": "Stint Ultra Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Stint+Ultra+Condensed",
-      "enum": [
-        "Stint Ultra Condensed"
-      ]
+      "const": "Stint Ultra Condensed"
     },
     {
       "title": "Stint Ultra Expanded",
       "markdownDescription": "https://fonts.google.com/specimen/Stint+Ultra+Expanded",
-      "enum": [
-        "Stint Ultra Expanded"
-      ]
+      "const": "Stint Ultra Expanded"
     },
     {
       "title": "Stoke",
       "markdownDescription": "https://fonts.google.com/specimen/Stoke",
-      "enum": [
-        "Stoke"
-      ]
+      "const": "Stoke"
     },
     {
       "title": "Strait",
       "markdownDescription": "https://fonts.google.com/specimen/Strait",
-      "enum": [
-        "Strait"
-      ]
+      "const": "Strait"
     },
     {
       "title": "Style Script",
       "markdownDescription": "https://fonts.google.com/specimen/Style+Script",
-      "enum": [
-        "Style Script"
-      ]
+      "const": "Style Script"
     },
     {
       "title": "Stylish",
       "markdownDescription": "https://fonts.google.com/specimen/Stylish",
-      "enum": [
-        "Stylish"
-      ]
+      "const": "Stylish"
     },
     {
       "title": "Sue Ellen Francisco",
       "markdownDescription": "https://fonts.google.com/specimen/Sue+Ellen+Francisco",
-      "enum": [
-        "Sue Ellen Francisco"
-      ]
+      "const": "Sue Ellen Francisco"
     },
     {
       "title": "Suez One",
       "markdownDescription": "https://fonts.google.com/specimen/Suez+One",
-      "enum": [
-        "Suez One"
-      ]
+      "const": "Suez One"
     },
     {
       "title": "Sulphur Point",
       "markdownDescription": "https://fonts.google.com/specimen/Sulphur+Point",
-      "enum": [
-        "Sulphur Point"
-      ]
+      "const": "Sulphur Point"
     },
     {
       "title": "Sumana",
       "markdownDescription": "https://fonts.google.com/specimen/Sumana",
-      "enum": [
-        "Sumana"
-      ]
+      "const": "Sumana"
     },
     {
       "title": "Sunflower",
       "markdownDescription": "https://fonts.google.com/specimen/Sunflower",
-      "enum": [
-        "Sunflower"
-      ]
+      "const": "Sunflower"
     },
     {
       "title": "Sunshiney",
       "markdownDescription": "https://fonts.google.com/specimen/Sunshiney",
-      "enum": [
-        "Sunshiney"
-      ]
+      "const": "Sunshiney"
     },
     {
       "title": "Supermercado One",
       "markdownDescription": "https://fonts.google.com/specimen/Supermercado+One",
-      "enum": [
-        "Supermercado One"
-      ]
+      "const": "Supermercado One"
     },
     {
       "title": "Sura",
       "markdownDescription": "https://fonts.google.com/specimen/Sura",
-      "enum": [
-        "Sura"
-      ]
+      "const": "Sura"
     },
     {
       "title": "Suranna",
       "markdownDescription": "https://fonts.google.com/specimen/Suranna",
-      "enum": [
-        "Suranna"
-      ]
+      "const": "Suranna"
     },
     {
       "title": "Suravaram",
       "markdownDescription": "https://fonts.google.com/specimen/Suravaram",
-      "enum": [
-        "Suravaram"
-      ]
+      "const": "Suravaram"
     },
     {
       "title": "Suwannaphum",
       "markdownDescription": "https://fonts.google.com/specimen/Suwannaphum",
-      "enum": [
-        "Suwannaphum"
-      ]
+      "const": "Suwannaphum"
     },
     {
       "title": "Swanky and Moo Moo",
       "markdownDescription": "https://fonts.google.com/specimen/Swanky+and+Moo+Moo",
-      "enum": [
-        "Swanky and Moo Moo"
-      ]
+      "const": "Swanky and Moo Moo"
     },
     {
       "title": "Syncopate",
       "markdownDescription": "https://fonts.google.com/specimen/Syncopate",
-      "enum": [
-        "Syncopate"
-      ]
+      "const": "Syncopate"
     },
     {
       "title": "Syne",
       "markdownDescription": "https://fonts.google.com/specimen/Syne",
-      "enum": [
-        "Syne"
-      ]
+      "const": "Syne"
     },
     {
       "title": "Syne Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Syne+Mono",
-      "enum": [
-        "Syne Mono"
-      ]
+      "const": "Syne Mono"
     },
     {
       "title": "Syne Tactile",
       "markdownDescription": "https://fonts.google.com/specimen/Syne+Tactile",
-      "enum": [
-        "Syne Tactile"
-      ]
+      "const": "Syne Tactile"
     },
     {
       "title": "Tai Heritage Pro",
       "markdownDescription": "https://fonts.google.com/specimen/Tai+Heritage+Pro",
-      "enum": [
-        "Tai Heritage Pro"
-      ]
+      "const": "Tai Heritage Pro"
     },
     {
       "title": "Tajawal",
       "markdownDescription": "https://fonts.google.com/specimen/Tajawal",
-      "enum": [
-        "Tajawal"
-      ]
+      "const": "Tajawal"
     },
     {
       "title": "Tangerine",
       "markdownDescription": "https://fonts.google.com/specimen/Tangerine",
-      "enum": [
-        "Tangerine"
-      ]
+      "const": "Tangerine"
     },
     {
       "title": "Tapestry",
       "markdownDescription": "https://fonts.google.com/specimen/Tapestry",
-      "enum": [
-        "Tapestry"
-      ]
+      "const": "Tapestry"
     },
     {
       "title": "Taprom",
       "markdownDescription": "https://fonts.google.com/specimen/Taprom",
-      "enum": [
-        "Taprom"
-      ]
+      "const": "Taprom"
     },
     {
       "title": "Tauri",
       "markdownDescription": "https://fonts.google.com/specimen/Tauri",
-      "enum": [
-        "Tauri"
-      ]
+      "const": "Tauri"
     },
     {
       "title": "Taviraj",
       "markdownDescription": "https://fonts.google.com/specimen/Taviraj",
-      "enum": [
-        "Taviraj"
-      ]
+      "const": "Taviraj"
     },
     {
       "title": "Teko",
       "markdownDescription": "https://fonts.google.com/specimen/Teko",
-      "enum": [
-        "Teko"
-      ]
+      "const": "Teko"
     },
     {
       "title": "Tektur",
       "markdownDescription": "https://fonts.google.com/specimen/Tektur",
-      "enum": [
-        "Tektur"
-      ]
+      "const": "Tektur"
     },
     {
       "title": "Telex",
       "markdownDescription": "https://fonts.google.com/specimen/Telex",
-      "enum": [
-        "Telex"
-      ]
+      "const": "Telex"
     },
     {
       "title": "Tenali Ramakrishna",
       "markdownDescription": "https://fonts.google.com/specimen/Tenali+Ramakrishna",
-      "enum": [
-        "Tenali Ramakrishna"
-      ]
+      "const": "Tenali Ramakrishna"
     },
     {
       "title": "Tenor Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Tenor+Sans",
-      "enum": [
-        "Tenor Sans"
-      ]
+      "const": "Tenor Sans"
     },
     {
       "title": "Text Me One",
       "markdownDescription": "https://fonts.google.com/specimen/Text+Me+One",
-      "enum": [
-        "Text Me One"
-      ]
+      "const": "Text Me One"
     },
     {
       "title": "Texturina",
       "markdownDescription": "https://fonts.google.com/specimen/Texturina",
-      "enum": [
-        "Texturina"
-      ]
+      "const": "Texturina"
     },
     {
       "title": "Thasadith",
       "markdownDescription": "https://fonts.google.com/specimen/Thasadith",
-      "enum": [
-        "Thasadith"
-      ]
+      "const": "Thasadith"
     },
     {
       "title": "The Girl Next Door",
       "markdownDescription": "https://fonts.google.com/specimen/The+Girl+Next+Door",
-      "enum": [
-        "The Girl Next Door"
-      ]
+      "const": "The Girl Next Door"
     },
     {
       "title": "The Nautigal",
       "markdownDescription": "https://fonts.google.com/specimen/The+Nautigal",
-      "enum": [
-        "The Nautigal"
-      ]
+      "const": "The Nautigal"
     },
     {
       "title": "Tienne",
       "markdownDescription": "https://fonts.google.com/specimen/Tienne",
-      "enum": [
-        "Tienne"
-      ]
+      "const": "Tienne"
     },
     {
       "title": "Tillana",
       "markdownDescription": "https://fonts.google.com/specimen/Tillana",
-      "enum": [
-        "Tillana"
-      ]
+      "const": "Tillana"
     },
     {
       "title": "Tilt Neon",
       "markdownDescription": "https://fonts.google.com/specimen/Tilt+Neon",
-      "enum": [
-        "Tilt Neon"
-      ]
+      "const": "Tilt Neon"
     },
     {
       "title": "Tilt Prism",
       "markdownDescription": "https://fonts.google.com/specimen/Tilt+Prism",
-      "enum": [
-        "Tilt Prism"
-      ]
+      "const": "Tilt Prism"
     },
     {
       "title": "Tilt Warp",
       "markdownDescription": "https://fonts.google.com/specimen/Tilt+Warp",
-      "enum": [
-        "Tilt Warp"
-      ]
+      "const": "Tilt Warp"
     },
     {
       "title": "Timmana",
       "markdownDescription": "https://fonts.google.com/specimen/Timmana",
-      "enum": [
-        "Timmana"
-      ]
+      "const": "Timmana"
     },
     {
       "title": "Tinos",
       "markdownDescription": "https://fonts.google.com/specimen/Tinos",
-      "enum": [
-        "Tinos"
-      ]
+      "const": "Tinos"
     },
     {
       "title": "Tiro Bangla",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Bangla",
-      "enum": [
-        "Tiro Bangla"
-      ]
+      "const": "Tiro Bangla"
     },
     {
       "title": "Tiro Devanagari Hindi",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Devanagari+Hindi",
-      "enum": [
-        "Tiro Devanagari Hindi"
-      ]
+      "const": "Tiro Devanagari Hindi"
     },
     {
       "title": "Tiro Devanagari Marathi",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Devanagari+Marathi",
-      "enum": [
-        "Tiro Devanagari Marathi"
-      ]
+      "const": "Tiro Devanagari Marathi"
     },
     {
       "title": "Tiro Devanagari Sanskrit",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Devanagari+Sanskrit",
-      "enum": [
-        "Tiro Devanagari Sanskrit"
-      ]
+      "const": "Tiro Devanagari Sanskrit"
     },
     {
       "title": "Tiro Gurmukhi",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Gurmukhi",
-      "enum": [
-        "Tiro Gurmukhi"
-      ]
+      "const": "Tiro Gurmukhi"
     },
     {
       "title": "Tiro Kannada",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Kannada",
-      "enum": [
-        "Tiro Kannada"
-      ]
+      "const": "Tiro Kannada"
     },
     {
       "title": "Tiro Tamil",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Tamil",
-      "enum": [
-        "Tiro Tamil"
-      ]
+      "const": "Tiro Tamil"
     },
     {
       "title": "Tiro Telugu",
       "markdownDescription": "https://fonts.google.com/specimen/Tiro+Telugu",
-      "enum": [
-        "Tiro Telugu"
-      ]
+      "const": "Tiro Telugu"
     },
     {
       "title": "Titan One",
       "markdownDescription": "https://fonts.google.com/specimen/Titan+One",
-      "enum": [
-        "Titan One"
-      ]
+      "const": "Titan One"
     },
     {
       "title": "Titillium Web",
       "markdownDescription": "https://fonts.google.com/specimen/Titillium+Web",
-      "enum": [
-        "Titillium Web"
-      ]
+      "const": "Titillium Web"
     },
     {
       "title": "Tomorrow",
       "markdownDescription": "https://fonts.google.com/specimen/Tomorrow",
-      "enum": [
-        "Tomorrow"
-      ]
+      "const": "Tomorrow"
     },
     {
       "title": "Tourney",
       "markdownDescription": "https://fonts.google.com/specimen/Tourney",
-      "enum": [
-        "Tourney"
-      ]
+      "const": "Tourney"
     },
     {
       "title": "Trade Winds",
       "markdownDescription": "https://fonts.google.com/specimen/Trade+Winds",
-      "enum": [
-        "Trade Winds"
-      ]
+      "const": "Trade Winds"
     },
     {
       "title": "Train One",
       "markdownDescription": "https://fonts.google.com/specimen/Train+One",
-      "enum": [
-        "Train One"
-      ]
+      "const": "Train One"
     },
     {
       "title": "Trirong",
       "markdownDescription": "https://fonts.google.com/specimen/Trirong",
-      "enum": [
-        "Trirong"
-      ]
+      "const": "Trirong"
     },
     {
       "title": "Trispace",
       "markdownDescription": "https://fonts.google.com/specimen/Trispace",
-      "enum": [
-        "Trispace"
-      ]
+      "const": "Trispace"
     },
     {
       "title": "Trocchi",
       "markdownDescription": "https://fonts.google.com/specimen/Trocchi",
-      "enum": [
-        "Trocchi"
-      ]
+      "const": "Trocchi"
     },
     {
       "title": "Trochut",
       "markdownDescription": "https://fonts.google.com/specimen/Trochut",
-      "enum": [
-        "Trochut"
-      ]
+      "const": "Trochut"
     },
     {
       "title": "Truculenta",
       "markdownDescription": "https://fonts.google.com/specimen/Truculenta",
-      "enum": [
-        "Truculenta"
-      ]
+      "const": "Truculenta"
     },
     {
       "title": "Trykker",
       "markdownDescription": "https://fonts.google.com/specimen/Trykker",
-      "enum": [
-        "Trykker"
-      ]
+      "const": "Trykker"
     },
     {
       "title": "Tsukimi Rounded",
       "markdownDescription": "https://fonts.google.com/specimen/Tsukimi+Rounded",
-      "enum": [
-        "Tsukimi Rounded"
-      ]
+      "const": "Tsukimi Rounded"
     },
     {
       "title": "Tulpen One",
       "markdownDescription": "https://fonts.google.com/specimen/Tulpen+One",
-      "enum": [
-        "Tulpen One"
-      ]
+      "const": "Tulpen One"
     },
     {
       "title": "Turret Road",
       "markdownDescription": "https://fonts.google.com/specimen/Turret+Road",
-      "enum": [
-        "Turret Road"
-      ]
+      "const": "Turret Road"
     },
     {
       "title": "Twinkle Star",
       "markdownDescription": "https://fonts.google.com/specimen/Twinkle+Star",
-      "enum": [
-        "Twinkle Star"
-      ]
+      "const": "Twinkle Star"
     },
     {
       "title": "Ubuntu",
       "markdownDescription": "https://fonts.google.com/specimen/Ubuntu",
-      "enum": [
-        "Ubuntu"
-      ]
+      "const": "Ubuntu"
     },
     {
       "title": "Ubuntu Condensed",
       "markdownDescription": "https://fonts.google.com/specimen/Ubuntu+Condensed",
-      "enum": [
-        "Ubuntu Condensed"
-      ]
+      "const": "Ubuntu Condensed"
     },
     {
       "title": "Ubuntu Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Ubuntu+Mono",
-      "enum": [
-        "Ubuntu Mono"
-      ]
+      "const": "Ubuntu Mono"
     },
     {
       "title": "Uchen",
       "markdownDescription": "https://fonts.google.com/specimen/Uchen",
-      "enum": [
-        "Uchen"
-      ]
+      "const": "Uchen"
     },
     {
       "title": "Ultra",
       "markdownDescription": "https://fonts.google.com/specimen/Ultra",
-      "enum": [
-        "Ultra"
-      ]
+      "const": "Ultra"
     },
     {
       "title": "Unbounded",
       "markdownDescription": "https://fonts.google.com/specimen/Unbounded",
-      "enum": [
-        "Unbounded"
-      ]
+      "const": "Unbounded"
     },
     {
       "title": "Uncial Antiqua",
       "markdownDescription": "https://fonts.google.com/specimen/Uncial+Antiqua",
-      "enum": [
-        "Uncial Antiqua"
-      ]
+      "const": "Uncial Antiqua"
     },
     {
       "title": "Underdog",
       "markdownDescription": "https://fonts.google.com/specimen/Underdog",
-      "enum": [
-        "Underdog"
-      ]
+      "const": "Underdog"
     },
     {
       "title": "Unica One",
       "markdownDescription": "https://fonts.google.com/specimen/Unica+One",
-      "enum": [
-        "Unica One"
-      ]
+      "const": "Unica One"
     },
     {
       "title": "UnifrakturCook",
       "markdownDescription": "https://fonts.google.com/specimen/UnifrakturCook",
-      "enum": [
-        "UnifrakturCook"
-      ]
+      "const": "UnifrakturCook"
     },
     {
       "title": "UnifrakturMaguntia",
       "markdownDescription": "https://fonts.google.com/specimen/UnifrakturMaguntia",
-      "enum": [
-        "UnifrakturMaguntia"
-      ]
+      "const": "UnifrakturMaguntia"
     },
     {
       "title": "Unkempt",
       "markdownDescription": "https://fonts.google.com/specimen/Unkempt",
-      "enum": [
-        "Unkempt"
-      ]
+      "const": "Unkempt"
     },
     {
       "title": "Unlock",
       "markdownDescription": "https://fonts.google.com/specimen/Unlock",
-      "enum": [
-        "Unlock"
-      ]
+      "const": "Unlock"
     },
     {
       "title": "Unna",
       "markdownDescription": "https://fonts.google.com/specimen/Unna",
-      "enum": [
-        "Unna"
-      ]
+      "const": "Unna"
     },
     {
       "title": "Updock",
       "markdownDescription": "https://fonts.google.com/specimen/Updock",
-      "enum": [
-        "Updock"
-      ]
+      "const": "Updock"
     },
     {
       "title": "Urbanist",
       "markdownDescription": "https://fonts.google.com/specimen/Urbanist",
-      "enum": [
-        "Urbanist"
-      ]
+      "const": "Urbanist"
     },
     {
       "title": "VT323",
       "markdownDescription": "https://fonts.google.com/specimen/VT323",
-      "enum": [
-        "VT323"
-      ]
+      "const": "VT323"
     },
     {
       "title": "Vampiro One",
       "markdownDescription": "https://fonts.google.com/specimen/Vampiro+One",
-      "enum": [
-        "Vampiro One"
-      ]
+      "const": "Vampiro One"
     },
     {
       "title": "Varela",
       "markdownDescription": "https://fonts.google.com/specimen/Varela",
-      "enum": [
-        "Varela"
-      ]
+      "const": "Varela"
     },
     {
       "title": "Varela Round",
       "markdownDescription": "https://fonts.google.com/specimen/Varela+Round",
-      "enum": [
-        "Varela Round"
-      ]
+      "const": "Varela Round"
     },
     {
       "title": "Varta",
       "markdownDescription": "https://fonts.google.com/specimen/Varta",
-      "enum": [
-        "Varta"
-      ]
+      "const": "Varta"
     },
     {
       "title": "Vast Shadow",
       "markdownDescription": "https://fonts.google.com/specimen/Vast+Shadow",
-      "enum": [
-        "Vast Shadow"
-      ]
+      "const": "Vast Shadow"
     },
     {
       "title": "Vazirmatn",
       "markdownDescription": "https://fonts.google.com/specimen/Vazirmatn",
-      "enum": [
-        "Vazirmatn"
-      ]
+      "const": "Vazirmatn"
     },
     {
       "title": "Vesper Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Vesper+Libre",
-      "enum": [
-        "Vesper Libre"
-      ]
+      "const": "Vesper Libre"
     },
     {
       "title": "Viaoda Libre",
       "markdownDescription": "https://fonts.google.com/specimen/Viaoda+Libre",
-      "enum": [
-        "Viaoda Libre"
-      ]
+      "const": "Viaoda Libre"
     },
     {
       "title": "Vibes",
       "markdownDescription": "https://fonts.google.com/specimen/Vibes",
-      "enum": [
-        "Vibes"
-      ]
+      "const": "Vibes"
     },
     {
       "title": "Vibur",
       "markdownDescription": "https://fonts.google.com/specimen/Vibur",
-      "enum": [
-        "Vibur"
-      ]
+      "const": "Vibur"
     },
     {
       "title": "Victor Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Victor+Mono",
-      "enum": [
-        "Victor Mono"
-      ]
+      "const": "Victor Mono"
     },
     {
       "title": "Vidaloka",
       "markdownDescription": "https://fonts.google.com/specimen/Vidaloka",
-      "enum": [
-        "Vidaloka"
-      ]
+      "const": "Vidaloka"
     },
     {
       "title": "Viga",
       "markdownDescription": "https://fonts.google.com/specimen/Viga",
-      "enum": [
-        "Viga"
-      ]
+      "const": "Viga"
     },
     {
       "title": "Vina Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Vina+Sans",
-      "enum": [
-        "Vina Sans"
-      ]
+      "const": "Vina Sans"
     },
     {
       "title": "Voces",
       "markdownDescription": "https://fonts.google.com/specimen/Voces",
-      "enum": [
-        "Voces"
-      ]
+      "const": "Voces"
     },
     {
       "title": "Volkhov",
       "markdownDescription": "https://fonts.google.com/specimen/Volkhov",
-      "enum": [
-        "Volkhov"
-      ]
+      "const": "Volkhov"
     },
     {
       "title": "Vollkorn",
       "markdownDescription": "https://fonts.google.com/specimen/Vollkorn",
-      "enum": [
-        "Vollkorn"
-      ]
+      "const": "Vollkorn"
     },
     {
       "title": "Vollkorn SC",
       "markdownDescription": "https://fonts.google.com/specimen/Vollkorn+SC",
-      "enum": [
-        "Vollkorn SC"
-      ]
+      "const": "Vollkorn SC"
     },
     {
       "title": "Voltaire",
       "markdownDescription": "https://fonts.google.com/specimen/Voltaire",
-      "enum": [
-        "Voltaire"
-      ]
+      "const": "Voltaire"
     },
     {
       "title": "Vujahday Script",
       "markdownDescription": "https://fonts.google.com/specimen/Vujahday+Script",
-      "enum": [
-        "Vujahday Script"
-      ]
+      "const": "Vujahday Script"
     },
     {
       "title": "Waiting for the Sunrise",
       "markdownDescription": "https://fonts.google.com/specimen/Waiting+for+the+Sunrise",
-      "enum": [
-        "Waiting for the Sunrise"
-      ]
+      "const": "Waiting for the Sunrise"
     },
     {
       "title": "Wallpoet",
       "markdownDescription": "https://fonts.google.com/specimen/Wallpoet",
-      "enum": [
-        "Wallpoet"
-      ]
+      "const": "Wallpoet"
     },
     {
       "title": "Walter Turncoat",
       "markdownDescription": "https://fonts.google.com/specimen/Walter+Turncoat",
-      "enum": [
-        "Walter Turncoat"
-      ]
+      "const": "Walter Turncoat"
     },
     {
       "title": "Warnes",
       "markdownDescription": "https://fonts.google.com/specimen/Warnes",
-      "enum": [
-        "Warnes"
-      ]
+      "const": "Warnes"
     },
     {
       "title": "Water Brush",
       "markdownDescription": "https://fonts.google.com/specimen/Water+Brush",
-      "enum": [
-        "Water Brush"
-      ]
+      "const": "Water Brush"
     },
     {
       "title": "Waterfall",
       "markdownDescription": "https://fonts.google.com/specimen/Waterfall",
-      "enum": [
-        "Waterfall"
-      ]
+      "const": "Waterfall"
     },
     {
       "title": "Wavefont",
       "markdownDescription": "https://fonts.google.com/specimen/Wavefont",
-      "enum": [
-        "Wavefont"
-      ]
+      "const": "Wavefont"
     },
     {
       "title": "Wellfleet",
       "markdownDescription": "https://fonts.google.com/specimen/Wellfleet",
-      "enum": [
-        "Wellfleet"
-      ]
+      "const": "Wellfleet"
     },
     {
       "title": "Wendy One",
       "markdownDescription": "https://fonts.google.com/specimen/Wendy+One",
-      "enum": [
-        "Wendy One"
-      ]
+      "const": "Wendy One"
     },
     {
       "title": "Whisper",
       "markdownDescription": "https://fonts.google.com/specimen/Whisper",
-      "enum": [
-        "Whisper"
-      ]
+      "const": "Whisper"
     },
     {
       "title": "WindSong",
       "markdownDescription": "https://fonts.google.com/specimen/WindSong",
-      "enum": [
-        "WindSong"
-      ]
+      "const": "WindSong"
     },
     {
       "title": "Wire One",
       "markdownDescription": "https://fonts.google.com/specimen/Wire+One",
-      "enum": [
-        "Wire One"
-      ]
+      "const": "Wire One"
     },
     {
       "title": "Wix Madefor Display",
       "markdownDescription": "https://fonts.google.com/specimen/Wix+Madefor+Display",
-      "enum": [
-        "Wix Madefor Display"
-      ]
+      "const": "Wix Madefor Display"
     },
     {
       "title": "Wix Madefor Text",
       "markdownDescription": "https://fonts.google.com/specimen/Wix+Madefor+Text",
-      "enum": [
-        "Wix Madefor Text"
-      ]
+      "const": "Wix Madefor Text"
     },
     {
       "title": "Work Sans",
       "markdownDescription": "https://fonts.google.com/specimen/Work+Sans",
-      "enum": [
-        "Work Sans"
-      ]
+      "const": "Work Sans"
     },
     {
       "title": "Xanh Mono",
       "markdownDescription": "https://fonts.google.com/specimen/Xanh+Mono",
-      "enum": [
-        "Xanh Mono"
-      ]
+      "const": "Xanh Mono"
     },
     {
       "title": "Yaldevi",
       "markdownDescription": "https://fonts.google.com/specimen/Yaldevi",
-      "enum": [
-        "Yaldevi"
-      ]
+      "const": "Yaldevi"
     },
     {
       "title": "Yanone Kaffeesatz",
       "markdownDescription": "https://fonts.google.com/specimen/Yanone+Kaffeesatz",
-      "enum": [
-        "Yanone Kaffeesatz"
-      ]
+      "const": "Yanone Kaffeesatz"
     },
     {
       "title": "Yantramanav",
       "markdownDescription": "https://fonts.google.com/specimen/Yantramanav",
-      "enum": [
-        "Yantramanav"
-      ]
+      "const": "Yantramanav"
     },
     {
       "title": "Yatra One",
       "markdownDescription": "https://fonts.google.com/specimen/Yatra+One",
-      "enum": [
-        "Yatra One"
-      ]
+      "const": "Yatra One"
     },
     {
       "title": "Yellowtail",
       "markdownDescription": "https://fonts.google.com/specimen/Yellowtail",
-      "enum": [
-        "Yellowtail"
-      ]
+      "const": "Yellowtail"
     },
     {
       "title": "Yeon Sung",
       "markdownDescription": "https://fonts.google.com/specimen/Yeon+Sung",
-      "enum": [
-        "Yeon Sung"
-      ]
+      "const": "Yeon Sung"
     },
     {
       "title": "Yeseva One",
       "markdownDescription": "https://fonts.google.com/specimen/Yeseva+One",
-      "enum": [
-        "Yeseva One"
-      ]
+      "const": "Yeseva One"
     },
     {
       "title": "Yesteryear",
       "markdownDescription": "https://fonts.google.com/specimen/Yesteryear",
-      "enum": [
-        "Yesteryear"
-      ]
+      "const": "Yesteryear"
     },
     {
       "title": "Yomogi",
       "markdownDescription": "https://fonts.google.com/specimen/Yomogi",
-      "enum": [
-        "Yomogi"
-      ]
+      "const": "Yomogi"
     },
     {
       "title": "Young Serif",
       "markdownDescription": "https://fonts.google.com/specimen/Young+Serif",
-      "enum": [
-        "Young Serif"
-      ]
+      "const": "Young Serif"
     },
     {
       "title": "Yrsa",
       "markdownDescription": "https://fonts.google.com/specimen/Yrsa",
-      "enum": [
-        "Yrsa"
-      ]
+      "const": "Yrsa"
     },
     {
       "title": "Ysabeau",
       "markdownDescription": "https://fonts.google.com/specimen/Ysabeau",
-      "enum": [
-        "Ysabeau"
-      ]
+      "const": "Ysabeau"
     },
     {
       "title": "Ysabeau Infant",
       "markdownDescription": "https://fonts.google.com/specimen/Ysabeau+Infant",
-      "enum": [
-        "Ysabeau Infant"
-      ]
+      "const": "Ysabeau Infant"
     },
     {
       "title": "Ysabeau Office",
       "markdownDescription": "https://fonts.google.com/specimen/Ysabeau+Office",
-      "enum": [
-        "Ysabeau Office"
-      ]
+      "const": "Ysabeau Office"
     },
     {
       "title": "Ysabeau SC",
       "markdownDescription": "https://fonts.google.com/specimen/Ysabeau+SC",
-      "enum": [
-        "Ysabeau SC"
-      ]
+      "const": "Ysabeau SC"
     },
     {
       "title": "Yuji Boku",
       "markdownDescription": "https://fonts.google.com/specimen/Yuji+Boku",
-      "enum": [
-        "Yuji Boku"
-      ]
+      "const": "Yuji Boku"
     },
     {
       "title": "Yuji Hentaigana Akari",
       "markdownDescription": "https://fonts.google.com/specimen/Yuji+Hentaigana+Akari",
-      "enum": [
-        "Yuji Hentaigana Akari"
-      ]
+      "const": "Yuji Hentaigana Akari"
     },
     {
       "title": "Yuji Hentaigana Akebono",
       "markdownDescription": "https://fonts.google.com/specimen/Yuji+Hentaigana+Akebono",
-      "enum": [
-        "Yuji Hentaigana Akebono"
-      ]
+      "const": "Yuji Hentaigana Akebono"
     },
     {
       "title": "Yuji Mai",
       "markdownDescription": "https://fonts.google.com/specimen/Yuji+Mai",
-      "enum": [
-        "Yuji Mai"
-      ]
+      "const": "Yuji Mai"
     },
     {
       "title": "Yuji Syuku",
       "markdownDescription": "https://fonts.google.com/specimen/Yuji+Syuku",
-      "enum": [
-        "Yuji Syuku"
-      ]
+      "const": "Yuji Syuku"
     },
     {
       "title": "Yusei Magic",
       "markdownDescription": "https://fonts.google.com/specimen/Yusei+Magic",
-      "enum": [
-        "Yusei Magic"
-      ]
+      "const": "Yusei Magic"
     },
     {
       "title": "ZCOOL KuaiLe",
       "markdownDescription": "https://fonts.google.com/specimen/ZCOOL+KuaiLe",
-      "enum": [
-        "ZCOOL KuaiLe"
-      ]
+      "const": "ZCOOL KuaiLe"
     },
     {
       "title": "ZCOOL QingKe HuangYou",
       "markdownDescription": "https://fonts.google.com/specimen/ZCOOL+QingKe+HuangYou",
-      "enum": [
-        "ZCOOL QingKe HuangYou"
-      ]
+      "const": "ZCOOL QingKe HuangYou"
     },
     {
       "title": "ZCOOL XiaoWei",
       "markdownDescription": "https://fonts.google.com/specimen/ZCOOL+XiaoWei",
-      "enum": [
-        "ZCOOL XiaoWei"
-      ]
+      "const": "ZCOOL XiaoWei"
     },
     {
       "title": "Zen Antique",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Antique",
-      "enum": [
-        "Zen Antique"
-      ]
+      "const": "Zen Antique"
     },
     {
       "title": "Zen Antique Soft",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Antique+Soft",
-      "enum": [
-        "Zen Antique Soft"
-      ]
+      "const": "Zen Antique Soft"
     },
     {
       "title": "Zen Dots",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Dots",
-      "enum": [
-        "Zen Dots"
-      ]
+      "const": "Zen Dots"
     },
     {
       "title": "Zen Kaku Gothic Antique",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Kaku+Gothic+Antique",
-      "enum": [
-        "Zen Kaku Gothic Antique"
-      ]
+      "const": "Zen Kaku Gothic Antique"
     },
     {
       "title": "Zen Kaku Gothic New",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Kaku+Gothic+New",
-      "enum": [
-        "Zen Kaku Gothic New"
-      ]
+      "const": "Zen Kaku Gothic New"
     },
     {
       "title": "Zen Kurenaido",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Kurenaido",
-      "enum": [
-        "Zen Kurenaido"
-      ]
+      "const": "Zen Kurenaido"
     },
     {
       "title": "Zen Loop",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Loop",
-      "enum": [
-        "Zen Loop"
-      ]
+      "const": "Zen Loop"
     },
     {
       "title": "Zen Maru Gothic",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Maru+Gothic",
-      "enum": [
-        "Zen Maru Gothic"
-      ]
+      "const": "Zen Maru Gothic"
     },
     {
       "title": "Zen Old Mincho",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Old+Mincho",
-      "enum": [
-        "Zen Old Mincho"
-      ]
+      "const": "Zen Old Mincho"
     },
     {
       "title": "Zen Tokyo Zoo",
       "markdownDescription": "https://fonts.google.com/specimen/Zen+Tokyo+Zoo",
-      "enum": [
-        "Zen Tokyo Zoo"
-      ]
+      "const": "Zen Tokyo Zoo"
     },
     {
       "title": "Zeyada",
       "markdownDescription": "https://fonts.google.com/specimen/Zeyada",
-      "enum": [
-        "Zeyada"
-      ]
+      "const": "Zeyada"
     },
     {
       "title": "Zhi Mang Xing",
       "markdownDescription": "https://fonts.google.com/specimen/Zhi+Mang+Xing",
-      "enum": [
-        "Zhi Mang Xing"
-      ]
+      "const": "Zhi Mang Xing"
     },
     {
       "title": "Zilla Slab",
       "markdownDescription": "https://fonts.google.com/specimen/Zilla+Slab",
-      "enum": [
-        "Zilla Slab"
-      ]
+      "const": "Zilla Slab"
     },
     {
       "title": "Zilla Slab Highlight",
       "markdownDescription": "https://fonts.google.com/specimen/Zilla+Slab+Highlight",
-      "enum": [
-        "Zilla Slab Highlight"
-      ]
+      "const": "Zilla Slab Highlight"
     }
   ]
 }

--- a/docs/schema/extensions/pymdownx.json
+++ b/docs/schema/extensions/pymdownx.json
@@ -27,9 +27,7 @@
         {
           "title": "Arithmatex – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#arithmatex",
-          "enum": [
-            "pymdownx.arithmatex"
-          ]
+          "const": "pymdownx.arithmatex"
         }
       ]
     },
@@ -63,9 +61,7 @@
         {
           "title": "BetterEm – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#betterem",
-          "enum": [
-            "pymdownx.betterem"
-          ]
+          "const": "pymdownx.betterem"
         }
       ]
     },
@@ -74,9 +70,7 @@
         {
           "title": "Caret – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#caret-mark-tilde",
-          "enum": [
-            "pymdownx.caret"
-          ]
+          "const": "pymdownx.caret"
         },
         {
           "type": "object",
@@ -114,9 +108,7 @@
         {
           "title": "Critic – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#critic",
-          "enum": [
-            "pymdownx.critic"
-          ]
+          "const": "pymdownx.critic"
         },
         {
           "type": "object",
@@ -145,18 +137,14 @@
     {
       "title": "Details – Python Markdown Extensions",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#details",
-      "enum": [
-        "pymdownx.details"
-      ]
+      "const": "pymdownx.details"
     },
     {
       "oneOf": [
         {
           "title": "Emoji – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#emoji",
-          "enum": [
-            "pymdownx.emoji"
-          ]
+          "const": "pymdownx.emoji"
         },
         {
           "type": "object",
@@ -208,9 +196,7 @@
         {
           "title": "Highlight – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight",
-          "enum": [
-            "pymdownx.highlight"
-          ]
+          "const": "pymdownx.highlight"
         },
         {
           "type": "object",
@@ -267,18 +253,14 @@
     {
       "title": "InlineHilite – Python Markdown Extensions",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#inlinehilite",
-      "enum": [
-        "pymdownx.inlinehilite"
-      ]
+      "const": "pymdownx.inlinehilite"
     },
     {
       "oneOf": [
         {
           "title": "Keys – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#keys",
-          "enum": [
-            "pymdownx.keys"
-          ]
+          "const": "pymdownx.keys"
         },
         {
           "type": "object",
@@ -320,9 +302,7 @@
         {
           "title": "MagicLink – Python Markdown Extensions",
           "markdownDescription": "https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/",
-          "enum": [
-            "pymdownx.magiclink"
-          ]
+          "const": "pymdownx.magiclink"
         },
         {
           "type": "object",
@@ -410,9 +390,7 @@
         {
           "title": "Mark – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#caret-mark-tilde",
-          "enum": [
-            "pymdownx.mark"
-          ]
+          "const": "pymdownx.mark"
         },
         {
           "type": "object",
@@ -440,9 +418,7 @@
         {
           "title": "SmartSymbols – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#smartsymbols",
-          "enum": [
-            "pymdownx.smartsymbols"
-          ]
+          "const": "pymdownx.smartsymbols"
         },
         {
           "type": "object",
@@ -569,9 +545,7 @@
         {
           "title": "Snippets – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets",
-          "enum": [
-            "pymdownx.snippets"
-          ]
+          "const": "pymdownx.snippets"
         }
       ]
     },
@@ -580,9 +554,7 @@
         {
           "title": "SuperFences – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#superfences",
-          "enum": [
-            "pymdownx.superfences"
-          ]
+          "const": "pymdownx.superfences"
         },
         {
           "type": "object",
@@ -663,9 +635,7 @@
         {
           "title": "Tasklist – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tasklist",
-          "enum": [
-            "pymdownx.tasklist"
-          ]
+          "const": "pymdownx.tasklist"
         },
         {
           "type": "object",
@@ -697,9 +667,7 @@
         {
           "title": "Tilde – Python Markdown Extensions",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#caret-mark-tilde",
-          "enum": [
-            "pymdownx.tilde"
-          ]
+          "const": "pymdownx.tilde"
         },
         {
           "type": "object",

--- a/docs/schema/extra.json
+++ b/docs/schema/extra.json
@@ -18,9 +18,7 @@
           "if": {
             "properties": {
               "provider": {
-                "enum": [
-                  "google"
-                ]
+                "const": "google"
               }
             }
           },
@@ -29,9 +27,7 @@
               "provider": {
                 "title": "Google Analytics",
                 "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics",
-                "enum": [
-                  "google"
-                ]
+                "const": "google"
               },
               "property": {
                 "anyOf": [
@@ -189,21 +185,15 @@
             "oneOf": [
               {
                 "title": "Button to accept cookies",
-                "enum": [
-                  "accept"
-                ]
+                "const": "accept"
               },
               {
                 "title": "Button to reject cookies",
-                "enum": [
-                  "reject"
-                ]
+                "const": "reject"
               },
               {
                 "title": "Button to manage settings",
-                "enum": [
-                  "manage"
-                ]
+                "const": "manage"
               }
             ]
           },
@@ -310,9 +300,7 @@
         "provider": {
           "title": "Versioning provider",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#versioning",
-          "enum": [
-            "mike"
-          ]
+          "const": "mike"
         },
         "default": {
           "title": "Default version",

--- a/docs/schema/plugins/blog.json
+++ b/docs/schema/plugins/blog.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/blog/",
-      "enum": [
-        "blog"
-      ]
+      "const": "blog"
     },
     {
       "type": "object",
@@ -114,15 +112,11 @@
               "oneOf": [
                 {
                   "title": "Post excerpts are optional",
-                  "enum": [
-                    "optional"
-                  ]
+                  "const": "optional"
                 },
                 {
                   "title": "Post excerpts are required, thus the build will fail",
-                  "enum": [
-                    "required"
-                  ]
+                  "const": "required"
                 }
               ],
               "default": "optional"

--- a/docs/schema/plugins/external/gen-files.json
+++ b/docs/schema/plugins/external/gen-files.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/oprypin/mkdocs-gen-files",
-      "enum": [
-        "git-authors"
-      ]
+      "const": "git-authors"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/git-authors.json
+++ b/docs/schema/plugins/external/git-authors.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://timvink.github.io/mkdocs-git-authors-plugin/",
-      "enum": [
-        "git-authors"
-      ]
+      "const": "git-authors"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/git-committers.json
+++ b/docs/schema/plugins/external/git-committers.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/ojacques/mkdocs-git-committers-plugin-2",
-      "enum": [
-        "git-committers"
-      ]
+      "const": "git-committers"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/git-revision-date.json
+++ b/docs/schema/plugins/external/git-revision-date.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/zhaoterryy/mkdocs-git-revision-date-plugin",
-      "enum": [
-        "git-revision-date"
-      ]
+      "const": "git-revision-date"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/literate-nav.json
+++ b/docs/schema/plugins/external/literate-nav.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/oprypin/mkdocs-literate-nav",
-      "enum": [
-        "literate-nav"
-      ]
+      "const": "literate-nav"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/macros.json
+++ b/docs/schema/plugins/external/macros.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/fralau/mkdocs_macros_plugin",
-      "enum": [
-        "macros"
-      ]
+      "const": "macros"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/external/section-index.json
+++ b/docs/schema/plugins/external/section-index.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://github.com/oprypin/mkdocs-section-index",
-      "enum": [
-        "section-index"
-      ]
+      "const": "section-index"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/info.json
+++ b/docs/schema/plugins/info.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/info/",
-      "enum": [
-        "info"
-      ]
+      "const": "info"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/meta.json
+++ b/docs/schema/plugins/meta.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/meta/",
-      "enum": [
-        "meta"
-      ]
+      "const": "meta"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/offline.json
+++ b/docs/schema/plugins/offline.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/offline/",
-      "enum": [
-        "offline"
-      ]
+      "const": "offline"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/optimize.json
+++ b/docs/schema/plugins/optimize.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/optimize/",
-      "enum": [
-        "optimize"
-      ]
+      "const": "optimize"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/privacy.json
+++ b/docs/schema/plugins/privacy.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/privacy/",
-      "enum": [
-        "privacy"
-      ]
+      "const": "privacy"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/projects.json
+++ b/docs/schema/plugins/projects.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/projects/",
-      "enum": [
-        "projects"
-      ]
+      "const": "projects"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/search.json
+++ b/docs/schema/plugins/search.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/search/",
-      "enum": [
-        "search"
-      ]
+      "const": "search"
     },
     {
       "type": "object",
@@ -73,117 +71,79 @@
       "oneOf": [
         {
           "title": "Site search language: Arabic",
-          "enum": [
-            "ar"
-          ]
+          "const": "ar"
         },
         {
           "title": "Site search language: Danish",
-          "enum": [
-            "da"
-          ]
+          "const": "da"
         },
         {
           "title": "Site search language: German",
-          "enum": [
-            "de"
-          ]
+          "const": "de"
         },
         {
           "title": "Site search language: Dutch",
-          "enum": [
-            "du"
-          ]
+          "const": "du"
         },
         {
           "title": "Site search language: English",
-          "enum": [
-            "en"
-          ]
+          "const": "en"
         },
         {
           "title": "Site search language: Spanish",
-          "enum": [
-            "es"
-          ]
+          "const": "es"
         },
         {
           "title": "Site search language: Finnish",
-          "enum": [
-            "fi"
-          ]
+          "const": "fi"
         },
         {
           "title": "Site search language: French",
-          "enum": [
-            "fr"
-          ]
+          "const": "fr"
         },
         {
           "title": "Site search language: Hungarian",
-          "enum": [
-            "hu"
-          ]
+          "const": "hu"
         },
         {
           "title": "Site search language: Italian",
-          "enum": [
-            "it"
-          ]
+          "const": "it"
         },
         {
           "title": "Site search language: Japanese",
-          "enum": [
-            "ja"
-          ]
+          "const": "ja"
         },
         {
           "title": "Site search language: Norwegian",
-          "enum": [
-            "no"
-          ]
+          "const": "no"
         },
         {
           "title": "Site search language: Portuguese",
-          "enum": [
-            "pt"
-          ]
+          "const": "pt"
         },
         {
           "title": "Site search language: Romanian",
-          "enum": [
-            "ro"
-          ]
+          "const": "ro"
         },
         {
           "title": "Site search language: Russian",
-          "enum": [
-            "ru"
-          ]
+          "const": "ru"
         },
         {
           "title": "Site search language: Swedish",
-          "enum": [
-            "sv"
-          ]
+          "const": "sv"
         },
         {
           "title": "Site search language: Thai",
-          "enum": [
-            "th"
-          ]
+          "const": "th"
         },
         {
           "title": "Site search language: Turkish",
-          "enum": [
-            "tr"
-          ]
+          "const": "tr"
         },
         {
           "title": "Site search language: Vietnamese",
-          "enum": [
-            "vi"
-          ]
+          "const": "vi"
         }
       ]
     }

--- a/docs/schema/plugins/social.json
+++ b/docs/schema/plugins/social.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/social/",
-      "enum": [
-        "social"
-      ]
+      "const": "social"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/tags.json
+++ b/docs/schema/plugins/tags.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/tags/",
-      "enum": [
-        "tags"
-      ]
+      "const": "tags"
     },
     {
       "type": "object",

--- a/docs/schema/plugins/typeset.json
+++ b/docs/schema/plugins/typeset.json
@@ -4,9 +4,7 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/typeset/",
-      "enum": [
-        "typeset"
-      ]
+      "const": "typeset"
     },
     {
       "type": "object",

--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -9,9 +9,7 @@
       "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#name",
       "oneOf": [
         {
-          "enum": [
-            "material"
-          ]
+          "const": "material"
         },
         {
           "type": "null"
@@ -48,375 +46,251 @@
         {
           "title": "Site language: Custom",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#custom-translations",
-          "enum": [
-            "custom"
-          ]
+          "const": "custom"
         },
         {
           "title": "Site language: Afrikaans",
-          "enum": [
-            "af"
-          ]
+          "const": "af"
         },
         {
           "title": "Site language: Arabic",
-          "enum": [
-            "ar"
-          ]
+          "const": "ar"
         },
         {
           "title": "Site language: Bulgarian",
-          "enum": [
-            "bg"
-          ]
+          "const": "bg"
         },
         {
           "title": "Site language: Bengali (Bangla)",
-          "enum": [
-            "bn"
-          ]
+          "const": "bn"
         },
         {
           "title": "Site language: Catalan",
-          "enum": [
-            "ca"
-          ]
+          "const": "ca"
         },
         {
           "title": "Site language: Czech",
-          "enum": [
-            "cs"
-          ]
+          "const": "cs"
         },
         {
           "title": "Site language: Danish",
-          "enum": [
-            "da"
-          ]
+          "const": "da"
         },
         {
           "title": "Site language: German",
-          "enum": [
-            "de"
-          ]
+          "const": "de"
         },
         {
           "title": "Site language: Greek",
-          "enum": [
-            "el"
-          ]
+          "const": "el"
         },
         {
           "title": "Site language: English",
-          "enum": [
-            "en"
-          ]
+          "const": "en"
         },
         {
           "title": "Site language: Esperanto",
-          "enum": [
-            "eo"
-          ]
+          "const": "eo"
         },
         {
           "title": "Site language: Spanish",
-          "enum": [
-            "es"
-          ]
+          "const": "es"
         },
         {
           "title": "Site language: Estonian",
-          "enum": [
-            "et"
-          ]
+          "const": "et"
         },
         {
           "title": "Site language: Persian (Farsi)",
-          "enum": [
-            "fa"
-          ]
+          "const": "fa"
         },
         {
           "title": "Site language: Finnish",
-          "enum": [
-            "fi"
-          ]
+          "const": "fi"
         },
         {
           "title": "Site language: French",
-          "enum": [
-            "fr"
-          ]
+          "const": "fr"
         },
         {
           "title": "Site language: Galician",
-          "enum": [
-            "gl"
-          ]
+          "const": "gl"
         },
         {
           "title": "Site language: Hebrew",
-          "enum": [
-            "he"
-          ]
+          "const": "he"
         },
         {
           "title": "Site language: Hindi",
-          "enum": [
-            "hi"
-          ]
+          "const": "hi"
         },
         {
           "title": "Site language: Croatian",
-          "enum": [
-            "hr"
-          ]
+          "const": "hr"
         },
         {
           "title": "Site language: Hungarian",
-          "enum": [
-            "hu"
-          ]
+          "const": "hu"
         },
         {
           "title": "Site language: Armenian",
-          "enum": [
-            "hy"
-          ]
+          "const": "hy"
         },
         {
           "title": "Site language: Indonesian",
-          "enum": [
-            "id"
-          ]
+          "const": "id"
         },
         {
           "title": "Site language: Icelandic",
-          "enum": [
-            "is"
-          ]
+          "const": "is"
         },
         {
           "title": "Site language: Italian",
-          "enum": [
-            "it"
-          ]
+          "const": "it"
         },
         {
           "title": "Site language: Japanese",
-          "enum": [
-            "ja"
-          ]
+          "const": "ja"
         },
         {
           "title": "Site language: Georgian",
-          "enum": [
-            "ka"
-          ]
+          "const": "ka"
         },
         {
           "title": "Site language: Kannada",
-          "enum": [
-            "kn"
-          ]
+          "const": "kn"
         },
         {
           "title": "Site language: Korean",
-          "enum": [
-            "ko"
-          ]
+          "const": "ko"
         },
         {
           "title": "Site language: Lithuanian",
-          "enum": [
-            "lt"
-          ]
+          "const": "lt"
         },
         {
           "title": "Site language: Latvian",
-          "enum": [
-            "lv"
-          ]
+          "const": "lv"
         },
         {
           "title": "Site language: Macedonian",
-          "enum": [
-            "mk"
-          ]
+          "const": "mk"
         },
         {
           "title": "Site language: Mongolian",
-          "enum": [
-            "mn"
-          ]
+          "const": "mn"
         },
         {
           "title": "Site language: Bahasa Malaysia",
-          "enum": [
-            "ms"
-          ]
+          "const": "ms"
         },
         {
           "title": "Site language: Burmese",
-          "enum": [
-            "my"
-          ]
+          "const": "my"
         },
         {
           "title": "Site language: Dutch",
-          "enum": [
-            "nl"
-          ]
+          "const": "nl"
         },
         {
           "title": "Site language: Norwegian (Bokmål)",
-          "enum": [
-            "nb"
-          ]
+          "const": "nb"
         },
         {
           "title": "Site language: Norwegian (Nynorsk)",
-          "enum": [
-            "nn"
-          ]
+          "const": "nn"
         },
         {
           "title": "Site language: Polish",
-          "enum": [
-            "pl"
-          ]
+          "const": "pl"
         },
         {
           "title": "Site language: Portuguese",
-          "enum": [
-            "pt"
-          ]
+          "const": "pt"
         },
         {
           "title": "Site language: Portuguese (Brasilian)",
-          "enum": [
-            "pt-BR"
-          ]
+          "const": "pt-BR"
         },
         {
           "title": "Site language: Romanian",
-          "enum": [
-            "ro"
-          ]
+          "const": "ro"
         },
         {
           "title": "Site language: Russian",
-          "enum": [
-            "ru"
-          ]
+          "const": "ru"
         },
         {
           "title": "Site language: Sanskrit",
-          "enum": [
-            "sa"
-          ]
+          "const": "sa"
         },
         {
           "title": "Site language: Serbo-Croatian",
-          "enum": [
-            "sh"
-          ]
+          "const": "sh"
         },
         {
           "title": "Site language: Sinhalese",
-          "enum": [
-            "si"
-          ]
+          "const": "si"
         },
         {
           "title": "Site language: Slovak",
-          "enum": [
-            "sk"
-          ]
+          "const": "sk"
         },
         {
           "title": "Site language: Slovenian",
-          "enum": [
-            "sl"
-          ]
+          "const": "sl"
         },
         {
           "title": "Site language: Serbian",
-          "enum": [
-            "sr"
-          ]
+          "const": "sr"
         },
         {
           "title": "Site language: Swedish",
-          "enum": [
-            "sv"
-          ]
+          "const": "sv"
         },
         {
           "title": "Site language: Telugu",
-          "enum": [
-            "te"
-          ]
+          "const": "te"
         },
         {
           "title": "Site language: Thai",
-          "enum": [
-            "th"
-          ]
+          "const": "th"
         },
         {
           "title": "Site language: Tagalog",
-          "enum": [
-            "tl"
-          ]
+          "const": "tl"
         },
         {
           "title": "Site language: Turkish",
-          "enum": [
-            "tr"
-          ]
+          "const": "tr"
         },
         {
           "title": "Site language: Ukrainian",
-          "enum": [
-            "uk"
-          ]
+          "const": "uk"
         },
         {
           "title": "Site language: Urdu",
-          "enum": [
-            "ur"
-          ]
+          "const": "ur"
         },
         {
           "title": "Site language: Uzbek",
-          "enum": [
-            "uz"
-          ]
+          "const": "uz"
         },
         {
           "title": "Site language: Vietnamese",
-          "enum": [
-            "vi"
-          ]
+          "const": "vi"
         },
         {
           "title": "Site language: Chinese (Simplified)",
-          "enum": [
-            "zh"
-          ]
+          "const": "zh"
         },
         {
           "title": "Site language: Chinese (Traditional)",
-          "enum": [
-            "zh-Hant"
-          ]
+          "const": "zh-Hant"
         },
         {
           "title": "Site language: Chinese (Taiwanese)",
-          "enum": [
-            "zh-TW"
-          ]
+          "const": "zh-TW"
         }
       ],
       "default": "en"
@@ -597,191 +471,137 @@
           {
             "title": "Mark as read",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#mark-as-read",
-            "enum": [
-              "announce.dismiss"
-            ]
+            "const": "announce.dismiss"
           },
           {
             "title": "Edit this page",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions",
-            "enum": [
-              "content.action.edit"
-            ]
+            "const": "content.action.edit"
           },
           {
             "title": "View source of this page",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions",
-            "enum": [
-              "content.action.view"
-            ]
+            "const": "content.action.view"
           },
           {
             "title": "Code annotations",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-annotations",
-            "enum": [
-              "content.code.annotate"
-            ]
+            "const": "content.code.annotate"
           },
           {
             "title": "Code copy button",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button",
-            "enum": [
-              "content.code.copy"
-            ]
+            "const": "content.code.copy"
           },
           {
             "title": "Code selection button",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-selection-button",
-            "enum": [
-              "content.code.select"
-            ]
+            "const": "content.code.select"
           },
           {
             "title": "Linked content tabs",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#linked-content-tabs",
-            "enum": [
-              "content.tabs.link"
-            ]
+            "const": "content.tabs.link"
           },
           {
             "title": "Improved tooltips",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/tooltips/#improved-tooltips",
-            "enum": [
-              "content.tooltips"
-            ]
+            "const": "content.tooltips"
           },
           {
             "title": "Header hides automatically when scrolling",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#automatic-hiding",
-            "enum": [
-              "header.autohide"
-            ]
+            "const": "header.autohide"
           },
           {
             "title": "Navigation expansion",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-expansion",
-            "enum": [
-              "navigation.expand"
-            ]
+            "const": "navigation.expand"
           },
           {
             "title": "Navigation footer",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-footer",
-            "enum": [
-              "navigation.footer"
-            ]
+            "const": "navigation.footer"
           },
           {
             "title": "Section index pages",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages",
-            "enum": [
-              "navigation.indexes"
-            ]
+            "const": "navigation.indexes"
           },
           {
             "title": "Instant loading",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading",
-            "enum": [
-              "navigation.instant"
-            ]
+            "const": "navigation.instant"
           },
           {
             "title": "Instant prefetching",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-prefetching",
-            "enum": [
-              "navigation.instant.prefetch"
-            ]
+            "const": "navigation.instant.prefetch"
           },
           {
             "title": "Progress indicator",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#progress-indicator",
-            "enum": [
-              "navigation.instant.progress"
-            ]
+            "const": "navigation.instant.progress"
           },
           {
             "title": "Navigation path (Breadcrumbs)",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-path",
-            "enum": [
-              "navigation.path"
-            ]
+            "const": "navigation.path"
           },
           {
             "title": "Navigation pruning",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-pruning",
-            "enum": [
-              "navigation.prune"
-            ]
+            "const": "navigation.prune"
           },
           {
             "title": "Navigation sections",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-sections",
-            "enum": [
-              "navigation.sections"
-            ]
+            "const": "navigation.sections"
           },
           {
             "title": "Navigation tabs",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-tabs",
-            "enum": [
-              "navigation.tabs"
-            ]
+            "const": "navigation.tabs"
           },
           {
             "title": "Sticky navigation tabs",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#sticky-navigation-tabs",
-            "enum": [
-              "navigation.tabs.sticky"
-            ]
+            "const": "navigation.tabs.sticky"
           },
           {
             "title": "Back-to-top button",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#back-to-top-button",
-            "enum": [
-              "navigation.top"
-            ]
+            "const": "navigation.top"
           },
           {
             "title": "Anchor tracking",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-tracking",
-            "enum": [
-              "navigation.tracking"
-            ]
+            "const": "navigation.tracking"
           },
           {
             "title": "Search higlighting",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-highlighting",
-            "enum": [
-              "search.highlight"
-            ]
+            "const": "search.highlight"
           },
           {
             "title": "Search sharing",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-sharing",
-            "enum": [
-              "search.share"
-            ]
+            "const": "search.share"
           },
           {
             "title": "Search suggestions",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-suggestions",
-            "enum": [
-              "search.suggest"
-            ]
+            "const": "search.suggest"
           },
           {
             "title": "Integrated table of contents",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-following",
-            "enum": [
-              "toc.follow"
-            ]
+            "const": "toc.follow"
           },
           {
             "title": "Integrated table of contents",
             "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration",
-            "enum": [
-              "toc.integrate"
-            ]
+            "const": "toc.integrate"
           }
         ]
       },

--- a/tools/build/index.ts
+++ b/tools/build/index.ts
@@ -337,9 +337,7 @@ const schema$ = merge(
           "markdownDescription": `https://fonts.google.com/specimen/${
             font.replace(/\s+/g, "+")
           }`,
-          "enum": [
-            font
-          ],
+          "const": font,
         }))
       })),
       switchMap(data => write(


### PR DESCRIPTION
I've refactored the schema files a bit to use the more concise [`const` keyword](https://json-schema.org/understanding-json-schema/reference/const) instead of `enum` with a single array item for constant value types. All schemas are based on JSON Schema Draft 7, and `const` was introduced in Draft 6, so it's a supported keyword.