### PR TITLE
Fixed privacy plugin to exclude Giscus client script

### DIFF
--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -209,6 +209,10 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
     # Check if the given URL is excluded
     def _is_excluded(self, url: URL, initiator: File | None = None):
+        # Skip Giscus client script - see https://t.ly/QTJ3s
+        if url.geturl() == "https://giscus.app/client.js":
+            return True
+
         if not self._is_external(url):
             return True
 


### PR DESCRIPTION
The [Giscus client script cannot be self-hosted](https://github.com/giscus/giscus/issues/900#issuecomment-1427794340), as the Giscus widget fails to work then. Since [Material for MkDocs officially supports Giscus](https://squidfunk.github.io/mkdocs-material/setup/adding-a-comment-system/) and the privacy plugin has become available to everybody thanks to meeting the "Goat's Horn" funding goal &ndash; although without the [`assets_exclude` setting](https://squidfunk.github.io/mkdocs-material/plugins/privacy/#config.assets_exclude), which would allow excluding the Giscus client script URL in userland &ndash; I think it's fair to support usage of the privacy plugin along with Giscus for everybody. Also Insiders users, who use the pivacy plugin, would benefit as Giscus would simply work out of the box also for them.

To make the privacy plugin work with Giscus, I've added a special case that excludes the Giscus client script from getting self-hosted.

WDYT, @squidfunk?