### PR TITLE
Add missing `anchors` field in top-level of validation config

### DIFF
--- a/docs/schema/validation.json
+++ b/docs/schema/validation.json
@@ -7,6 +7,7 @@
     "omitted_files": { "$ref": "#/$defs/omitted_files" },
     "not_found": { "$ref": "#/$defs/not_found" },
     "absolute_links": { "$ref": "#/$defs/absolute_links" },
+    "anchors": { "$ref": "#/$defs/anchors" },
     "unrecognized_links": { "$ref": "#/$defs/unrecognized_links" },
     "nav": {
       "title": "validation of navigation",


### PR DESCRIPTION
The `anchors` field can also be set at the top-level of `validation`.

Ref: [mkdocs 1.6 config schema](https://json.schemastore.org/mkdocs-1.6.json)

Related to #7158 