### PR TITLE
fix: was post_slugify instead of categories_slugify in example

### DIFF
--- a/docs/plugins/blog.md
+++ b/docs/plugins/blog.md
@@ -882,7 +882,7 @@ from [Python Markdown Extensions] is used as follows:
 ``` yaml
 plugins:
   - blog:
-      post_slugify: !!python/object/apply:pymdownx.slugs.slugify
+      categories_slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
 ```


### PR DESCRIPTION
wrong setting name was used in the example for `categories_slugify`.