### PR TITLE
Fix a bug where the tooltip style of the logo was missing in instant loading mode

### DIFF
--- a/src/templates/assets/javascripts/integrations/instant/index.ts
+++ b/src/templates/assets/javascripts/integrations/instant/index.ts
@@ -180,7 +180,6 @@ function inject(next: Document): Observable<Document> {
     "[data-md-component=container]",
     "[data-md-component=header-topic]",
     "[data-md-component=outdated]",
-    "[data-md-component=logo]",
     "[data-md-component=skip]",
     ...feature("navigation.tabs.sticky")
       ? ["[data-md-component=tabs]"]


### PR DESCRIPTION
Issue: #7619 

I've tried to fix this, and while I'm not sure if my fix makes sense, it works. If there is a problem, please point it out, thanks.