### PR TITLE
Add mkdocs.yml JSON schema support for `sane_lists` and Neoteroi markdown extensions

### DIFF
--- a/docs/schema/extensions.json
+++ b/docs/schema/extensions.json
@@ -10,6 +10,9 @@
       },
       {
         "$ref": "extensions/pymdownx.json"
+      },
+      {
+        "$ref": "extensions/external/neoteroi.json"
       }
     ]
   },

--- a/docs/schema/extensions/external/neoteroi.json
+++ b/docs/schema/extensions/external/neoteroi.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "Neoteroi markdown extensions",
+  "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins",
+  "oneOf": [
+    {
+      "title": "Cards – Neoteroi Markdown",
+      "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/cards/",
+      "const": "neoteroi.cards"
+    },
+    {
+      "title": "Timeline – Neoteroi Markdown",
+      "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/timeline/",
+      "const": "neoteroi.timeline"
+    },
+    {
+      "title": "Gantt – Neoteroi Markdown",
+      "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/gantt/",
+      "const": "neoteroi.projects"
+    },
+    {
+      "title": "Spantable – Neoteroi Markdown",
+      "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/spantable/",
+      "const": "neoteroi.spantable"
+    }
+  ]
+}

--- a/docs/schema/extensions/markdown.json
+++ b/docs/schema/extensions/markdown.json
@@ -60,6 +60,14 @@
       ]
     },
     {
+      "title": "Sane Lists – Python Markdown",
+      "markdownDescription": "https://python-markdown.github.io/extensions/sane_lists/",
+      "enum": [
+        "markdown.extensions.sane_lists",
+        "sane_lists"
+      ]
+    },
+    {
       "title": "Tables – Python Markdown",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#tables",
       "enum": [


### PR DESCRIPTION
As suggested in #6378, this PR adds support for several markdown extensions to the JSON schema for `mkdocs.yml`:

- [`sane_lists`](https://python-markdown.github.io/extensions/sane_lists/) from `python-markdown`
- The Cards, Timeline, Gantt, and Spantable markdown extensions from [`neoteroi-mkdocs`](https://www.neoteroi.dev/mkdocs-plugins/) (I've added a separate `external/` folder under the folder containing the schemas for markdown extensions - does that make sense?)