### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -35,15 +35,17 @@ contents:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
+            with:
+              fetch-depth: 0
           - name: Configure Git Credentials
             run: |
               git config user.name github-actions[bot]
               git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          - uses: actions/setup-python@v4
+          - uses: actions/setup-python@v5
             with:
               python-version: 3.x
           - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV # (3)!
-          - uses: actions/cache@v3
+          - uses: actions/cache@v4
             with:
               key: mkdocs-material-${{ env.cache_id }}
               path: .cache

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -35,8 +35,6 @@ contents:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
-            with:
-              fetch-depth: 0
           - name: Configure Git Credentials
             run: |
               git config user.name github-actions[bot]
@@ -100,11 +98,11 @@ contents:
             run: |
               git config user.name github-actions[bot]
               git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          - uses: actions/setup-python@v4
+          - uses: actions/setup-python@v5
             with:
               python-version: 3.x
           - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-          - uses: actions/cache@v3
+          - uses: actions/cache@v4
             with:
               key: mkdocs-material-${{ env.cache_id }}
               path: .cache


### PR DESCRIPTION
Update action versions for 'setup-python' and 'cache'.

Set 'fetch-depth: 0' for 'checkout' action to obtain correct document dates when using 'mkdocs-git-revision-date-localized-plugin' (cf. https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/blob/v1.2.2/mkdocs_git_revision_date_localized_plugin/ci.py#L37-L48)