### PR TITLE
GF font retrieve win (#7085)

### DIFF
--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -444,11 +444,17 @@ class SocialPlugin(BasePlugin[SocialConfig]):
         svg2png(bytestring = data, write_to = file, scale = 10)
         return Image.open(file)
 
-    # Retrieve font
+    # Retrieve font either from the card layout option or from the Material
+    # font defintion. If no font is defined for Material or font is False
+    # then choose a default.
     def _load_font(self, config):
         name = self.config.cards_layout_options.get("font_family")
         if not name:
-            name = config.theme.get("font", {}).get("text", "Roboto")
+            material_name = config.theme.get("font", False)
+            if material_name is False:
+                name = "Roboto"
+            else:
+                name = material_name.get("text", "Roboto")
 
         # Resolve relevant fonts
         font = {}

--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -522,11 +522,10 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
-                # Extract font family name and style
-                # using the content in the response via ByteIO to avoid writing
-                # a temp file. Done to fix problems with passing a
-                # NamedTemporaryFile to ImageFont.truetype() on Windows,
-                # see https://t.ly/LiF_k
+                # Extract font family name and style using the content in the
+                # response via ByteIO to avoid writing a temp file. Done to fix
+                # problems with passing a NamedTemporaryFile to
+                # ImageFont.truetype() on Windows, see https://t.ly/LiF_k
                 with BytesIO(res.content) as fontdata:
                     font = ImageFont.truetype(fontdata)
                     name, style = font.getname()

--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -522,14 +522,18 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
-                #  Extract font family name and style
-                content = BytesIO(res.content)
-                font = ImageFont.truetype(content)
-                name, style = font.getname()
-                name = " ".join([name.replace(family, ""), style]).strip()
-                target = os.path.join(path, family, f"{name}.ttf")
+                # Extract font family name and style
+                # using the content in the response via ByteIO to avoid writing
+                # a temp file. Done to fix problems with passing a
+                # NamedTemporaryFile to ImageFont.truetype() on Windows,
+                # see https://t.ly/LiF_k
+                with BytesIO(res.content) as fontdata:
+                    font = ImageFont.truetype(fontdata)
+                    name, style = font.getname()
+                    name = " ".join([name.replace(family, ""), style]).strip()
+                    target = os.path.join(path, family, f"{name}.ttf")
 
-                # write font to cache
+                # write file to cache
                 write_file(res.content, target)
 
 # -----------------------------------------------------------------------------

--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -46,7 +46,7 @@ from io import BytesIO
 from mkdocs.commands.build import DuplicateFilter
 from mkdocs.exceptions import PluginError
 from mkdocs.plugins import BasePlugin
-from mkdocs.utils import copy_file
+from mkdocs.utils import write_file
 from shutil import copyfile
 from tempfile import NamedTemporaryFile
 
@@ -522,19 +522,15 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
-                # Create a temporary file to download the font
-                with NamedTemporaryFile() as temp:
-                    temp.write(res.content)
-                    temp.flush()
+                #  Extract font family name and style
+                content = BytesIO(res.content)
+                font = ImageFont.truetype(content)
+                name, style = font.getname()
+                name = " ".join([name.replace(family, ""), style]).strip()
+                target = os.path.join(path, family, f"{name}.ttf")
 
-                    # Extract font family name and style
-                    font = ImageFont.truetype(temp.name)
-                    name, style = font.getname()
-                    name = " ".join([name.replace(family, ""), style]).strip()
-
-                    # Move fonts to cache directory
-                    target = os.path.join(path, family, f"{name}.ttf")
-                    copy_file(temp.name, target)
+                # write font to cache
+                write_file(res.content, target)
 
 # -----------------------------------------------------------------------------
 # Data

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -444,11 +444,17 @@ class SocialPlugin(BasePlugin[SocialConfig]):
         svg2png(bytestring = data, write_to = file, scale = 10)
         return Image.open(file)
 
-    # Retrieve font
+    # Retrieve font either from the card layout option or from the Material
+    # font defintion. If no font is defined for Material or font is False
+    # then choose a default.
     def _load_font(self, config):
         name = self.config.cards_layout_options.get("font_family")
         if not name:
-            name = config.theme.get("font", {}).get("text", "Roboto")
+            material_name = config.theme.get("font", False)
+            if material_name is False:
+                name = "Roboto"
+            else:
+                name = material_name.get("text", "Roboto")
 
         # Resolve relevant fonts
         font = {}

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -522,11 +522,10 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
-                # Extract font family name and style
-                # using the content in the response via ByteIO to avoid writing
-                # a temp file. Done to fix problems with passing a
-                # NamedTemporaryFile to ImageFont.truetype() on Windows,
-                # see https://t.ly/LiF_k
+                # Extract font family name and style using the content in the
+                # response via ByteIO to avoid writing a temp file. Done to fix
+                # problems with passing a NamedTemporaryFile to
+                # ImageFont.truetype() on Windows, see https://t.ly/LiF_k
                 with BytesIO(res.content) as fontdata:
                     font = ImageFont.truetype(fontdata)
                     name, style = font.getname()

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -46,7 +46,7 @@ from io import BytesIO
 from mkdocs.commands.build import DuplicateFilter
 from mkdocs.exceptions import PluginError
 from mkdocs.plugins import BasePlugin
-from mkdocs.utils import copy_file
+from mkdocs.utils import write_file
 from shutil import copyfile
 from tempfile import NamedTemporaryFile
 
@@ -522,19 +522,27 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
+                content = BytesIO(res.content)
+                font = ImageFont.truetype(content)
+                name, style = font.getname()
+                name = " ".join([name.replace(family, ""), style]).strip()
+                target = os.path.join(path, family, f"{name}.ttf")
+                content.seek(0)
+                write_file(content, target)
+                
                 # Create a temporary file to download the font
-                with NamedTemporaryFile() as temp:
-                    temp.write(res.content)
-                    temp.flush()
+                # with NamedTemporaryFile() as temp:
+                #     temp.write(res.content)
+                #     temp.flush()
 
-                    # Extract font family name and style
-                    font = ImageFont.truetype(temp.name)
-                    name, style = font.getname()
-                    name = " ".join([name.replace(family, ""), style]).strip()
+                #     # Extract font family name and style
+                #     font = ImageFont.truetype(temp.name)
+                #     name, style = font.getname()
+                #     name = " ".join([name.replace(family, ""), style]).strip()
 
-                    # Move fonts to cache directory
-                    target = os.path.join(path, family, f"{name}.ttf")
-                    copy_file(temp.name, target)
+                #     # Move fonts to cache directory
+                #     target = os.path.join(path, family, f"{name}.ttf")
+                #     copy_file(temp.name, target)
 
 # -----------------------------------------------------------------------------
 # Data

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -523,11 +523,16 @@ class SocialPlugin(BasePlugin[SocialConfig]):
                 res.raise_for_status()
 
                 # Extract font family name and style
-                font = ImageFont.truetype(BytesIO(res.content))
-                name, style = font.getname()
-                name = " ".join([name.replace(family, ""), style]).strip()
-                target = os.path.join(path, family, f"{name}.ttf")
-                
+                # using the content in the response via ByteIO to avoid writing
+                # a temp file. Done to fix problems with passing a
+                # NamedTemporaryFile to ImageFont.truetype() on Windows,
+                # see https://t.ly/LiF_k
+                with BytesIO(res.content) as fontdata:
+                    font = ImageFont.truetype(fontdata)
+                    name, style = font.getname()
+                    name = " ".join([name.replace(family, ""), style]).strip()
+                    target = os.path.join(path, family, f"{name}.ttf")
+
                 # write file to cache
                 write_file(res.content, target)
 

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -522,27 +522,14 @@ class SocialPlugin(BasePlugin[SocialConfig]):
             with requests.get(match) as res:
                 res.raise_for_status()
 
-                content = BytesIO(res.content)
-                font = ImageFont.truetype(content)
+                # Extract font family name and style
+                font = ImageFont.truetype(BytesIO(res.content))
                 name, style = font.getname()
                 name = " ".join([name.replace(family, ""), style]).strip()
                 target = os.path.join(path, family, f"{name}.ttf")
-                content.seek(0)
-                write_file(content, target)
                 
-                # Create a temporary file to download the font
-                # with NamedTemporaryFile() as temp:
-                #     temp.write(res.content)
-                #     temp.flush()
-
-                #     # Extract font family name and style
-                #     font = ImageFont.truetype(temp.name)
-                #     name, style = font.getname()
-                #     name = " ".join([name.replace(family, ""), style]).strip()
-
-                #     # Move fonts to cache directory
-                #     target = os.path.join(path, family, f"{name}.ttf")
-                #     copy_file(temp.name, target)
+                # write file to cache
+                write_file(res.content, target)
 
 # -----------------------------------------------------------------------------
 # Data


### PR DESCRIPTION
Changed the way that font information is extracted once downloaded from GF. This avoids creating a temporary file and so resolves the issue with `NamedTemporaryFile` on Windows (https://github.com/squidfunk/mkdocs-material/issues/7085)

Tested this with our own documentation on Windows and MacOS. 