### PR TITLE
Fixed UTF-8 with BOM encoding support

### DIFF
--- a/material/plugins/blog/plugin.py
+++ b/material/plugins/blog/plugin.py
@@ -460,7 +460,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
             return config.authors
 
         # Open file and parse as YAML
-        with open(file, encoding = "utf-8") as f:
+        with open(file, encoding = "utf-8-sig") as f:
             config.config_file_path = os.path.abspath(file)
             try:
                 config.load_dict(yaml.load(f, SafeLoader) or {})

--- a/material/plugins/blog/structure/__init__.py
+++ b/material/plugins/blog/structure/__init__.py
@@ -57,7 +57,7 @@ class Post(Page):
         path = os.path.relpath(file.abs_src_path, docs)
 
         # Read contents and metadata immediately
-        with open(file.abs_src_path, encoding = "utf-8") as f:
+        with open(file.abs_src_path, encoding = "utf-8-sig") as f:
             self.markdown = f.read()
 
             # Sadly, MkDocs swallows any exceptions that occur during parsing.

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -437,7 +437,7 @@ def _convert_to_abs(path: str, abs_prefix: str = None) -> str:
 # logic. Side effect: It converts the INHERIT path to absolute.
 def _load_yaml(abs_src_path: str):
 
-    with open(abs_src_path, "r", encoding ="utf-8-sig") as file:
+    with open(abs_src_path, encoding ="utf-8-sig") as file:
         source = file.read()
 
     try:
@@ -479,7 +479,7 @@ def _resolve_pattern(abspath: str, return_path: bool = False):
 
 # Get project configuration with resolved absolute paths for validation
 def _get_project_config(project_config_file: str):
-    with open(project_config_file, encoding="utf-8") as file:
+    with open(project_config_file, encoding="utf-8-sig") as file:
         config = MkDocsConfig(config_file_path = project_config_file)
         config.load_file(file)
 

--- a/material/plugins/privacy/plugin.py
+++ b/material/plugins/privacy/plugin.py
@@ -254,7 +254,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
         # Find and extract all external asset URLs
         expr = re.compile(self.assets_expr_map[extension], flags = re.I | re.M)
-        with open(initiator.abs_src_path, encoding = "utf-8") as f:
+        with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
             return [urlparse(url) for url in re.findall(expr, f.read())]
 
     # Parse template or page HTML and find all external links that need to be
@@ -437,7 +437,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
     # Patch all links to external assets in the given file
     def _patch(self, initiator: File):
-        with open(initiator.abs_src_path, encoding = "utf-8") as f:
+        with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
 
             # Replace callback
             def replace(match: Match):

--- a/src/plugins/blog/plugin.py
+++ b/src/plugins/blog/plugin.py
@@ -460,7 +460,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
             return config.authors
 
         # Open file and parse as YAML
-        with open(file, encoding = "utf-8") as f:
+        with open(file, encoding = "utf-8-sig") as f:
             config.config_file_path = os.path.abspath(file)
             try:
                 config.load_dict(yaml.load(f, SafeLoader) or {})

--- a/src/plugins/blog/structure/__init__.py
+++ b/src/plugins/blog/structure/__init__.py
@@ -57,7 +57,7 @@ class Post(Page):
         path = os.path.relpath(file.abs_src_path, docs)
 
         # Read contents and metadata immediately
-        with open(file.abs_src_path, encoding = "utf-8") as f:
+        with open(file.abs_src_path, encoding = "utf-8-sig") as f:
             self.markdown = f.read()
 
             # Sadly, MkDocs swallows any exceptions that occur during parsing.

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -437,7 +437,7 @@ def _convert_to_abs(path: str, abs_prefix: str = None) -> str:
 # logic. Side effect: It converts the INHERIT path to absolute.
 def _load_yaml(abs_src_path: str):
 
-    with open(abs_src_path, "r", encoding ="utf-8-sig") as file:
+    with open(abs_src_path, encoding ="utf-8-sig") as file:
         source = file.read()
 
     try:
@@ -479,7 +479,7 @@ def _resolve_pattern(abspath: str, return_path: bool = False):
 
 # Get project configuration with resolved absolute paths for validation
 def _get_project_config(project_config_file: str):
-    with open(project_config_file, encoding="utf-8") as file:
+    with open(project_config_file, encoding="utf-8-sig") as file:
         config = MkDocsConfig(config_file_path = project_config_file)
         config.load_file(file)
 

--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -254,7 +254,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
         # Find and extract all external asset URLs
         expr = re.compile(self.assets_expr_map[extension], flags = re.I | re.M)
-        with open(initiator.abs_src_path, encoding = "utf-8") as f:
+        with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
             return [urlparse(url) for url in re.findall(expr, f.read())]
 
     # Parse template or page HTML and find all external links that need to be
@@ -437,7 +437,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
 
     # Patch all links to external assets in the given file
     def _patch(self, initiator: File):
-        with open(initiator.abs_src_path, encoding = "utf-8") as f:
+        with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
 
             # Replace callback
             def replace(match: Match):


### PR DESCRIPTION
PR for #6917 

Changed `utf-8` to `utf-8-sig` in all instanced where a file is read, that the user could've created with an external editor. 
Kept `utf-8` for reading files that are generated or already provided by the theme.
I decided to not add comments to each changed line, as supporting BOM isn't a priority, and if someone forgets using `-sig` it won't be the end of the world.

Tested by serving `mkdocs-material` documentation with this Community version of the codebase, and there was no crash. 
Therefore the privacy plugin wasn't tested, but those changed got tested in Insiders.
https://github.com/squidfunk/mkdocs-material-insiders/pull/82