### PR TITLE
Apply `text-align: justify` to `md-content` class

### DIFF
--- a/src/templates/assets/stylesheets/main/components/_content.scss
+++ b/src/templates/assets/stylesheets/main/components/_content.scss
@@ -31,6 +31,7 @@
   // dimensions of its parent. Otherwise, long code blocks might lead to a
   // wider content area which will overflow. See https://bit.ly/3bP3f8k
   min-width: 0;
+  text-align: justify;
 
   // Content wrapper
   &__inner {


### PR DESCRIPTION
This pull request introduces a modification to align the text of content to justify, enhancing readability and visual coherence. The accompanying before-and-after comparison showcases the improvement:

| Before   | After        |
|-------------------------------|---------------------------------|
| ![before](https://github.com/squidfunk/mkdocs-material/assets/68323012/512ffcf0-e9f6-40a6-ba32-367c1cb210c5)  |  ![after](https://github.com/squidfunk/mkdocs-material/assets/68323012/1164d98e-3d59-47cd-a1ca-d6cf1b059e3d) |

I've been personally adjusting this value via `extra/stylesheet.css` for over two years across multiple sites, because I had hesitation regarding it's acceptance. However, I've concluded that this change benefits end users, including myself, and may prove valuable to others in the community. Thus, I've decided to proceed with confidence in  the value this enhancement can bring.