### PR TITLE
Add more high starred Open Source Projects using Material for Mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,23 +291,29 @@ For detailed installation instructions, configuration options, and a demo, visit
 [Crystal](https://crystal-lang.org/reference/),
 [Electron](https://www.electron.build/),
 [FastAPI](https://fastapi.tiangolo.com/),
+[Freqtrade](https://www.freqtrade.io/en/stable/),
 [GoReleaser](https://goreleaser.com/),
+[Hummingbot](https://hummingbot.org/),
 [Knative](https://knative.dev/docs/),
 [Kubernetes](https://kops.sigs.k8s.io/),
 [kSQL](https://docs.ksqldb.io/),
 [Nokogiri](https://nokogiri.org/),
 [OpenFaaS](https://docs.openfaas.com/),
+[Orchard Core](https://docs.orchardcore.net/en/latest/),
 [Percona](https://docs.percona.com/percona-monitoring-and-management/),
 [Pi-Hole](https://docs.pi-hole.net/),
 [Pydantic](https://pydantic-docs.helpmanual.io/),
 [PyPI](https://docs.pypi.org/),
 [Renovate](https://docs.renovatebot.com/),
+[Supervision](https://supervision.roboflow.com/latest/),
 [Traefik](https://docs.traefik.io/),
 [Trivy](https://aquasecurity.github.io/trivy/),
+[Typer](https://typer.tiangolo.com/),
+[Ultralytics](https://docs.ultralytics.com/),
 [Vapor](https://docs.vapor.codes/),
-[ZeroNet](https://zeronet.io/docs/),
 [WebKit](https://docs.webkit.org/),
-[WTF](https://wtfutil.com/)
+[WTF](https://wtfutil.com/),
+[ZeroNet](https://zeronet.io/docs/)
 
 ## License
 


### PR DESCRIPTION
Hi,

I came across the list of repositories that use M-MkDocs for documentation and thought it would be valuable to add a few more active, highly starred GitHub projects to the list. I personally find these resources very helpful for exploring various implementations of M-MkDocs and getting ideas for documentation in different fields. How they design the site, how they use the features,  … 

Here are some additional repositories to consider:

- [Freqtrade](https://www.freqtrade.io/en/stable/) – 28.4k stars
- [Hummingbot](https://hummingbot.org/) – 8.1k stars
- [Orchard Core](https://docs.orchardcore.net/en/latest/) – 7.4k stars
- [Supervision](https://supervision.roboflow.com/latest/) – 23.6k stars
- [Typer](https://typer.tiangolo.com/) – 15.6k stars
- [Ultralytics](https://docs.ultralytics.com/) – 30.7k stars

*Note: I also adjusted the list to maintain alphabetical order for easier navigation.*

Thank you, and I hope this helps! 🚀