### PR TITLE
Update material builtin plugins with patterns

### DIFF
--- a/docs/schema/plugins/blog.json
+++ b/docs/schema/plugins/blog.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/blog/",
-      "const": "blog"
+      "type": "string",
+      "pattern": "^(material/)?blog$"
     },
     {
       "type": "object",
-      "properties": {
-        "blog": {
+      "patternProperties": {
+        "^(material/)?blog$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/blog/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/group.json
+++ b/docs/schema/plugins/group.json
@@ -4,8 +4,8 @@
   "oneOf": [
     {
       "type": "object",
-      "properties": {
-        "group": {
+      "patternProperties": {
+        "^(material/)?group$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/group/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/info.json
+++ b/docs/schema/plugins/info.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/info/",
-      "const": "info"
+      "type": "string",
+      "pattern":"^(material/)?info$"
     },
     {
       "type": "object",
-      "properties": {
-        "info": {
+      "patternProperties": {
+        "^(material/)?info$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/info/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/meta.json
+++ b/docs/schema/plugins/meta.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/meta/",
-      "const": "meta"
+      "type": "string",
+      "pattern": "^(material/)?meta$"
     },
     {
       "type": "object",
-      "properties": {
-        "meta": {
+      "patternProperties": {
+        "^(material/)?meta$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/meta/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/offline.json
+++ b/docs/schema/plugins/offline.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/offline/",
-      "const": "offline"
+      "type": "string",
+      "pattern": "^(material/)?offline$"
     },
     {
       "type": "object",
-      "properties": {
-        "offline": {
+      "patternProperties": {
+        "^(material/)?offline$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/offline/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/optimize.json
+++ b/docs/schema/plugins/optimize.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/optimize/",
-      "const": "optimize"
+      "type": "string",
+      "pattern": "^(material/)?optimize$"
     },
     {
       "type": "object",
-      "properties": {
-        "optimize": {
+      "patternProperties": {
+        "^(material/)?optimize$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/optimize/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/privacy.json
+++ b/docs/schema/plugins/privacy.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/privacy/",
-      "const": "privacy"
+      "type": "string",
+      "pattern": "^(material/)?privacy$"
     },
     {
       "type": "object",
-      "properties": {
-        "privacy": {
+      "patternProperties": {
+        "^(material/)?privacy$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/privacy/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/projects.json
+++ b/docs/schema/plugins/projects.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/projects/",
-      "const": "projects"
+      "type": "string",
+      "pattern": "^(material/)?projects$"
     },
     {
       "type": "object",
-      "properties": {
-        "projects": {
+      "patternProperties": {
+        "^(material/)?projects$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/projects/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/search.json
+++ b/docs/schema/plugins/search.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/search/",
-      "const": "search"
+      "type": "string",
+      "pattern": "^(material/)?search$"
     },
     {
       "type": "object",
-      "properties": {
-        "search": {
+      "patternProperties": {
+        "^(material/)?search$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/search/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/social.json
+++ b/docs/schema/plugins/social.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/social/",
-      "const": "social"
+      "type": "string",
+      "pattern": "^(material/)?social$"
     },
     {
       "type": "object",
       "properties": {
-        "social": {
+        "^(material/)?social$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/social/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/tags.json
+++ b/docs/schema/plugins/tags.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/tags/",
-      "const": "tags"
+      "type": "string",
+      "pattern": "^(material/)?tags$"
     },
     {
       "type": "object",
-      "properties": {
-        "tags": {
+      "patternProperties": {
+        "^(material/)?tags$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/tags/",
           "type": "object",
           "properties": {

--- a/docs/schema/plugins/typeset.json
+++ b/docs/schema/plugins/typeset.json
@@ -4,12 +4,13 @@
   "oneOf": [
     {
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/typeset/",
-      "const": "typeset"
+      "type": "string",
+      "pattern": "^(material/)?typeset$"
     },
     {
       "type": "object",
-      "properties": {
-        "typeset": {
+      "patternProperties": {
+        "^(material/)?typeset$": {
           "markdownDescription": "https://squidfunk.github.io/mkdocs-material/plugins/typeset/",
           "type": "object",
           "properties": {


### PR DESCRIPTION
WIP

The `patternProperties` idea was definitely better!

I'm not really fond of the pattern for the strings, though. Maybe two `const` declarations would be better?
I think I should have either used two `const`, or maybe added a default value (if possible. It's my first time building json schema, as you probably guessed...) with the patterns, because for now, the user will loose the suggestions.

Your opinion?