### PR TITLE
Google Analytics dashboard: 'Configure' changed to 'Admin'

### DIFF
--- a/docs/setup/setting-up-site-analytics.md
+++ b/docs/setup/setting-up-site-analytics.md
@@ -98,8 +98,8 @@ integrated with the [cookie consent] feature[^2].
 
     1.  Go to your Google Analytics __dashboard__
 
-    2.  Go to the __configure__ page on the left hand menu, then select
-        __custom definitions__
+    2.  Go to the __Admin__ page on the left hand menu (at the bottom), then select
+        __custom definitions__ in the __Data display__ card
 
     3.  Click the __custom metrics__ tab and then __create custom metrics__,
         enter the following values:

--- a/docs/setup/setting-up-site-analytics.md
+++ b/docs/setup/setting-up-site-analytics.md
@@ -99,7 +99,7 @@ integrated with the [cookie consent] feature[^2].
     1.  Go to your Google Analytics __dashboard__
 
     2.  Go to the __Admin__ page on the left hand menu (at the bottom), then select
-        __custom definitions__ in the __Data display__ card
+        __custom definitions__ on the __Data display__ card
 
     3.  Click the __custom metrics__ tab and then __create custom metrics__,
         enter the following values:


### PR DESCRIPTION
Google has updated its Analytics dashboard, replacing the "Configure" menu item with "Admin".

Page: https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful

Also directing users to the "Data display" card to assist them in finding the "Custom definitions" option.

![image](https://github.com/user-attachments/assets/e36c51f0-c314-42b9-ba88-6471b6889736)
