### PR TITLE
fix for #6983

### DIFF
--- a/material/plugins/social/config.py
+++ b/material/plugins/social/config.py
@@ -29,6 +29,7 @@ from mkdocs.config.config_options import Deprecated, Type
 class SocialConfig(Config):
     enabled = Type(bool, default = True)
     cache_dir = Type(str, default = ".cache/plugin/social")
+    fonts_dir = Type(str, default = "fonts")
 
     # Settings for social cards
     cards = Type(bool, default = True)

--- a/src/plugins/social/config.py
+++ b/src/plugins/social/config.py
@@ -29,6 +29,7 @@ from mkdocs.config.config_options import Deprecated, Type
 class SocialConfig(Config):
     enabled = Type(bool, default = True)
     cache_dir = Type(str, default = ".cache/plugin/social")
+    fonts_dir = Type(str, default = "fonts")
 
     # Settings for social cards
     cards = Type(bool, default = True)


### PR DESCRIPTION
Google Font download no longer provides zip files, so I added an option to source fonts from a .zip file in a local directory configured with `fonts_dir`, just as in the PR for the Insider Edition. 

The code changes here for the public version are a bit smaller as I accepted a little bit of duplication. 