### PR TITLE
Update creating-your-site.md

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -16,7 +16,7 @@ Alternatively, if you're running Material for MkDocs from within Docker, use:
     docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material new .
     ```
 
-=== "Windows Commandline"
+=== "Windows (cmd)"
 
     ```
     docker run --rm -it -v "%cd%":/docs squidfunk/mkdocs-material new .

--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -16,7 +16,7 @@ Alternatively, if you're running Material for MkDocs from within Docker, use:
     docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material new .
     ```
 
-=== "Windows"
+=== "Windows Commandline"
 
     ```
     docker run --rm -it -v "%cd%":/docs squidfunk/mkdocs-material new .


### PR DESCRIPTION
I just wanted to clarify some confusion I had while setting up my documentation site. 

As I am on Windows I tried the Windows option first only to find out later that this command was specific to the command line and not the default terminal (Powershell) in Windows 11.

This should make it clear that this command is aimed only at Windows CommandLine users and not generally Windows users.

I was unsure if I should open a PR for this, as it is such a small change. If it is no welcome just close it - no need for discussion. 