### PR TITLE
Documentation formatting and grammar improvement

### DIFF
--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -667,8 +667,8 @@ The following configuration options are supported:
 
 <!-- md:option pymdownx.tabbed.combine_header_slug -->
 
-:   <!-- md:default `false` --> This option enables the content tabs
-    [combine_header_slug style] flag, which prepends the id of the header to
+:   <!-- md:default `false` --> This option enables the content tabs'
+    [`combine_header_slug` style] flag, which prepends the id of the header to
     the id of the tab:
 
     ``` yaml


### PR DESCRIPTION
I've added backticks around `combine_header_slugs` for better formatting fixed a grammar error in the docs.