### PR TITLE
Fixed blog readtime calculation to ignore non-content text

### DIFF
--- a/material/plugins/blog/readtime/parser.py
+++ b/material/plugins/blog/readtime/parser.py
@@ -20,6 +20,10 @@
 
 from html.parser import HTMLParser
 
+# TODO: Refactor the `void` set into a common module and import it from there
+# and not from the search plugin.
+from material.plugins.search.plugin import void
+
 # -----------------------------------------------------------------------------
 # Classes
 # -----------------------------------------------------------------------------
@@ -31,15 +35,40 @@ class ReadtimeParser(HTMLParser):
     def __init__(self):
         super().__init__(convert_charrefs = True)
 
+        # Tags to skip
+        self.skip = set([
+            "object",                  # Objects
+            "script",                  # Scripts
+            "style",                   # Styles
+            "svg"                      # SVGs
+        ])
+
+        # Current context
+        self.context = []
+
         # Keep track of text and images
         self.text   = []
         self.images = 0
 
-    # Collect images
+    # Called at the start of every HTML tag
     def handle_starttag(self, tag, attrs):
+        # Collect images
         if tag == "img":
             self.images += 1
 
-    # Collect text
+        # Ignore self-closing tags
+        if tag not in void:
+            # Add tag to context
+            self.context.append(tag)
+
+    # Called for the text contents of each tag
     def handle_data(self, data):
-        self.text.append(data)
+        # Collect text if not inside skip context
+        if not self.skip.intersection(self.context):
+            self.text.append(data)
+
+    # Called at the end of every HTML tag
+    def handle_endtag(self, tag):
+        if self.context and self.context[-1] == tag:
+            # Remove tag from context
+            self.context.pop()

--- a/src/plugins/blog/readtime/parser.py
+++ b/src/plugins/blog/readtime/parser.py
@@ -20,6 +20,10 @@
 
 from html.parser import HTMLParser
 
+# TODO: Refactor the `void` set into a common module and import it from there
+# and not from the search plugin.
+from material.plugins.search.plugin import void
+
 # -----------------------------------------------------------------------------
 # Classes
 # -----------------------------------------------------------------------------
@@ -31,15 +35,40 @@ class ReadtimeParser(HTMLParser):
     def __init__(self):
         super().__init__(convert_charrefs = True)
 
+        # Tags to skip
+        self.skip = set([
+            "object",                  # Objects
+            "script",                  # Scripts
+            "style",                   # Styles
+            "svg"                      # SVGs
+        ])
+
+        # Current context
+        self.context = []
+
         # Keep track of text and images
         self.text   = []
         self.images = 0
 
-    # Collect images
+    # Called at the start of every HTML tag
     def handle_starttag(self, tag, attrs):
+        # Collect images
         if tag == "img":
             self.images += 1
 
-    # Collect text
+        # Ignore self-closing tags
+        if tag not in void:
+            # Add tag to context
+            self.context.append(tag)
+
+    # Called for the text contents of each tag
     def handle_data(self, data):
-        self.text.append(data)
+        # Collect text if not inside skip context
+        if not self.skip.intersection(self.context):
+            self.text.append(data)
+
+    # Called at the end of every HTML tag
+    def handle_endtag(self, tag):
+        if self.context and self.context[-1] == tag:
+            # Remove tag from context
+            self.context.pop()


### PR DESCRIPTION
I've fixed the blog readtime calculation to ignore non-content text, i.e. any text nodes that are inside the following tags are omitted from calculating the readtime:

* `<object>`
* `<script>`
* `<style>`
* `<svg>`

The implementation is inspired by the [search plugin parser](https://github.com/squidfunk/mkdocs-material/blob/4f8081c268d31bf74d546e600cadd0cff7dc89e8/src/plugins/search/plugin.py#L371-L579).

Note that I've duplicated the `void` set from the search plugin. It might be cleaner to deduplicate it, but I wasn't sure where to best move it to import from. If you'd prefer deduplication, I'd appreciate your guidance on where to factor `void` out, @squidfunk.

Fixes #7367.