### PR TITLE
feature: make JSON feed discoverable

### DIFF
--- a/material/templates/partials/languages/en.html
+++ b/material/templates/partials/languages/en.html
@@ -25,6 +25,8 @@
   "footer.next": "Next",
   "footer.previous": "Previous",
   "header": "Header",
+  "json_feed.created": "JSON feed",
+  "json_feed.updated": "JSON feed of updated content",
   "meta.comments": "Comments",
   "meta.source": "Source",
   "nav": "Navigation",

--- a/material/templates/partials/languages/fr.html
+++ b/material/templates/partials/languages/fr.html
@@ -24,6 +24,8 @@
   "footer.next": "Suivant",
   "footer.previous": "Précédent",
   "header": "En-tête",
+  "json_feed.created": "Flux JSON",
+  "json_feed.updated": "Flux JSON du contenu mis à jour",
   "meta.comments": "Commentaires",
   "meta.source": "Source",
   "nav": "Navigation",

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -60,7 +60,7 @@
         <link rel="next" href="{{ page.next_page.url | url }}" />
       {% endif %}
 
-      <!-- RSS feed -->
+      <!-- RSS and JSON feed -->
       {% if "rss" in config.plugins %}
         <link
           rel="alternate"
@@ -73,6 +73,18 @@
           type="application/rss+xml"
           title="{{ lang.t('rss.updated') }}"
           href="{{ 'feed_rss_updated.xml' | url }}"
+        />
+        <link 
+          rel="alternate"
+          type="application/feed+json"
+          title="{{ lang.t('json_feed.created') }}"
+          href="{{ 'feed_rss_createdupdated.json' | url }}"
+        />
+        <link 
+          rel="alternate"
+          type="application/feed+json"
+          title="{{ lang.t('json_feed.updated') }}"
+          href="{{ 'feed_rss_updated.json' | url }}"
         />
       {% endif %}
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -78,7 +78,7 @@
           rel="alternate"
           type="application/feed+json"
           title="{{ lang.t('json_feed.created') }}"
-          href="{{ 'feed_rss_createdupdated.json' | url }}"
+          href="{{ 'feed_rss_created.json' | url }}"
         />
         <link 
           rel="alternate"


### PR DESCRIPTION
Since its [version 1.12](https://github.com/Guts/mkdocs-rss-plugin/releases/tag/1.12.0) ([plugin's documentation](https://guts.github.io/mkdocs-rss-plugin/integrations/?h=json#reference-json-feeds-in-html-meta-tags)), the RSS plugin creates also a [JSON Feed](https://www.jsonfeed.org/version/1.1/).

In this PR, I propose to add the same feed discovery mechanism as for RSS in the base template.