### PR TITLE
Added gif and webp to the regex of the images patterns in theme schema

### DIFF
--- a/docs/schema/theme.json
+++ b/docs/schema/theme.json
@@ -314,7 +314,7 @@
     "favicon": {
       "title": "Favicon",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#favicon",
-      "pattern": "\\.(ico|png|svg|jpe?g)$",
+      "pattern": "\\.(ico|png|svg|jpe?g|gif)$",
       "defaultSnippets": [
         {
           "body": "${1:path/to/file}.png"
@@ -324,7 +324,7 @@
     "logo": {
       "title": "Logo",
       "markdownDescription": "https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#logo",
-      "pattern": "\\.(png|svg|jpe?g)$",
+      "pattern": "\\.(png|svg|jpe?g|gif|webp)$",
       "defaultSnippets": [
         {
           "body": "${1:path/to/file}.png"


### PR DESCRIPTION
I believe the schema should allow the `.gif` and `.webp` formats for the images in the Logo and Favicon since they are widely used formats in the web.

For the Logo both of them should work just fine since they are standardized formats and commonly used for this purpose.

Aditionally, for the Favicon, according to [Wikipedia](https://en.wikipedia.org/wiki/Favicon#Image_file_format_support) and its sources, all major browsers have support to the `.gif` format, while Firefox and Opera even allows it to be animated.