### PR TITLE
Add 2 items to "external-community" in plugins.json

### DIFF
--- a/docs/schema/plugins.json
+++ b/docs/schema/plugins.json
@@ -127,6 +127,12 @@
         },
         {
           "$ref": "https://raw.githubusercontent.com/timvink/mkdocs-table-reader-plugin/master/docs/schema.json"
+        },
+        {
+          "$ref": "https://gitlab.com/frederic-zinelli/pyodide-mkdocs-theme/-/raw/main/pyodide-macros-schema.json"
+        },
+        {
+          "$ref": "https://gitlab.com/frederic-zinelli/mkdocs-addresses/-/raw/main/mkdocs-addresses-schema.json"
         }
       ]
     }


### PR DESCRIPTION
Hello again,

So, the easy part first : adding the links to the schemas of two plugins of mine. (as [previously stated](https://github.com/squidfunk/mkdocs-material/pull/7464#issue-2474271089), the second file is just a stub, for now).