### PR TITLE
Details / Collapsible blocks - Rotate Arrows

### DIFF
--- a/src/templates/assets/stylesheets/main/extensions/pymdownx/_details.scss
+++ b/src/templates/assets/stylesheets/main/extensions/pymdownx/_details.scss
@@ -44,7 +44,7 @@
 
     // Details title icon - rotate icon on transition to open state
     &[open] > summary::after {
-      transform: rotate(90deg);
+      transform: rotate(270deg);
     }
 
     // Adjust spacing for details in closed state
@@ -97,17 +97,12 @@
       content: "";
       background-color: currentcolor;
       transition: transform 250ms;
-      transform: rotate(0deg);
+      transform: rotate(90deg);
       inset-inline-end: px2rem(8px);
       mask-image: var(--md-details-icon);
       mask-position: center;
       mask-repeat: no-repeat;
       mask-size: contain;
-
-      // Adjust for right-to-left languages
-      [dir="rtl"] & {
-        transform: rotate(180deg);
-      }
     }
 
     // Hide native details marker - modern


### PR DESCRIPTION
Wouldn't it be more intuitive having arrows point the way that detail's section will expand/hide?
The current solution is confusing for some, they don't actually know that section is expandable.


**Proposed change**

![2023-12-11_02-22-50-firefox](https://github.com/squidfunk/mkdocs-material/assets/10072920/abdb813d-4384-4039-8097-4d40201c8bf5)

**Current form**

![2023-12-11_02-27-36-firefox](https://github.com/squidfunk/mkdocs-material/assets/10072920/2b008861-3201-484e-88bd-c77713e18740)
