### PR TITLE
Handle external images for SVGs in privacy plugin

### DIFF
--- a/material/plugins/privacy/plugin.py
+++ b/material/plugins/privacy/plugin.py
@@ -313,12 +313,19 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
                     file = self._queue(url, config)
                     el.set("src", resolve(file))
 
+            # Handle external image in SVG
+            if el.tag == "image":
+                url = urlparse(el.get("href"))
+                if not self._is_excluded(url, initiator):
+                    file = self._queue(url, config)
+                    el.set("href", resolve(file))
+
             # Return element as string
             return self._print(el)
 
         # Find and replace all external asset URLs in current page
         return re.sub(
-            r"<(?:(?:a|link)[^>]+href|(?:script|img)[^>]+src)=['\"]?http[^>]+>",
+            r"<(?:(?:a|link|image)[^>]+href|(?:script|img)[^>]+src)=['\"]?http[^>]+>",
             replace, output, flags = re.I | re.M
         )
 

--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -313,12 +313,19 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
                     file = self._queue(url, config)
                     el.set("src", resolve(file))
 
+            # Handle external image in SVG
+            if el.tag == "image":
+                url = urlparse(el.get("href"))
+                if not self._is_excluded(url, initiator):
+                    file = self._queue(url, config)
+                    el.set("href", resolve(file))
+
             # Return element as string
             return self._print(el)
 
         # Find and replace all external asset URLs in current page
         return re.sub(
-            r"<(?:(?:a|link)[^>]+href|(?:script|img)[^>]+src)=['\"]?http[^>]+>",
+            r"<(?:(?:a|link|image)[^>]+href|(?:script|img)[^>]+src)=['\"]?http[^>]+>",
             replace, output, flags = re.I | re.M
         )
 


### PR DESCRIPTION
Some users (like us) might have quirks around serving SVG images/logos, so we include them from remote locations, e.g. for licensing reasons etc.

Since we can't include them locally but some users would like to have offline builds, this PR adds support for loading remote images from SVGs in the privacy plugin. WDYT? See also some references below :bow:  

* SVG `<image>` reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image
* example site with external SVG: https://opensource.siemens.com/
* regex match against real example: https://regex101.com/r/3Dp1TP/1

:hammer_and_wrench: with :heart: at Siemens 