### PR TITLE
Add github-callouts as callouts markdown extension

### DIFF
--- a/docs/schema/extensions/markdown.json
+++ b/docs/schema/extensions/markdown.json
@@ -32,7 +32,8 @@
       "markdownDescription": "https://github.com/oprypin/markdown-callouts",
       "enum": [
         "markdown.extensions.callouts",
-        "callouts"
+        "callouts",
+        "github-callouts"
       ]
     },
     {


### PR DESCRIPTION
The `markdown-callouts` extension also supports GitHub-style alerts.
Instead of `callouts` it is enabled via `github-callouts`.

See here: https://github.com/oprypin/markdown-callouts/releases/tag/v0.4.0