### PR TITLE
fix: error on empty fields in search index

### DIFF
--- a/src/templates/assets/javascripts/integrations/search/_/index.ts
+++ b/src/templates/assets/javascripts/integrations/search/_/index.ts
@@ -244,7 +244,7 @@ export class Search {
 
           /* Highlight matches in fields */
           for (const field of this.index.fields) {
-            if (typeof doc[field] === "undefined")
+            if (typeof doc[field] === "undefined" || doc[field].length === 0)
               continue
 
             /* Collect positions from matches */


### PR DESCRIPTION
If fields in the search index exist but are empty, the search can throw an error and return no results. This can happen, for example, if the markdown includes a section heading without any text, resulting in an empty "text" field in the search index. If the search term is found in the section heading "title" field, the highlighting code will then throw an error when processing the "text" field.