### PR TITLE
Add testing environments for Python

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,0 +1,21 @@
+[envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "pytest-mock",
+  "pytest-randomly",
+]
+[envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[envs.test.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,19 @@ include = ["/material"]
 [tool.hatch.build.targets.sdist]
 include = ["/material", "/package.json", "/requirements.txt"]
 exclude = ["/material/overrides"]
+
+[tool.coverage.run]
+source_pkgs = ["material", "tests"]
+branch = true
+parallel = true
+
+[tool.coverage.paths]
+material = ["material", "*/material/material"]
+tests = ["tests", "*/material/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
As requested elsewhere from you, here is the initial config to set up a test matrix. You can enter a shell into the default environment (which will use the highest Python that can be found on PATH) by running `hatch shell` and test scripts can be executed like `hatch run cov`. The matrix can run tests in each like `hatch run test:cov` or individually like `hatch run test.py3.12:cov`.

- I am aware that there is no such tests directory yet, this is just to show how it would happen
- I haven't taken a look at CI so let me know if/when you would like me to add stuff there
- This uses pytest (rather than unittest as I saw in the other commit to insiders) as that is basically the standard for testing in Python now