### PR TITLE
Correct Outdated Twemoji Link

### DIFF
--- a/docs/contributing/adding-translations.md
+++ b/docs/contributing/adding-translations.md
@@ -98,7 +98,7 @@ adding the shortcode for the country flag to this field. Go to our
     translations for a subdivision, please choose the most appropriate available
     flag.
 
-  [Twemoji]: https://twemoji.twitter.com/
+  [Twemoji]: https://github.com/twitter/twemoji
   [emoji search]: ../reference/icons-emojis.md#search
 
 > __Why this might be helpful__: adding a country flag next to the country name


### PR DESCRIPTION
A minor issue where the existing link directed to the outdated Twitter/X URL. Updated it to point to the official Twemoji repository on GitHub to ensure consistency with the corresponding links across other pages.