### PR TITLE
Add tabindex="0" to solve accessibility issue on searchbar not being recognized as scrollable

### DIFF
--- a/src/templates/partials/search.html
+++ b/src/templates/partials/search.html
@@ -94,7 +94,7 @@
       {% endif %}
     </form>
     <div class="md-search__output">
-      <div class="md-search__scrollwrap" data-md-scrollfix>
+      <div class="md-search__scrollwrap" tabindex="0" data-md-scrollfix>
 
         <!-- Search results -->
         <div class="md-search-result" data-md-component="search-result">


### PR DESCRIPTION
Pull request discussed in following [issue](https://github.com/squidfunk/mkdocs-material/issues/7193)