### PR TITLE
Fetch KaTeX and MathJax from UNPKG

### DIFF
--- a/docs/plugins/privacy.md
+++ b/docs/plugins/privacy.md
@@ -387,7 +387,7 @@ external assets for different origins:
 plugins:
   - privacy:
       assets_exclude: # (1)!
-        - cdn.jsdelivr.net/npm/mathjax@3/*
+        - unpkg.com/mathjax@3/*
         - giscus.app/*
 ```
 

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -65,7 +65,7 @@ to your `mkdocs.yml`.
     extra_javascript:
       - javascripts/mathjax.js
       - https://polyfill.io/v3/polyfill.min.js?features=es6
-      - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+      - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
     ```
 
 See additional configuration options:
@@ -76,7 +76,7 @@ See additional configuration options:
   [instant loading]: ../setup/setting-up-navigation.md#instant-loading
 
 <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script id="MathJax-script" async src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
   window.MathJax = {
     tex: {
@@ -124,11 +124,11 @@ supports a subset of LaTeX syntax and can render math to HTML and SVG. To use
 
     extra_javascript:
       - javascripts/katex.js
-      - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.js
-      - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
+      - https://unpkg.com/katex@0/dist/katex.min.js
+      - https://unpkg.com/katex@0/dist/contrib/auto-render.min.js
 
     extra_css:
-      - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
+      - https://unpkg.com/katex@0/dist/katex.min.css
     ```
 
 ## Usage

--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -70,7 +70,7 @@ of [additional JavaScript]:
     extra_javascript:
       - javascripts/mathjax.js
       - https://polyfill.io/v3/polyfill.min.js?features=es6
-      - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+      - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
     ```
 
 The other configuration options of this extension are not officially supported


### PR DESCRIPTION
This is consistent with how we fetch Mermaid.js and automatically picks the latest minor version.