### PR TITLE
Add missing icons and their defaults to `theme.json` schema

### DIFF
--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -490,6 +490,34 @@
         {
           "label": "repo",
           "body": "repo: ${1:fontawesome/brands/git-alt}"
+        },
+        {
+          "label": "top",
+          "body": "top: ${1:material/arrow-up}"
+        },
+        {
+          "label": "menu",
+          "body": "menu: ${1:material/menu}"
+        },
+        {
+          "label": "alternate",
+          "body": "alternate: ${1:material/translate}"
+        },
+        {
+          "label": "share",
+          "body": "share: ${1:material/share-variant}"
+        },
+        {
+          "label": "search",
+          "body": "search: ${1:material/magnify}"
+        },
+        {
+          "label": "previous",
+          "body": "previous: ${1:material/arrow-left}"
+        },
+        {
+          "label": "next",
+          "body": "next: ${1:material/arrow-right}"
         }
       ]
     },

--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -344,6 +344,33 @@
         "repo": {
           "$ref": "#/$defs/icon"
         },
+        "annotation": {
+          "$ref": "#/$defs/icon"
+        },
+        "top": {
+          "$ref": "#/$defs/icon"
+        },
+        "share": {
+          "$ref": "#/$defs/icon"
+        },
+        "menu": {
+          "$ref": "#/$defs/icon"
+        },
+        "alternate": {
+          "$ref": "#/$defs/icon"
+        },
+        "search": {
+          "$ref": "#/$defs/icon"
+        },
+        "close": {
+          "$ref": "#/$defs/icon"
+        },
+        "previous": {
+          "$ref": "#/$defs/icon"
+        },
+        "next": {
+          "$ref": "#/$defs/icon"
+        },
         "admonition": {
           "title": "Admonition icon",
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/reference/admonitions/#admonition-icons",


### PR DESCRIPTION
Started using the schema yesterday and noticed `theme.json` was missing some of the [icons defined in the docs](https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#site-icons), including the [annotation icon](https://squidfunk.github.io/mkdocs-material/reference/annotations/#annotation-icons). - a9a6202a743e442603dc81b0df7a9894e6193320

Also added some of the missing defaults for those icons - 1eea36b88efdbad13ebfe95915e79a759ffa22c1