### PR TITLE
Handle quoted external CSS URLs in privacy plugin

### DIFF
--- a/material/plugins/privacy/plugin.py
+++ b/material/plugins/privacy/plugin.py
@@ -64,8 +64,8 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
         # Initialize collections of external assets
         self.assets = Files([])
         self.assets_expr_map = {
-            ".css": r"url\((\s*http?[^)]+)\)",
-            ".js": r"[\"'](http[^\"']+\.(?:css|js(?:on)?))[\"']",
+            ".css": r"url\(\s*([\"']?)(?P<url>http?[^)'\"]+)\1\s*\)",
+            ".js": r"[\"'](?P<url>http[^\"']+\.(?:css|js(?:on)?))[\"']",
             **self.config.assets_expr_map
         }
 
@@ -271,7 +271,8 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
         # Find and extract all external asset URLs
         expr = re.compile(self.assets_expr_map[extension], flags = re.I | re.M)
         with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
-            return [urlparse(url) for url in re.findall(expr, f.read())]
+            results = re.finditer(expr, f.read())
+            return [urlparse(result.group("url")) for result in results]
 
     # Parse template or page HTML and find all external links that need to be
     # replaced. Many of the assets should already be downloaded earlier, i.e.,

--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -64,8 +64,8 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
         # Initialize collections of external assets
         self.assets = Files([])
         self.assets_expr_map = {
-            ".css": r"url\((\s*http?[^)]+)\)",
-            ".js": r"[\"'](http[^\"']+\.(?:css|js(?:on)?))[\"']",
+            ".css": r"url\(\s*([\"']?)(?P<url>http?[^)'\"]+)\1\s*\)",
+            ".js": r"[\"'](?P<url>http[^\"']+\.(?:css|js(?:on)?))[\"']",
             **self.config.assets_expr_map
         }
 
@@ -271,7 +271,8 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
         # Find and extract all external asset URLs
         expr = re.compile(self.assets_expr_map[extension], flags = re.I | re.M)
         with open(initiator.abs_src_path, encoding = "utf-8-sig") as f:
-            return [urlparse(url) for url in re.findall(expr, f.read())]
+            results = re.finditer(expr, f.read())
+            return [urlparse(result.group("url")) for result in results]
 
     # Parse template or page HTML and find all external links that need to be
     # replaced. Many of the assets should already be downloaded earlier, i.e.,


### PR DESCRIPTION
This one is very similar to https://github.com/squidfunk/mkdocs-material/pull/7650, but keeping it separate as it covers different files. I was wondering why our external woff/woff2 files weren't being downloaded and noticed this issue.

* CSS map regex test: https://regex101.com/r/UG2Bv0/1
* JS map regex test: https://regex101.com/r/zPRrTp/1

The back-reference helps get the exact URL and to avoid more false positives on invalid quoting, though there are still some - but still better than just expecting quotes on either side IMO. Also, this is probably caught by CSS linters and build system anyway.

I had to introduce named groups to handle this, hence the slight change in logic as `findall` doesn't support named groups. But IMO this might also help in the future if more edge cases show up.

🛠️ with ❤️ at Siemens