### PR TITLE
Fix typo in SmartSymbols section

### DIFF
--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -532,7 +532,7 @@ See reference for usage:
 <!-- md:extension [pymdownx.smartsymbols][SmartSymbols] -->
 
 The [SmartSymbols] extension converts some sequences of characters into their
-corresponding symbols, e.h. copyright symbols or fractions. Enable it via
+corresponding symbols, e.g. copyright symbols or fractions. Enable it via
 `mkdocs.yml`:
 
 ``` yaml


### PR DESCRIPTION
The text following "e.h." are listing examples of SmartSymbols, so "e.h." could be a typo for "e.g." in the description.