### PR TITLE
docs(publish gitlab pages): Update publish comment on gitlab

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -205,7 +205,9 @@ Now, when a new commit is pushed to the [default branch] (typically `master` or
 `main`), the static site is automatically built and deployed. Commit and push
 the file to your repository to see the workflow in action.
 
-Your documentation should shortly appear at `<username>.gitlab.io/<repository>`.
+Your documentation is not published under `<username>.gitlab.io/<repository>` by default. So that you can access your documentation at `<username>.gitlab.io/<repository>`, you can view the blog [^1] from a community member.
+
+[^1]: Blog post by @niclasheinz [here](https://nh.hobbilies.net/blog/2024/12/deploy-your-material-for-mkdocs-site-on-gitlab-pages-without-unique-domains/)
 
 ## Other
 

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -205,10 +205,18 @@ Now, when a new commit is pushed to the [default branch] (typically `master` or
 `main`), the static site is automatically built and deployed. Commit and push
 the file to your repository to see the workflow in action.
 
-Your documentation is not published under `<username>.gitlab.io/<repository>` by default. So that you can access your documentation at `<username>.gitlab.io/<repository>`, you can view the blog [^1] from a community member.
+Your documentation is not published under `<username>.gitlab.io/<repository>` by default since **GitLab 17.4** [^1]. However, if you prefer a cleaner URL structure, such as `<username>.gitlab.io/<repository>`, you need to adjust your configuration.
 
-[^1]: Blog post by @niclasheinz [here](https://nh.hobbilies.net/blog/2024/12/deploy-your-material-for-mkdocs-site-on-gitlab-pages-without-unique-domains/)
+To switch from a unique domain to the traditional URL structure, follow these steps:
 
+1.  Locate Your Repository
+2.    Go to **Settings > Pages** in the repository menu.
+3.    In the **Unique domain settings** section, **uncheck** the box labeled **Use unique domain**.
+4.    Click **Save changes** to apply the update.
+
+Now you can reach your documentation under `<username>.gitlab.io/<repository>`. 
+
+[^1]: [Release notes for Gitlab 17.4](https://about.gitlab.com/releases/2024/09/19/gitlab-17-4-released/)
 ## Other
 
 Since we can't cover all possible platforms, we rely on community contributed

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -205,18 +205,24 @@ Now, when a new commit is pushed to the [default branch] (typically `master` or
 `main`), the static site is automatically built and deployed. Commit and push
 the file to your repository to see the workflow in action.
 
-Your documentation is not published under `<username>.gitlab.io/<repository>` by default since **GitLab 17.4** [^1]. However, if you prefer a cleaner URL structure, such as `<username>.gitlab.io/<repository>`, you need to adjust your configuration.
+Your documentation is not published under `<username>.gitlab.io/<repository>`
+by default since **GitLab 17.4** [^1]. However, if you prefer a cleaner URL 
+structure, such as `<username>.gitlab.io/<repository>`, you need to adjust
+your configuration.
 
-To switch from a unique domain to the traditional URL structure, follow these steps:
+To switch from a unique domain to the traditional URL structure, follow
+these steps:
 
 1.  Locate Your Repository
-2.    Go to **Settings > Pages** in the repository menu.
-3.    In the **Unique domain settings** section, **uncheck** the box labeled **Use unique domain**.
-4.    Click **Save changes** to apply the update.
+2.  Go to **Settings › Pages** in the repository menu.
+3.  In the **Unique domain settings** section, **uncheck** the box labeled
+4.  **Use unique domain**.
+5.  Click **Save changes** to apply the update.
 
 Now you can reach your documentation under `<username>.gitlab.io/<repository>`. 
 
 [^1]: [Release notes for Gitlab 17.4](https://about.gitlab.com/releases/2024/09/19/gitlab-17-4-released/)
+
 ## Other
 
 Since we can't cover all possible platforms, we rely on community contributed


### PR DESCRIPTION
I have noticed that since a few GitLab releases, unique domains are used by default for GitLab Pages deployments, for example `https://website-5c034c.gitlab.io/` instead of `niclasheinz.gitlab.io/website`. I have written a small blog post that helps users to use the desired domain.