### PR TITLE
Replaced mutable argument default by `None`

### DIFF
--- a/src/plugins/search/plugin.py
+++ b/src/plugins/search/plugin.py
@@ -312,9 +312,9 @@ class Element:
     """
 
     # Initialize HTML element
-    def __init__(self, tag, attrs = {}):
+    def __init__(self, tag, attrs = None):
         self.tag   = tag
-        self.attrs = attrs
+        self.attrs = attrs or {}
 
     # String representation
     def __repr__(self):


### PR DESCRIPTION
I've fixed the use of a mutable argument default (here, a `dict` literal), which _can_ introduce bugs that are a bit hard to debug. Here, it doesn't seem to be a problem because `self.attrs` isn't mutated, but it's generally discouraged to use mutable argument defaults. See https://docs.astral.sh/ruff/rules/mutable-argument-default/#mutable-argument-default-b006 for more details.