### PR TITLE
Fix issue with author images not filling container height

### DIFF
--- a/src/templates/assets/stylesheets/main/components/_author.scss
+++ b/src/templates/assets/stylesheets/main/components/_author.scss
@@ -43,6 +43,7 @@
     // Author image
     img {
       display: block;
+      height: 100%;
     }
 
     // More authors


### PR DESCRIPTION
Without this some author avatars became squeezed if the avatar image didn't fill the container height.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bccad28a-c2b2-42df-91a6-4540e299a4a3) | ![image](https://github.com/user-attachments/assets/c99433d7-400c-43be-99a5-3f7f88efe740) | 