### PR TITLE
Fix #8012 - Privacy plugin crashes on HTTP errors

### DIFF
--- a/material/plugins/privacy/plugin.py
+++ b/material/plugins/privacy/plugin.py
@@ -430,7 +430,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
                 )
                 res.raise_for_status()
             except Exception as error:  # this could be a ConnectionError or an HTTPError
-                log.error(f"Could not retrieve {file.url}: {error}")
+                log.warning(f"Could not retrieve {file.url}: {error}")
                 return False
 
             # Compute expected file extension and append if missing

--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -430,7 +430,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
                 )
                 res.raise_for_status()
             except Exception as error:  # this could be a ConnectionError or an HTTPError
-                log.error(f"Could not retrieve {file.url}: {error}")
+                log.warning(f"Could not retrieve {file.url}: {error}")
                 return False
 
             # Compute expected file extension and append if missing


### PR DESCRIPTION
I tested manually this change and it works fine for my case:
```
$ mkdocs serve --watch-theme --open
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Downloading external file: https://unpkg.com/mermaid@11/dist/mermaid.min.js
INFO    -  Downloading external file: https://api.star-history.com/svg?repos=py-pdf/fpdf2
ERROR   -  Could not retrieve https://api.star-history.com/svg?repos=py-pdf/fpdf2: 503 Server Error: Service Unavailable for
           url: https://api.star-history.com/svg?repos=py-pdf/fpdf2
```

I also tested providing an non-resolvable URL as image, and one that only answers after a long delay, and those cases are well handled now.
There is a test file you can use:
```markdown
![](https://api.star-history.com/svg?repos=py-pdf/fpdf2) <!-- Triggers a HTTP 5XX -->

![](https://this-does-not-exist.com) <!-- Triggers a NameResolutionError -->

![](https://httpbin.org/delay/10) <!-- Triggers a timeout -->
```

I ran `black` on the source files, which caused several unrelated changes.