### PR TITLE
Fix JSON parse error in schema.json

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -97,7 +97,7 @@
       "type": "array",
       "items": {
         "title": "Path to JavaScript file (may be local or absolute URL to external JS)",
-        "markdownDescription": "https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript",
+        "markdownDescription": "https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript"
       },
       "uniqueItems": true,
       "minItems": 1


### PR DESCRIPTION
It looks like the recently merged PR #7150  accidentally caused a JSON parse error in the `schema.json`.

I noticed it because I use the YAML extension in vscode and it failed validating my `mkdocs.yml` with the following error:

> Unable to parse content from 'https://squidfunk.github.io/mkdocs-material/schema.json': Parse error at offset 4055.YAML(768)