### PR TITLE
Added --force-reinstall to insiders upgrade instructions

### DIFF
--- a/docs/insiders/upgrade.md
+++ b/docs/insiders/upgrade.md
@@ -34,7 +34,12 @@ need to run different commands:
     latest development version, run:
 
     ```
-    pip install --upgrade git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+    pip install --upgrade --force-reinstall git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+    ```
+
+    The `--force-reinstall` option serves to make sure `pip` does, in fact,
+    install the latest development version, instead of deciding that  nothing
+    is to be done based on the version numbers.
     ```
 
 === "git upgrade"


### PR DESCRIPTION
As discussed, added `--force-reinstall` to the upgrade instructions for people who need the latest development version. This avoids the problem that `pip` might decide there is nothing to do based on comparing version numbers.