### PR TITLE
Fix: equation compatible with KateX and GitHub

### DIFF
--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -138,14 +138,14 @@ lines:
 
 ``` latex title="block syntax"
 $$
-\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}
+\cos x=\sum_{k=0}^{\infty}\frac{(-1)^k}{(2k)!}x^{2k}
 $$
 ```
 
 <div class="result" markdown>
 
 $$
-\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}
+\cos x=\sum_{k=0}^{\infty}\frac{(-1)^k}{(2k)!}x^{2k}
 $$
 
 </div>


### PR DESCRIPTION
Hi,

With my students we discovered that the former equation is not compatible with GitHub and KateX

**GitHub**

The following macros are not allowed: operatorname

**Katex**
```
auto-render.min.js:1 
 KaTeX auto-render: Failed to parse `
\operatorname{ker} f=\{g\in G:f(g)=e_{H}\}{\mbox{.}}
` with  ParseError: KaTeX parse error: Undefined control sequence: \mbox at position 45: …G:f(g)=e_{H}\}{\̲m̲b̲o̲x̲{.}}
````