### PR TITLE
Docs: add missing vscode tag config for slugify

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -78,7 +78,8 @@ plugins require the `site_url` to be set, so you should always do this.
                 "!relative scalar",
                 "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg",
                 "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
-                "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
+                "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format",
+                "tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify mapping"
               ]
             }
             ```


### PR DESCRIPTION
slugify uses a [custom yaml tag](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#+pymdownx.tabbed.slugify) to customize the slug function. This pr adds the missing config for VSCode in the docs.