### PR TITLE
link to subsection on adding an excerpt from blog plugin page

### DIFF
--- a/docs/plugins/blog.md
+++ b/docs/plugins/blog.md
@@ -479,9 +479,9 @@ plugins:
 <!-- md:version 9.2.0 -->
 <!-- md:default `optional` -->
 
-By default, the plugin makes post excerpts optional. When a post doesn't define
-an excerpt, views include the entire post. This setting can be used to make
-post excerpts required:
+By default, the plugin makes [post excerpts](../setup/setting-up-a-blog.md#adding-an-excerpt)
+optional. When a post doesn't define an excerpt, views include the entire post.
+This setting can be used to make post excerpts required:
 
 === "Optional"
 


### PR DESCRIPTION
I just spent way too much time to figure out how to create a blog post excerpt after finding a hint towards that feature at https://squidfunk.github.io/mkdocs-material/plugins/blog/#config.post_excerpt.

If there would have been a link in that section to the subsection on adding an excerpt at https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt, that would have helped me a lot...