### PR TITLE
build(deps): bump pillow version 10.2 for fix security vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ git = [
   "mkdocs-git-revision-date-localized-plugin~=1.2"
 ]
 imaging = [
-  "pillow~=9.4",
+  "pillow~=10.2",
   "cairosvg~=2.6"
 ]
 


### PR DESCRIPTION
Hello @squidfunk  I notice that you were using pillow version 9.4 and it has security problems and recently dependabot also gives me warning about security problems listed in here. 

https://github.com/advisories/GHSA-j7hp-h8jx-5ppr
https://github.com/advisories/GHSA-8vj2-vxx3-667w
https://github.com/advisories/GHSA-hhrh-69hc-fgg7

libwebp: OOB write in BuildHuffmanTable
Arbitrary Code Execution in Pillow
Pillow Denial of Service vulnerability


I also notice that minimum python 3.8 and using pillow 10.2 also going keep that version so it should be fine as well. I also build docs and in my tests it was also works fine as well. 

Thank you. 