### PR TITLE
Removed unnecessary quotes from type annotation

### DIFF
--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -247,7 +247,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
     # Parse and extract all external assets from a media file using a preset
     # regular expression, and return all URLs found.
-    def _parse_media(self, initiator: File) -> "list[URL]":
+    def _parse_media(self, initiator: File) -> list[URL]:
         _, extension = posixpath.splitext(initiator.dest_uri)
         if extension not in self.assets_expr_map:
             return []


### PR DESCRIPTION
I've remove unnecessary quotes from a type annotation.

@squidfunk When [you were questioning Python 3.8 compatibility](https://github.com/squidfunk/mkdocs-material/pull/6533#discussion_r1429825884) yesterday, [I thought this unquoted type isn't compatible](https://github.com/squidfunk/mkdocs-material/pull/6533#discussion_r1429832265), but I missed the `from __future__ import annotations` import, which does make it compatible. See a [simple mypy playground example](https://mypy-play.net/?mypy=1.7.1&python=3.8&flags=strict&gist=66405fddd5efe46822e4dfa2a2355863). When you remove that import, mypy will fail. I've also tested this snippet at runtime under Python 3.8, it works with the import but fails without the import.