### PR TITLE
Add `tini` as init system to improve signal handling in docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,8 +176,8 @@ jobs:
         env:
           REPO_FULL_NAME: '${{ github.event.repository.full_name }}'
         run: |
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} mkdocs new .
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} mkdocs build
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} new .
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} build
 
       - name: Set platforms
         if: github.event_name == 'release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,8 +176,8 @@ jobs:
         env:
           REPO_FULL_NAME: '${{ github.event.repository.full_name }}'
         run: |
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} new .
-          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} build
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} mkdocs new .
+          docker run --rm -i -v ${PWD}:/docs ${REPO_FULL_NAME,,}:${{ steps.meta.outputs.version }} mkdocs build
 
       - name: Set platforms
         if: github.event_name == 'release'

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN \
     git-fast-import \
     jpeg-dev \
     openssh \
+    tini \
     zlib-dev \
 && \
   apk add --no-cache --virtual .build \
@@ -96,5 +97,5 @@ WORKDIR /docs
 EXPOSE 8000
 
 # Start development server by default
-ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,5 +97,5 @@ WORKDIR /docs
 EXPOSE 8000
 
 # Start development server by default
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]
+ENTRYPOINT ["/sbin/tini", "--", "mkdocs"]
+CMD [ "serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
So far, there was no init system on the docker container and any `SIGTERM` is lost somewhere between the host and `mkdocs`. The consequence is that while stopping the container, nothing signaled docker that the process successful finished and docker waited the default 10 seconds before it killed the container.

```
root@s740:/home/pi/docker/mkdocs-material# docker compose down
[+] Running 1/1
 ✔ Container mkdocs-material  Removed                                                10.2s 
```

This PR adds `tini` as an init system which handles such signals and boost the shutdown

```
root@s740:/home/pi/docker/mkdocs-material# docker compose down
[+] Running 1/1
 ✔ Container mkdocs-material  Removed                                                 0.2s
```