### PR TITLE
Let browser decide how to properly render text

### DIFF
--- a/src/templates/assets/stylesheets/main/_typeset.scss
+++ b/src/templates/assets/stylesheets/main/_typeset.scss
@@ -26,8 +26,8 @@
 
 // Enable font-smoothing in Webkit and FF
 body {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
 
   // Font with fallback for body copy
   --md-text-font-family:


### PR DESCRIPTION
Grayscale = blurry text with Skia on linux (probably other OSes too nowadays) on low DPI screen (both chromium/firefox)

This issue with grayscale is much worse with light text on dark background, text becomes unreadable
 


https://github.com/mkdocs/mkdocs/issues/3488


https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/