### PR TITLE
Remove erroneous *.js pattern for extra_javascript in schema.json

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -96,9 +96,8 @@
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript",
       "type": "array",
       "items": {
-        "title": "Path to JavaScript file",
+        "title": "Path to JavaScript file (may be local or absolute URL to external JS)",
         "markdownDescription": "https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript",
-        "pattern": "\\.m?js($|\\?)"
       },
       "uniqueItems": true,
       "minItems": 1


### PR DESCRIPTION
Since https://github.com/mkdocs/mkdocs/pull/92 for https://github.com/mkdocs/mkdocs/issues/91, an extra_javascript item does not necessarily have to end in *.js; e.g. in https://github.com/enola-dev/enola/pull/669 I have an `extra_javascript: - https://unpkg.com/mustache@latest`, which this flags up as wrong - although it's not (it works great); ergo it's better to remove this constraint.