### PR TITLE
Add safety net for failing github action

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -50,6 +50,7 @@ contents:
               restore-keys: |
                 mkdocs-material-
           - run: pip install mkdocs-material # (4)!
+          - run: mkdir overrides # (5)!
           - run: mkdocs gh-deploy --force
     ```
 
@@ -69,6 +70,8 @@ contents:
 
     4.  This is the place to install further [MkDocs plugins] or Markdown
         extensions with `pip` to be used during the build:
+
+    5. You can safetly remove this if you have added files to your overrides directory or if your `mkdocs.yml` doesn't contain `custom_dir: overrides`.
 
         ``` sh
         pip install \


### PR DESCRIPTION
If someone adds the code block in the customization docs  

https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure

And if they use the cli command provided their github action will fail.

https://github.com/Nicolasara/IIT-Docs/actions/runs/11831606702/job/32967030933