### PR TITLE
Remove pyodide_macros plugin's schema

### DIFF
--- a/docs/schema/plugins.json
+++ b/docs/schema/plugins.json
@@ -129,9 +129,6 @@
           "$ref": "https://raw.githubusercontent.com/timvink/mkdocs-table-reader-plugin/master/docs/schema.json"
         },
         {
-          "$ref": "https://gitlab.com/frederic-zinelli/pyodide-mkdocs-theme/-/raw/main/pyodide-macros-schema.json"
-        },
-        {
           "$ref": "https://gitlab.com/frederic-zinelli/mkdocs-addresses/-/raw/main/mkdocs-addresses-schema.json"
         }
       ]


### PR DESCRIPTION
As discussed [here](https://github.com/squidfunk/mkdocs-material/pull/7467#issuecomment-2299427455), this schema will be introduced in the theme's own schemas "overrides" and since the plugin cannot be used outside of my theme anyway, so this schema has no point in your repo.

(Keeping the other plugin which has some use within other context)

Thanks again for your time and help!