### PR TITLE
Replace missing Azure Devops icon

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -215,7 +215,7 @@ other providers:
 
 <div class="mdx-columns" markdown>
 
-- [:simple-azuredevops: Azure][Azure]
+- [:material-microsoft-azure-devops: Azure][Azure]
 - [:simple-cloudflarepages: Cloudflare Pages][Cloudflare Pages]
 - [:simple-digitalocean: DigitalOcean][DigitalOcean]
 - [:material-airballoon-outline: Fly.io][Flyio]


### PR DESCRIPTION
Simple Icons has removed all Microsoft related icons:

- https://github.com/simple-icons/simple-icons/pull/10019

Appears in [Publishing your site](https://squidfunk.github.io/mkdocs-material/publishing-your-site/#other).