### PR TITLE
Normalize datetime values to UTC in blog plugin

### DIFF
--- a/material/plugins/blog/structure/options.py
+++ b/material/plugins/blog/structure/options.py
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from mkdocs.config.base import BaseConfigOption, Config, ValidationError
 from typing import Dict
 
@@ -69,9 +69,9 @@ class PostDate(BaseConfigOption[DateDict]):
                 continue
 
             # Handle date - we set 00:00:00 as the default time, if the author
-            # only supplied a date, and convert it to datetime
+            # only supplied a date, and convert it to datetime in UTC
             if isinstance(value, date):
-                config[key_name][key] = datetime.combine(value, time())
+                config[key_name][key] = datetime.combine(value, time()).replace(tzinfo=timezone.utc)
 
         # Initialize date dictionary
         config[key_name] = DateDict(config[key_name])

--- a/src/plugins/blog/structure/options.py
+++ b/src/plugins/blog/structure/options.py
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from mkdocs.config.base import BaseConfigOption, Config, ValidationError
 from typing import Dict
 
@@ -69,9 +69,9 @@ class PostDate(BaseConfigOption[DateDict]):
                 continue
 
             # Handle date - we set 00:00:00 as the default time, if the author
-            # only supplied a date, and convert it to datetime
+            # only supplied a date, and convert it to datetime in UTC
             if isinstance(value, date):
-                config[key_name][key] = datetime.combine(value, time())
+                config[key_name][key] = datetime.combine(value, time()).replace(tzinfo=timezone.utc)
 
         # Initialize date dictionary
         config[key_name] = DateDict(config[key_name])


### PR DESCRIPTION
Fixes #7705

Normalize datetime values to UTC in blog plugin to make the datetime object offset-aware.

* Import `timezone` from `datetime` in `material/plugins/blog/structure/options.py`.
* Modify `pre_validation` method to set `tzinfo=timezone.utc` for datetime values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/squidfunk/mkdocs-material/pull/7708?shareId=e7d671a5-932a-402a-9dc2-d5733a8b5524).