### PR TITLE
Github Action Plugin Support

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -49,7 +49,7 @@ contents:
               path: .cache
               restore-keys: |
                 mkdocs-material-
-          - run: pip install mkdocs-material 
+          - run: pip install mkdocs
           - run: pip install $(echo "mkdocs get-deps") # (4)!
           - run: mkdocs gh-deploy --force
     ```

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -49,7 +49,8 @@ contents:
               path: .cache
               restore-keys: |
                 mkdocs-material-
-          - run: pip install mkdocs-material # (4)!
+          - run: pip install mkdocs-material 
+          - run: pip install $(echo "mkdocs get-deps") # (4)!
           - run: mkdocs gh-deploy --force
     ```
 
@@ -67,15 +68,8 @@ contents:
 
         You can read the [manual page] to learn more about the formatting options of the `date` command.
 
-    4.  This is the place to install further [MkDocs plugins] or Markdown
-        extensions with `pip` to be used during the build:
-
-        ``` sh
-        pip install \
-          mkdocs-material \
-          mkdocs-awesome-pages-plugin \
-          ...
-        ```
+    4.  This checks mkdocs.yml again for your installed plugins and automatically installs them
+        using the mkdocks get-deps command.
 
 === "Insiders"
 


### PR DESCRIPTION
I know that it has a footnote explaining how to add this to the action however people, including me when I had not thought about this reason the action was failing, may easily miss this and not think to come back to it purely on the thought that its been there for a while and should be correct.

Overview of the small change being:

Adding 
` - run: pip install $(echo "mkdocs get-deps")` 
and updating the dropdown footnote attached to it. I see no problem but if you'd prefer to keep it the same then go ahead.
(I'd love a look over the footnote as I'm not the best at documenting the best)