### PR TITLE
Set timezone to UTC when draft_if_future_date: true Fixes #7748

### DIFF
--- a/material/plugins/blog/plugin.py
+++ b/material/plugins/blog/plugin.py
@@ -26,7 +26,7 @@ import posixpath
 import yaml
 
 from babel.dates import format_date, format_datetime
-from datetime import datetime
+from datetime import datetime, timezone
 from jinja2 import pass_context
 from jinja2.runtime import Context
 from mkdocs.config.defaults import MkDocsConfig
@@ -370,7 +370,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
         # and must be explicitly enabled by the author.
         if not isinstance(post.config.draft, bool):
             if self.config.draft_if_future_date:
-                return post.config.date.created > datetime.now()
+                return post.config.date.created > datetime.now().replace(tzinfo=timezone.utc)
 
         # Post might be a draft
         return bool(post.config.draft)

--- a/material/plugins/blog/plugin.py
+++ b/material/plugins/blog/plugin.py
@@ -370,7 +370,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
         # and must be explicitly enabled by the author.
         if not isinstance(post.config.draft, bool):
             if self.config.draft_if_future_date:
-                return post.config.date.created > datetime.now().replace(tzinfo=timezone.utc)
+                return post.config.date.created > datetime.now(timezone.utc)
 
         # Post might be a draft
         return bool(post.config.draft)

--- a/src/plugins/blog/plugin.py
+++ b/src/plugins/blog/plugin.py
@@ -26,7 +26,7 @@ import posixpath
 import yaml
 
 from babel.dates import format_date, format_datetime
-from datetime import datetime
+from datetime import datetime, timezone
 from jinja2 import pass_context
 from jinja2.runtime import Context
 from mkdocs.config.defaults import MkDocsConfig
@@ -370,7 +370,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
         # and must be explicitly enabled by the author.
         if not isinstance(post.config.draft, bool):
             if self.config.draft_if_future_date:
-                return post.config.date.created > datetime.now()
+                return post.config.date.created > datetime.now().replace(tzinfo=timezone.utc)
 
         # Post might be a draft
         return bool(post.config.draft)

--- a/src/plugins/blog/plugin.py
+++ b/src/plugins/blog/plugin.py
@@ -370,7 +370,7 @@ class BlogPlugin(BasePlugin[BlogConfig]):
         # and must be explicitly enabled by the author.
         if not isinstance(post.config.draft, bool):
             if self.config.draft_if_future_date:
-                return post.config.date.created > datetime.now().replace(tzinfo=timezone.utc)
+                return post.config.date.created > datetime.now(timezone.utc)
 
         # Post might be a draft
         return bool(post.config.draft)


### PR DESCRIPTION
I've tested this with the repro in #7748 and also done a grep for other instances of `datetime` in the plugin.