### PR TITLE
Improved Group plugin initialization for mike

### DIFF
--- a/material/plugins/group/plugin.py
+++ b/material/plugins/group/plugin.py
@@ -38,6 +38,14 @@ from .config import GroupConfig
 class GroupPlugin(BasePlugin[GroupConfig]):
     supports_multiple_instances = True
 
+    # Initialize plugin
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Initialize object attributes
+        self.is_serve = False
+        self.is_dirty = False
+
     # Determine whether we're serving the site
     def on_startup(self, *, command, dirty):
         self.is_serve = command == "serve"

--- a/src/plugins/group/plugin.py
+++ b/src/plugins/group/plugin.py
@@ -38,6 +38,14 @@ from .config import GroupConfig
 class GroupPlugin(BasePlugin[GroupConfig]):
     supports_multiple_instances = True
 
+    # Initialize plugin
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Initialize object attributes
+        self.is_serve = False
+        self.is_dirty = False
+
     # Determine whether we're serving the site
     def on_startup(self, *, command, dirty):
         self.is_serve = command == "serve"


### PR DESCRIPTION
Should fix the crash when running `mike` with the `group` plugin.
Related discussion: https://github.com/squidfunk/mkdocs-material/discussions/6520

I didn't change anything unrelated to the crash, I shall wait for https://github.com/squidfunk/mkdocs-material/pull/6473 to have some sort of resolution to propose bigger styling changes :v: