### PR TITLE
docs: fix pagination_url_format default value

### DIFF
--- a/docs/plugins/blog.md
+++ b/docs/plugins/blog.md
@@ -1256,7 +1256,7 @@ plugins:
 #### <!-- md:setting config.pagination_url_format -->
 
 <!-- md:version 9.2.0 -->
-<!-- md:default `{date}/{slug}` -->
+<!-- md:default `page/{page}` -->
 
 Use this setting to change the format string that is used when generating
 paginated view URLs. You can freely combine placeholders, and join them with


### PR DESCRIPTION
The default value of `pagination_url_format` is `page/{page}` as declared [here](https://github.com/squidfunk/mkdocs-material/blob/c8a2142263e5b8542c4546644b73d354850253b4/src/plugins/blog/config.py#L77). Fixed incorrectly set default value in documentation.