### PR TITLE
Dockerfile: Write to /etc/gitconfig for all users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,11 +83,11 @@ RUN \
   find ${PACKAGES} \
     -type f \
     -path "*/__pycache__/*" \
-    -exec rm -f {} \;
-
-# Trust directory, required for git >= 2.35.2
-RUN git config --system --add safe.directory /docs &&\
-    git config --system --add safe.directory /site
+    -exec rm -f {} \; \
+&& \
+  git config --system --add safe.directory /docs \
+&& \
+  git config --system --add safe.directory /site
 
 # Set working directory
 WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ RUN \
     -exec rm -f {} \;
 
 # Trust directory, required for git >= 2.35.2
-RUN git config --global --add safe.directory /docs &&\
-    git config --global --add safe.directory /site
+RUN git config --system --add safe.directory /docs &&\
+    git config --system --add safe.directory /site
 
 # Set working directory
 WORKDIR /docs


### PR DESCRIPTION
Change how `git config` is handled in the Docker image.

As it's currently written, `git config --global` writes to `/root/.gitconfig`. This file is not visible if a container is created specifying another user (e.g. `docker run -u 1000:1000`), which is a common practice when using Docker on user-owned files instead of root-owned files.

By replacing `--global` with `--system`, Git writes to `/etc/gitconfig`, whose content applies to all users on this system (container image).

I'm also curious why these `git config` commands are given on a separate `RUN` directive - seems unnecessary to create another layer just for a single `.gitconfig` / `gitconfig` file.