### PR TITLE
Add `edit_uri_template` to docs/schema.json

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -44,6 +44,11 @@
       "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#edit_uri",
       "type": "string"
     },
+    "edit_uri_template": {
+      "title": "More flexible variant of edit_uri",
+      "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#edit_uri_template",
+      "type": "string"
+    },
     "copyright": {
       "title": "Copyright, used in footer",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#copyright-notice",


### PR DESCRIPTION
Adding `edit_uri_template` to the main `docs/schema.json` file.

---

I initially planned to add the `docs/schema/theme.json` changes here, hence the name of the branch, but I realized that, if I add the name of my theme to your schema, it will appear in the suggestions of all your users and you probably won't want that.
This would mean to make the following change:

```yaml
{
  "$schema": "https://json-schema.org/draft-07/schema",
  "title": "Theme configuration",
  "markdownDescription": "https://squidfunk.github.io/mkdocs-material/",
  "type": "object",
  "properties": {
    "name": {
      "title": "Theme name",
      "markdownDescription": "https://www.mkdocs.org/user-guide/configuration/#name",
      "oneOf": [
        {
          "const": "material"
        },
        {
          "const": "pyodide-mkdocs-theme"      # <<< Here
        },
        {
          "type": "null"
        }
      ],
      "default": "material"
    },
...
```

Another possibility could be to accept strings, maybe?
Or maybe keeping the default, but using a pattern to validate both without the user seeing the name of mine?

Or just no changes, I can manage the red line if you're not happy with any of these suggestions.