### PR TITLE
Map nb_NO to nb

### DIFF
--- a/material/templates/partials/languages/nb_NO.html
+++ b/material/templates/partials/languages/nb_NO.html
@@ -1,0 +1,5 @@
+{#-
+  This is an alias file: nb_NO -> nb
+-#}
+{% import "partials/languages/nb.html" as nb %}
+{% macro t(key) %}{{ nb.t(key) }}{% endmacro %}


### PR DESCRIPTION
This is a fix to allow using the language code nb_NO.

My project uses other language codes that are longer. 
According to https://linguistics.stackexchange.com/a/36794, nb_NO can be mapped to nb. So, this is a mapping that makes the language build.

I see that this is the first language code that is longer. Maybe another fallback might be the right thing to do here.

Error:

```
Traceback (most recent call last):
  File "/home/nicco/open-web-calendar/.tox/docs/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/mkdocs/__main__.py", line 286, in build_command
    build.build(cfg, dirty=not clean)
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/mkdocs/commands/build.py", line 349, in build
    _build_page(
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/mkdocs/commands/build.py", line 232, in _build_page
    output = template.render(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/material/templates/main.html", line 4, in top-level template code
    {% extends "base.html" %}
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/material/templates/base.html", line 4, in top-level template code
    {% import "partials/language.html" as lang with context %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/jinja2/environment.py", line 1408, in make_module
    return TemplateModule(self, ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/jinja2/environment.py", line 1540, in __init__
    body_stream = list(template.root_render_func(context))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/material/templates/partials/language.html", line 4, in top-level template code
    {% import "partials/languages/" ~ config.theme.language ~ ".html" as lang %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/open-web-calendar/.tox/docs/lib/python3.11/site-packages/jinja2/loaders.py", line 207, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: partials/languages/nb_NO.html
```

I think, a fix can be more generic: Default to the simple code when you get a longer one. But this is a proposed small fix from my side.