### PR TITLE
Add repo href to source facts cache key

### DIFF
--- a/src/templates/assets/javascripts/components/source/_/index.ts
+++ b/src/templates/assets/javascripts/components/source/_/index.ts
@@ -85,7 +85,8 @@ export function watchSource(
   el: HTMLAnchorElement
 ): Observable<Source> {
   return fetch$ ||= defer(() => {
-    const cached = __md_get<SourceFacts>("__source", sessionStorage)
+    const cacheKey = `__source/${el.href}`
+    const cached = __md_get<SourceFacts>(cacheKey, sessionStorage)
     if (cached) {
       return of(cached)
     } else {
@@ -101,7 +102,7 @@ export function watchSource(
       /* Fetch repository facts */
       return fetchSourceFacts(el.href)
         .pipe(
-          tap(facts => __md_set("__source", facts, sessionStorage))
+          tap(facts => __md_set(cacheKey, facts, sessionStorage))
         )
     }
   })


### PR DESCRIPTION
I propose extending the `__source` cache key used for saving repo source facts in `watchSource` to include the `.href` of the associated anchor element.

This is useful for cases where we are overriding/updating the `repo_url` link between different pages on the same site (useful for mono/multi-repo scenarios). As it currently stands, the cache will always hit if any repo facts have ever been queried and gives no consideration for caching per-distinct repo - resulting in the return of facts for the first rendered Source component for all others.

I had also considered using `_md_hash()` on the `.href` to reduce noise in the cache key, but I think it's best that @squidfunk make any final calls on what/how to make the cache value distinct - open to suggestions.

Potential side-effects:

- Existing facts cached under the generic `__source` are not removed or modified
- The change would force a one-time re-query for facts in existing sites once updated