### PR TITLE
Updated link for Material Design Icons

### DIFF
--- a/docs/reference/icons-emojis.md
+++ b/docs/reference/icons-emojis.md
@@ -66,7 +66,7 @@ See additional configuration options:
 - [Emoji]
 - [Emoji with custom icons]
 
-  [Material Design]: https://materialdesignicons.com/
+  [Material Design]: https://pictogrammers.com/library/mdi/
   [FontAwesome]: https://fontawesome.com/search?m=free
   [Octicons]: https://octicons.github.com/
   [Simple Icons]: https://simpleicons.org/


### PR DESCRIPTION
The web link for https://materialdesignicons.com/ has been updated and now directs users to https://pictogrammers.com/library/mdi/

Updating the documentation to reflect the new link