### PR TITLE
Fetch and show the latest version for GitLab repositories

### DIFF
--- a/docs/setup/adding-a-git-repository.md
+++ b/docs/setup/adding-a-git-repository.md
@@ -22,20 +22,25 @@ repo_url: https://github.com/squidfunk/mkdocs-material
 
 The link to the repository will be rendered next to the search bar on big
 screens and as part of the main navigation drawer on smaller screen sizes.
-Additionally, for public repositories hosted on [GitHub] or [GitLab], the
-number of stars and forks is automatically requested and rendered.
 
-GitHub repositories also include the tag of the latest release.[^1]
+Additionally, for public repositories hosted on [GitHub] or [GitLab], the
+latest release tag[^1], as well as the number of stars and forks, are
+automatically requested and rendered.
 
   [^1]:
     Unfortunately, GitHub only provides an API endpoint to obtain the [latest
     release] - not the latest tag. Thus, make sure to [create a release] (not
     pre-release) for the latest tag you want to display next to the number of
-    stars and forks.
+    stars and forks. For GitLab, although it is possible to get a [list of tags
+    sorted by update time], the [equivalent API endpoint] is used. So, make sure
+    you also [create a release for GitLab repositories].
 
   [repo_url]: https://www.mkdocs.org/user-guide/configuration/#repo_url
   [latest release]: https://docs.github.com/en/rest/reference/releases#get-the-latest-release
   [create a release]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release
+  [list of tags sorted by update time]: https://docs.gitlab.com/ee/api/tags.html#list-project-repository-tags
+  [equivalent API endpoint]: https://docs.gitlab.com/ee/api/releases/#get-the-latest-release
+  [create a release for GitLab repositories]: https://docs.gitlab.com/ee/user/project/releases/#create-a-release
 
 #### Repository name
 

--- a/src/templates/assets/javascripts/components/source/facts/gitlab/index.ts
+++ b/src/templates/assets/javascripts/components/source/facts/gitlab/index.ts
@@ -67,7 +67,7 @@ export function fetchSourceFactsFromGitLab(
     requestJSON<Release>(`${url}/releases/permalink/latest`)
       .pipe(
         catchError(() => EMPTY), // @todo refactor instant loading
-        map(({tag_name}) => ({
+        map(({ tag_name }) => ({
           version: tag_name
         })),
         defaultIfEmpty({})
@@ -75,14 +75,14 @@ export function fetchSourceFactsFromGitLab(
 
     /* Fetch stars and forks */
     requestJSON<ProjectSchema>(url)
-    .pipe(
-      catchError(() => EMPTY), // @todo refactor instant loading
-      map(({ star_count, forks_count }) => ({
-        stars: star_count,
-        forks: forks_count
-      })),
-      defaultIfEmpty({})
-    )
+      .pipe(
+        catchError(() => EMPTY), // @todo refactor instant loading
+        map(({ star_count, forks_count }) => ({
+          stars: star_count,
+          forks: forks_count
+        })),
+        defaultIfEmpty({})
+      )
   )
     .pipe(
       map(([release, info]) => ({ ...release, ...info }))


### PR DESCRIPTION
Closes #7417 

## Testing

Adapt the `mkdocs.yml` file with the following repositories:

### Without releases

```yaml
# Repository
repo_name: dreamer-labs/libraries/jinja2-ansible-filters
repo_url: https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters
```

<img width="1582" alt="Screenshot 2024-08-03 at 15 34 05" src="https://github.com/user-attachments/assets/ba3f0d88-6751-48f9-8d55-b82501346665">

### With releases

```yaml
# Repository
repo_name: gitlab-org/gitlab
repo_url: https://gitlab.com/gitlab-org/gitlab
```

<img width="1582" alt="Screenshot 2024-08-03 at 15 38 52" src="https://github.com/user-attachments/assets/6d851484-58f1-4bfd-ab4c-920302cf1214">

```yaml
# Repository
repo_name: alelec/gitlab-release
repo_url: https://gitlab.com/alelec/gitlab-release
```

<img width="1582" alt="Screenshot 2024-08-03 at 15 40 08" src="https://github.com/user-attachments/assets/9f63630f-419b-46d9-9b17-9d25d71e9109">

```yaml
# Repository
repo_name: joaommpalmeiro/gaveta
repo_url: https://gitlab.com/joaommpalmeiro/gaveta
```

<img width="1582" alt="Screenshot 2024-08-03 at 15 43 29" src="https://github.com/user-attachments/assets/0a25cb07-a398-487c-bc7b-1fee30e3b17c">