### PR TITLE
Drop mkdocs-material-extensions from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@
 jinja2~=3.0
 markdown~=3.2
 mkdocs~=1.6
-mkdocs-material-extensions~=1.3
 pygments~=2.16
 pymdown-extensions~=10.2
 


### PR DESCRIPTION
This dependency isn't used anywhere anymore afaict