### PR TITLE
fix: Custom Elements support for getActiveElement

### DIFF
--- a/src/templates/assets/javascripts/browser/element/_/index.ts
+++ b/src/templates/assets/javascripts/browser/element/_/index.ts
@@ -114,6 +114,12 @@ export function getOptionalElement<T extends HTMLElement>(
  * @returns Element or nothing
  */
 export function getActiveElement(): HTMLElement | undefined {
+  const isHTMLElement = document.activeElement instanceof HTMLElement;
+  const hasShadowRoot = isHTMLElement && document.activeElement?.shadowRoot;
+
+  if (hasShadowRoot) {
+    return document.activeElement?.shadowRoot?.activeElement || undefined;
+  }
   return document.activeElement instanceof HTMLElement
     ? document.activeElement || undefined
     : undefined

--- a/src/templates/assets/javascripts/browser/element/_/index.ts
+++ b/src/templates/assets/javascripts/browser/element/_/index.ts
@@ -119,8 +119,8 @@ export function getActiveElement(): HTMLElement | undefined {
 
   if (hasShadowRoot) {
     return document.activeElement?.shadowRoot?.activeElement || undefined;
-  }
-  return document.activeElement instanceof HTMLElement
+  } 
+  return isHTMLElement
     ? document.activeElement || undefined
     : undefined
 }


### PR DESCRIPTION
## Before changes:

Focusing shadowRooted input vs regular input
<img width="710" alt="image" src="https://github.com/squidfunk/mkdocs-material/assets/142901247/bbba03ad-e9cf-486c-aa41-8893065003c0">

After changes:
<img width="668" alt="image" src="https://github.com/squidfunk/mkdocs-material/assets/142901247/3318f575-6049-4eeb-93a2-a455b8407720">

Unfortunately, that would not work if shadowRoot has closed mode. In this case internals of the custom element is not accessible via an external document.

The issue is described here: [Shadow DOM v1 - Self-Contained Web Components](https://web.dev/articles/shadowdom-v1#handling_focus).

Should we check recursively?

Resolves #6652