### PR TITLE
Better file gathering and validation for the info plugin

### DIFF
--- a/material/plugins/info/info.gitignore
+++ b/material/plugins/info/info.gitignore
@@ -1,18 +1,15 @@
 # Custom .gitignore-like file
-# The difference is that those are https://docs.python.org/3/library/re.html
-# regex patterns, that will be compared against directory and file names
-# case-sensitively.
-
-# Additional info:
-# The paths will be always in POSIX format.
-# Each directory path will have a / at the end to make it easier to
-# distinguish them from files.
-
-
-# Patterns for dynamic or custom paths like Virtual Environments (venv)
-# or build site directories are created during plugin runtime.
-
-# ---
+#
+# The difference is that those are regex patterns, which will be compared
+# against directory and file names case-sensitively. The plugin uses the
+# external https://pypi.org/project/regex/ module.
+#
+# Additional remarks for pattern creation:
+# - The compared paths will be always in POSIX format.
+# - Each directory path will have a / at the end to allow to distinguish them
+#   from files.
+# - Patterns for dynamic or custom paths like Virtual Environments (venv) or
+#   build site directories are created during plugin runtime.
 
 # Byte-compiled / optimized / DLL files
 # Python cache directory

--- a/material/plugins/info/info.gitignore
+++ b/material/plugins/info/info.gitignore
@@ -1,0 +1,40 @@
+# Custom .gitignore-like file
+# The difference is that those are https://docs.python.org/3/library/re.html
+# regex patterns, that will be compared against directory and file names
+# case-sensitively.
+
+# Additional info:
+# The paths will be always in POSIX format.
+# Each directory path will have a / at the end to make it easier to
+# distinguish them from files.
+
+
+# Patterns for dynamic or custom paths like Virtual Environments (venv)
+# or build site directories are created during plugin runtime.
+
+# ---
+
+# Byte-compiled / optimized / DLL files
+# Python cache directory
+.*__pycache__/
+
+# macOS
+
+.*\.DS_Store
+
+# .dotfiles in the root directory
+
+^/\.[^/]+$
+
+# Generated files and folders
+
+^/.*\.zip
+
+# Allow .github or .devcontainer directories
+# Exclude .cache files and folders
+# Exclude known IDE directories
+
+.*\.cache/?
+^/\.vscode/
+^/\.vs/
+^/\.idea/

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -135,7 +135,13 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                 json.dumps(
                     {
                         "system": platform.platform(),
-                        "python": platform.python_version()
+                        "architecture": platform.architecture(),
+                        "python": platform.python_version(),
+                        "command": " ".join([
+                            sys.argv[0].rsplit(os.sep, 1)[-1],
+                            *sys.argv[1:]
+                        ]),
+                        "sys.path": sys.path
                     },
                     default = str,
                     indent = 2

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -30,7 +30,6 @@ from importlib.metadata import distributions, version
 from io import BytesIO
 from markdown.extensions.toc import slugify
 from mkdocs.plugins import BasePlugin, event_priority
-from mkdocs.structure.files import get_files
 from mkdocs.utils import get_theme_dir
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -115,14 +114,11 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         # Create self-contained example from project
         files: list[str] = []
         with ZipFile(archive, "a", ZIP_DEFLATED, False) as f:
-            for path in ["mkdocs.yml", "requirements.txt"]:
-                if os.path.isfile(path):
+            for abs_root, dirnames, filenames in os.walk(os.getcwd()):
+                for name in filenames:
+                    path = os.path.join(abs_root, name)
+                    path = os.path.relpath(path, os.path.curdir)
                     f.write(path, os.path.join(example, path))
-
-            # Append all files visible to MkDocs
-            for file in get_files(config):
-                path = os.path.relpath(file.abs_src_path, os.path.curdir)
-                f.write(path, os.path.join(example, path))
 
             # Add information on installed packages
             f.writestr(

--- a/src/plugins/info/info.gitignore
+++ b/src/plugins/info/info.gitignore
@@ -1,18 +1,15 @@
 # Custom .gitignore-like file
-# The difference is that those are https://docs.python.org/3/library/re.html
-# regex patterns, that will be compared against directory and file names
-# case-sensitively.
-
-# Additional info:
-# The paths will be always in POSIX format.
-# Each directory path will have a / at the end to make it easier to
-# distinguish them from files.
-
-
-# Patterns for dynamic or custom paths like Virtual Environments (venv)
-# or build site directories are created during plugin runtime.
-
-# ---
+#
+# The difference is that those are regex patterns, which will be compared
+# against directory and file names case-sensitively. The plugin uses the
+# external https://pypi.org/project/regex/ module.
+#
+# Additional remarks for pattern creation:
+# - The compared paths will be always in POSIX format.
+# - Each directory path will have a / at the end to allow to distinguish them
+#   from files.
+# - Patterns for dynamic or custom paths like Virtual Environments (venv) or
+#   build site directories are created during plugin runtime.
 
 # Byte-compiled / optimized / DLL files
 # Python cache directory

--- a/src/plugins/info/info.gitignore
+++ b/src/plugins/info/info.gitignore
@@ -1,0 +1,40 @@
+# Custom .gitignore-like file
+# The difference is that those are https://docs.python.org/3/library/re.html
+# regex patterns, that will be compared against directory and file names
+# case-sensitively.
+
+# Additional info:
+# The paths will be always in POSIX format.
+# Each directory path will have a / at the end to make it easier to
+# distinguish them from files.
+
+
+# Patterns for dynamic or custom paths like Virtual Environments (venv)
+# or build site directories are created during plugin runtime.
+
+# ---
+
+# Byte-compiled / optimized / DLL files
+# Python cache directory
+.*__pycache__/
+
+# macOS
+
+.*\.DS_Store
+
+# .dotfiles in the root directory
+
+^/\.[^/]+$
+
+# Generated files and folders
+
+^/.*\.zip
+
+# Allow .github or .devcontainer directories
+# Exclude .cache files and folders
+# Exclude known IDE directories
+
+.*\.cache/?
+^/\.vscode/
+^/\.vs/
+^/\.idea/

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -135,7 +135,13 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                 json.dumps(
                     {
                         "system": platform.platform(),
-                        "python": platform.python_version()
+                        "architecture": platform.architecture(),
+                        "python": platform.python_version(),
+                        "command": " ".join([
+                            sys.argv[0].rsplit(os.sep, 1)[-1],
+                            *sys.argv[1:]
+                        ]),
+                        "sys.path": sys.path
                     },
                     default = str,
                     indent = 2

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -30,7 +30,6 @@ from importlib.metadata import distributions, version
 from io import BytesIO
 from markdown.extensions.toc import slugify
 from mkdocs.plugins import BasePlugin, event_priority
-from mkdocs.structure.files import get_files
 from mkdocs.utils import get_theme_dir
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -115,14 +114,11 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         # Create self-contained example from project
         files: list[str] = []
         with ZipFile(archive, "a", ZIP_DEFLATED, False) as f:
-            for path in ["mkdocs.yml", "requirements.txt"]:
-                if os.path.isfile(path):
+            for abs_root, dirnames, filenames in os.walk(os.getcwd()):
+                for name in filenames:
+                    path = os.path.join(abs_root, name)
+                    path = os.path.relpath(path, os.path.curdir)
                     f.write(path, os.path.join(example, path))
-
-            # Append all files visible to MkDocs
-            for file in get_files(config):
-                path = os.path.relpath(file.abs_src_path, os.path.curdir)
-                f.write(path, os.path.join(example, path))
 
             # Add information on installed packages
             f.writestr(


### PR DESCRIPTION
Fixes #6750

Took a bit longer than I expected to make a minimal viable improvement, or perhaps I was running circles in my head for too long instead of actually coding via trial and error 😅 

I also played a bit too much with the validation for different things relative to the root directory. 
I'll simplify it, but I don't want to remove it completely. 

As for the `info.gitignore` I hope the capabilities aren't too limiting compared to real `.gitignore` logic.
It's likely I'm missing something when it comes to `fnmatch`.

Once I'm closer to finishing, I'll also squash some of the commits to keep only relevant final changes.

> It's worth commenting that Snippets or any markdown_extension use the default working directory,
so the base_path is always relative to `mkdocs build` command, not relative to the config file. By default it also
doesn't crash when a include snippet path isn't resolved, just quietly omits it.

Task list:

- [x] Handle INHERIT configs
- [x] Read every file, not only the ones that MkDocs sees
- [x] Exclude paths we don't want
- [x] Basic validation for paths to assure `mkdocs build` at the top root directory.
  ~~Currently it's not basic enough, rather convoluted.~~ 
- [x] Improve fnmatch handling
- [x] Test with the community multi-lang project https://github.com/squidfunk/mkdocs-material/discussions/2346
- [x] Test with a `projects` plugin docs, like the examples repository
- [x] Fix styling (rough 80 lines), naming consistency etc.
- [x] Squash commits into categorized ones
- [x] Switch to `regex` from `fnmatch`