### PR TITLE
Remove mkdocs-material-extensions from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@
 jinja2~=3.0
 markdown~=3.2
 mkdocs~=1.6
-mkdocs-material-extensions~=1.3
 pygments~=2.16
 pymdown-extensions~=10.2
 


### PR DESCRIPTION
Per mkdocs-material-extensions and the repos code, this is no longer a required dependency and the logic has been put into this repo

Searching the repo, there were no usages of materialx