### PR TITLE
Update docs about general availability of automatic light/dark mode

### DIFF
--- a/docs/setup/changing-the-colors.md
+++ b/docs/setup/changing-the-colors.md
@@ -272,9 +272,9 @@ default color palette.
 <!-- md:example color-palette-system-preference -->
 
 Newer operating systems allow to automatically switch between light and dark
-appearance during day and night times. [Insiders] adds support for automatic
-light / dark mode, delegating color palette selection to the user's operating
-system. Add the following lines to `mkdocs.yml`:
+appearance during day and night times. Material for MkDocs adds support for
+automatic light / dark mode, delegating color palette selection to the user's
+operating system. Add the following lines to `mkdocs.yml`:
 
 ``` yaml
 theme:


### PR DESCRIPTION
Just a minor docs update on automatic light/dark mode being generally available now and not only via Insiders. I've actually only replaced `[Insiders]` by `Material for MkDocs`, the rest of the diff is related to changes due to the line length limit.