### PR TITLE
Fix `og:title` on homepage

### DIFF
--- a/material/plugins/social/plugin.py
+++ b/material/plugins/social/plugin.py
@@ -339,9 +339,11 @@ class SocialPlugin(BasePlugin[SocialConfig]):
         file, _ = os.path.splitext(page.file.src_uri)
 
         # Compute page title
-        title = page.meta.get("title", page.title)
-        if not page.is_homepage:
-            title = f"{title} - {config.site_name}"
+        if page.is_homepage:
+            title = config.site_name
+        else:
+            page_title = page.meta.get("title", page.title)
+            title = f"{page_title} - {config.site_name}"
 
         # Compute page description
         description = config.site_description

--- a/src/plugins/social/plugin.py
+++ b/src/plugins/social/plugin.py
@@ -339,9 +339,11 @@ class SocialPlugin(BasePlugin[SocialConfig]):
         file, _ = os.path.splitext(page.file.src_uri)
 
         # Compute page title
-        title = page.meta.get("title", page.title)
-        if not page.is_homepage:
-            title = f"{title} - {config.site_name}"
+        if page.is_homepage:
+            title = config.site_name
+        else:
+            page_title = page.meta.get("title", page.title)
+            title = f"{page_title} - {config.site_name}"
 
         # Compute page description
         description = config.site_description


### PR DESCRIPTION
Use `config.site_name` instead of `page.title`.

See the following discussion for more details:
https://github.com/squidfunk/mkdocs-material/discussions/7597#discussioncomment-10881713