### PR TITLE
Fix embedded mermaid css to fix class diagram arrow heads

### DIFF
--- a/src/templates/assets/javascripts/components/content/mermaid/index.css
+++ b/src/templates/assets/javascripts/components/content/mermaid/index.css
@@ -171,19 +171,15 @@ g.classGroup text {
 }
 
 /* Class extension, composition and dependency marker */
-defs #classDiagram-extensionStart,
-defs #classDiagram-extensionEnd,
-defs #classDiagram-compositionStart,
-defs #classDiagram-compositionEnd,
-defs #classDiagram-dependencyStart,
-defs #classDiagram-dependencyEnd {
+defs marker.marker.extension.class path,
+defs marker.marker.composition.class path ,
+defs marker.marker.dependency.class path  {
   fill: var(--md-mermaid-edge-color) !important;
   stroke: var(--md-mermaid-edge-color) !important;
 }
 
 /* Class aggregation marker */
-defs #classDiagram-aggregationStart,
-defs #classDiagram-aggregationEnd {
+defs marker.marker.aggregation.class path  {
   fill: var(--md-mermaid-label-bg-color) !important;
   stroke: var(--md-mermaid-edge-color) !important;
 }


### PR DESCRIPTION
Originally used id based selecters, which doesn't work as the ids are made unique. Replacing them with class based selectors fixes this.

This original css tries to target this id, but as you can see it's prepended with `__mermaid_3_` <img width="995" alt="path marker id" src="https://github.com/user-attachments/assets/442d7f0b-da73-4972-9b19-0a868b1bb8dd" />

The new css directly targets the marker: <img width="1016" alt="marker selected" src="https://github.com/user-attachments/assets/663d3e0c-3031-4319-b264-08f186787200" />

Using 'waybackmachine bisect' I can see it got introduced between:

- Issue not present: [Nov 21 2023](https://web.archive.org/web/20231121182633/https://squidfunk.github.io/mkdocs-material/reference/diagrams/#using-class-diagrams)

- Issue Appears: [Nov 27 2023](https://web.archive.org/web/20231127170019/https://squidfunk.github.io/mkdocs-material/reference/diagrams/#using-class-diagrams)

which leads to [these commits](https://github.com/squidfunk/mkdocs-material/commits/master/?since=2023-11-21&until=2023-11-27), the most likely culprit is the upgrade to mermaid 10.6.1 

Before: 
<img width="448" alt="before" src="https://github.com/user-attachments/assets/81131c7e-17fc-41ca-9b10-9539b43bdbc8" />

After:
 <img width="440" alt="after" src="https://github.com/user-attachments/assets/f1d1a02d-4261-4590-afa0-d0512cef6abf" />

Tested on latest safari and chrome on macOS, latest edge and chrome on windows 11.
