### PR TITLE
Explicitly mention setting defaults is for insiders only (meta plugin)

### DIFF
--- a/docs/setup/setting-up-a-blog.md
+++ b/docs/setup/setting-up-a-blog.md
@@ -535,6 +535,11 @@ This will disable automatic reading time computation.
 
 #### Setting defaults
 
+<!-- md:sponsors -->
+<!-- md:version insiders-4.21.0 -->
+<!-- md:plugin [meta] – built-in -->
+<!-- md:flag experimental -->
+
 If you have a lot of posts, it might feel redundant to define all of the above
 for each post. Luckily, the [built-in meta plugin] allows to set default front
 matter properties per folder. You can group your posts by categories, or


### PR DESCRIPTION
As the meta plugin is reserved for insiders only, this section could also mention that so people don't run into the below error.

```
$ mkdocs serve
ERROR   -  Config value 'plugins': The "meta" plugin is not installed

Aborted with 1 configuration errors!
```

I am not sure if I'm adding all the labels accurately. I got it from the meta plugin page under [configuration](https://squidfunk.github.io/mkdocs-material/plugins/meta/#configuration).  Please edit as you see fit. Thanks.