### PR TITLE
Fix missing blog_dir link in setting-up-a-blog.md

### DIFF
--- a/docs/setup/setting-up-a-blog.md
+++ b/docs/setup/setting-up-a-blog.md
@@ -675,6 +675,7 @@ All post excerpts belonging to the category are automatically appended.
   [page description]: ../reference/index.md#setting-the-page-description
   [categories_url_format]: ../plugins/blog.md#config.categories_url_format
   [categories_slugify]: ../plugins/blog.md#config.categories_slugify
+  [this is configurable]: ../plugins/blog.md#config.blog_dir
 
 ### Overriding templates
 


### PR DESCRIPTION
The `Custom index pages` section did not have a link for the `blog_dir` text, making it show up as `[blog_dir][this is configurable]`.

I've added a reference link with `../plugins/blog.md#config.blog_dir` as its value to fix this.