### PR TITLE
Fix unicode, case-sensitive `slugify` setting in the documentation

### DIFF
--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -686,7 +686,7 @@ The following configuration options are supported:
 
 <!-- md:option pymdownx.tabbed.slugify -->
 
-:   <!-- md:default `toc.slugify` --> This option allows for
+:   <!-- md:default `None` --> This option allows for
     customization of the slug function. For some languages, the default may not
     produce good and readable identifiers – consider using another slug function
     like for example those from [Python Markdown Extensions][Slugs]:
@@ -706,7 +706,7 @@ The following configuration options are supported:
         ``` yaml
         markdown_extensions:
           - pymdownx.tabbed:
-              slugify: !!python/object/apply:pymdownx.slugs.slugify
+              slugify: !!python/object/apply:pymdownx.slugs.slugify {}
         ```
 
 The other configuration options of this extension are not officially supported

--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -257,7 +257,7 @@ The following configuration options are supported:
         ``` yaml
         markdown_extensions:
           - toc:
-              slugify: !!python/object/apply:pymdownx.slugs.slugify
+              slugify: !!python/object/apply:pymdownx.slugs.slugify {}
         ```
 
 <!-- md:option toc.toc_depth -->


### PR DESCRIPTION
Unicode, case-sensitive reference setting causes error below.

```
yaml.constructor.ConstructorError: expected a mapping node, but found scalar
```

Update related sections in the documentation to address this issue.

Newer Python-Markdown has `slugify_unicode` built-in, so this

```yaml
markdown_extensions:
  - toc:
      slugify: !!python/name:markdown.extensions.toc.slugify_unicode
```

also works for case-insensitive use cases.

Fixes: ee1e675da613 ("Update slug reference")

## References

- https://pyyaml.org/wiki/PyYAMLDocumentation#objects
- https://python-markdown.github.io/extensions/toc/#usage
- https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/#options