### PR TITLE
Add reference to mkdocs-table-reader-plugin schema

### DIFF
--- a/docs/schema/plugins.json
+++ b/docs/schema/plugins.json
@@ -124,6 +124,9 @@
         },
         {
           "$ref": "https://raw.githubusercontent.com/pawamoy/markdown-exec/master/docs/schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/timvink/mkdocs-table-reader-plugin/master/docs/schema.json"
         }
       ]
     }


### PR DESCRIPTION
### Description
Added `mkdocs-table-reader-plugin` to `external-community` definition.

### Background
The [Data Table docs](https://squidfunk.github.io/mkdocs-material/reference/data-tables/?h=data+tab#import-table-from-file) recommends the [mkdocs-table-reader-plugin](https://timvink.github.io/mkdocs-table-reader-plugin/). However, when listing table-reader as a plugin, a `Value is not accepted.` linter error is thrown. I found a similar issue in the past, that was resolved with an identical approach: [PR 6381](https://github.com/squidfunk/mkdocs-material/pull/6381)

### 🚨 Requirements
I should also call out that this schema file doesn't yet exist. I've created a PR in the `mkdocs-table-reader-plugin` repo to resolve this:
https://github.com/timvink/mkdocs-table-reader-plugin/pull/58

Just an aside, I'm sorry in advance if I'm missing anything obvious; I'm new to to this setup!

