### PR TITLE
docs: update integration of KaTeX instructions

### DIFF
--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -101,8 +101,8 @@ supports a subset of LaTeX syntax and can render math to HTML and SVG. To use
 === ":octicons-file-code-16: `docs/javascripts/katex.js`"
 
     ``` js
-    document$.subscribe(({ body }) => { // (1)!
-      renderMathInElement(body, {
+    document$.subscribe(() => { // (1)!
+      renderMathInElement(document.body, {
         delimiters: [
           { left: "$$",  right: "$$",  display: true },
           { left: "$",   right: "$",   display: false },


### PR DESCRIPTION
I am using `KaTeX` in my `mkdocs-material` documentation. I had a problem: `KaTeX` never loads the first time; you need to refresh the page to make it load. 

I found the solution, rather than using this (which is given by the official documentation of material-mkdocs):
```javascript
document$.subscribe(({ body }) => { 
  renderMathInElement(body, {
    delimiters: [
      { left: "$$",  right: "$$",  display: true },
      { left: "$",   right: "$",   display: false },
      { left: "\\(", right: "\\)", display: false },
      { left: "\\[", right: "\\]", display: true }
    ],
  })
})
```

I used this:

```javascript
document$.subscribe(() => { 
  renderMathInElement(document.body, {
    delimiters: [
      { left: "$$",  right: "$$",  display: true },
      { left: "$",   right: "$",   display: false },
      { left: "\\(", right: "\\)", display: false },
      { left: "\\[", right: "\\]", display: true }
    ],
  })
})
```

It solved the problem. I don't know JavaScipt, so I don't know how it solved it, but it worked.

This pull request updates the documentation's instructions on KaTeX integration and fixes this issue for possible KaTeX users.