### PR TITLE
Add Zeabur as a platform in publishing guide

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -222,6 +222,7 @@ other providers:
 - [:simple-netlify: Netlify][Netlify]
 - [:simple-vercel: Vercel][Vercel]
 - [:simple-codeberg: Codeberg Pages][Codeberg Pages]
+- [Zeabur][Zeabur]
 
 </div>
 
@@ -236,3 +237,4 @@ other providers:
   [Netlify]: https://www.starfallprojects.co.uk/projects/deploy-host-docs/deploy-mkdocs-material-netlify/
   [Vercel]: https://www.starfallprojects.co.uk/projects/deploy-host-docs/deploy-mkdocs-material-vercel/
   [Codeberg Pages]: https://andre601.ch/blog/2023/11-05-using-codeberg-pages/
+  [Zeabur]: https://zeabur.com/docs/guides/static/mkdocs


### PR DESCRIPTION
This Pull Request add [Zeabur](https://zeabur.com) to [Publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/) documentation.

Zeabur is a PaaS that built on top of cloud providers like GCP, AWS and Digital Ocean. With out-of-the-box CI/CD helps users deploy their MkDocs website to the global CDN effortlessly.

Learn more: https://zeabur.com/docs/guides/static/mkdocs
Demo video: https://www.youtube.com/watch?v=DYlpqWQgQEM