### PR TITLE
Use Babel's `format_datetime`, not `format_date`

### DIFF
--- a/material/plugins/blog/plugin.py
+++ b/material/plugins/blog/plugin.py
@@ -25,7 +25,7 @@ import os
 import posixpath
 import yaml
 
-from babel.dates import format_date
+from babel.dates import format_datetime
 from datetime import datetime
 from jinja2 import pass_context
 from jinja2.runtime import Context
@@ -783,7 +783,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
     # Format date
     def _format_date(self, date: datetime, format: str, config: MkDocsConfig):
         locale: str = config.theme["language"].replace("-", "_")
-        return format_date(date, format = format, locale = locale)
+        return format_datetime(date, format = format, locale = locale)
 
     # Format date for post
     def _format_date_for_post(self, date: datetime, config: MkDocsConfig):

--- a/src/plugins/blog/plugin.py
+++ b/src/plugins/blog/plugin.py
@@ -25,7 +25,7 @@ import os
 import posixpath
 import yaml
 
-from babel.dates import format_date
+from babel.dates import format_datetime
 from datetime import datetime
 from jinja2 import pass_context
 from jinja2.runtime import Context
@@ -783,7 +783,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
     # Format date
     def _format_date(self, date: datetime, format: str, config: MkDocsConfig):
         locale: str = config.theme["language"].replace("-", "_")
-        return format_date(date, format = format, locale = locale)
+        return format_datetime(date, format = format, locale = locale)
 
     # Format date for post
     def _format_date_for_post(self, date: datetime, config: MkDocsConfig):


### PR DESCRIPTION
I am using MkDocs-Material 9.5.15 and Babel 2.14.0. When setting the config value `blog.post_date_format: "yyyy-MM-dd hh:mm:ss"`, the blog plugin crashes during compilation with the error "date objects have no hour field".

I believe this is occurring because the plugin provides a `datetime` to `babel.dates.format_date`, which upcasts it to a plain, timeless, `date`. Making this change to use `babel.dates.format_datetime` instead resolved the error and demonstrated expected behavior.

While I recognize that it is likely uncommon for a blog to want to include sub-date timestamps in any of these fields, I believe that the current documentation,

> The format string must adhere to babel's pattern syntax and should not contain whitespace

implies that _any_ of Babel's pattern markers are acceptable here. I would consider 

> The format string must adhere to Babel's pattern syntax for calendar dates and should not contain whitespace

to also be a sufficient fix for this case.

----

Thank you for your effort in creating this project; it has been a wonderful benefit to my team, and this is the first minor problem we've had in months of using it.