### PR TITLE
Documentation of sane_lists extension (#7327)

### DIFF
--- a/docs/reference/lists.md
+++ b/docs/reference/lists.md
@@ -11,13 +11,14 @@ are supported through extensions.
 
 ## Configuration
 
-This configuration enables the use of definition lists and tasks lists, which
+This configuration enables the use of definition lists, tasks lists and sane lists, which
 are both not part of the standard Markdown syntax. Add the following lines to
 `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
   - def_list
+  - sane_lists
   - pymdownx.tasklist:
       custom_checkbox: true
 ```
@@ -26,9 +27,11 @@ See additional configuration options:
 
 - [Definition Lists]
 - [Tasklist]
+- [Sane Lists]
 
   [Definition Lists]: ../setup/extensions/python-markdown.md#definition-lists
   [Tasklist]: ../setup/extensions/python-markdown-extensions.md#tasklist
+  [Sane Lists]: ../setup/extensions/python-markdown.md#sane-lists
 
 ## Usage
 
@@ -164,5 +167,109 @@ for the definition of task lists:
     * [x] In scelerisque nibh non dolor mollis congue sed et metus
     * [ ] Praesent sed risus massa
 - [ ] Aenean pretium efficitur erat, donec pharetra, ligula non scelerisque
+
+</div>
+
+### Using sane lists
+
+The [Sane Lists] extension prevents the mixing of list types.
+In other words, an ordered list will not continue when an unordered
+list item is encountered and vice versa.
+
+=== "With Sane Lists"
+    ``` markdown
+    1. Ordered item 1
+    2. Ordered item 2
+
+    * Unordered item 1
+    * Unordered item 2
+    ```
+
+    <div class="result" markdown>
+
+    1. Ordered item 1
+    2. Ordered item 2
+
+    * Unordered item 1
+    * Unordered item 2
+
+    </div>
+
+=== "Without Sane Lists"
+    ``` markdown
+    1. Ordered item 1
+    2. Ordered item 2
+
+    * Unordered item 1
+    * Unordered item 2
+    ```
+
+    <div class="result" markdown>
+      <ol>
+        <li>Ordered item 1</li>
+        <li>Ordered item 2</li>
+        <li>Unordered item 1</li>
+        <li>Unordered item 2</li>
+      </ol>
+    </div>
+
+A side effect of this extensions is that, unlike the default behavior of Markdown,
+if a blank line is not included between a paragraph and a list, the different list
+type will be completely ignored and will be rendered as a continuation of the
+previous list item.
+
+=== "With Sane Lists"
+    ``` markdown
+    A Paragraph.
+    * Not a list item.
+
+    1. Ordered list item.
+    * Not a separate list item.
+    ```
+
+    <div class="result" markdown>
+
+    A Paragraph.
+    * Not a list item.
+
+    1. Ordered list item.
+    * Not a separate list item.
+
+    </div>
+
+=== "Without Sane Lists"
+    ``` markdown
+    A Paragraph.
+    * Not a list item.
+
+    1. Ordered list item.
+    * Not a separate list item.
+    ```
+
+    <div class="result" markdown>
+      <p>A Paragraph.
+      * Not a list item.</p>
+      <ol>
+        <li>Ordered list item.</li>
+        <li>Not a separate list item.</li>
+      </ol>
+    </div>
+
+#### Defining starting numbers
+
+When [Sane Lists] is enabled, the starting number of ordered
+lists can be defined with the first number in the list:
+
+``` markdown title="Starting number"
+5. Lorem ipsum dolor sit amet, consectetur adipiscing elit
+1. Vestibulum convallis sit amet nisi a tincidunt
+1. In hac habitasse platea dictumst
+```
+
+<div class="result" markdown>
+
+5. Lorem ipsum dolor sit amet, consectetur adipiscing elit
+1. Vestibulum convallis sit amet nisi a tincidunt
+1. In hac habitasse platea dictumst
 
 </div>

--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -169,6 +169,26 @@ No configuration options are available. See reference for usage:
   [Using grids]: ../../reference/grids.md#usage
   [Image captions]: ../../reference/images.md#image-captions
 
+### Sane Lists
+
+<!-- md:version 0.1.0 -->
+<!-- md:extension [sane_lists][Sane Lists] -->
+
+The [Sane Lists] extension modifies the behavior of the standard Markdown list,
+making it less surprising and more intuitive. Enable it via `mkdocs.yml`:
+
+``` yaml
+markdown_extensions:
+  - sane_lists
+```
+
+No configuration options are available. See reference for usage:
+
+- [Using sane lists]
+
+  [Sane Lists]: https://python-markdown.github.io/extensions/sane_lists/
+  [Using sane lists]: ../../reference/lists.md#using-sane-lists
+
 ### Table of Contents
 
 <!-- md:version 0.1.0 -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ markdown_extensions:
   - admonition
   - attr_list
   - def_list
+  - sane_lists
   - footnotes
   - md_in_html
   - toc:


### PR DESCRIPTION
This PR adds documentation corresponding to the [Sane Lists extension](https://python-markdown.github.io/extensions/sane_lists/) included by default in Python-Markdown, but not mentioned in the documentation.

See: #7327

I've set the minim version for using this extension at `0.1.0`, but I'm really not sure if it's the correct one.

Also, I've enabled the extension in `mydocs.yml`:
```yml
markdown_extensions:
  - sane_lists
```

This extension modifies the default Markdown behavior (See [Sane Lists extension syntax](https://python-markdown.github.io/extensions/sane_lists/#syntax)). It may have changed the output in some other pages.

