### PR TITLE
Support fallback from `regex` package to standard `re` module

### DIFF
--- a/docs/blog/posts/chinese-search-support.md
+++ b/docs/blog/posts/chinese-search-support.md
@@ -41,12 +41,12 @@ search plugin in a few minutes._
 ## Configuration
 
 Chinese language support for Material for MkDocs is provided by [jieba], an
-excellent Chinese text segmentation library. If [jieba] is installed, the
-built-in search plugin automatically detects Chinese characters and runs them
-through the segmenter. You can install [jieba] with:
+excellent Chinese text segmentation library. If [jieba] and [regex] packages
+are installed, the built-in search plugin automatically detects Chinese
+characters and runs them through the segmenter. You can install them with:
 
 ```
-pip install jieba
+pip install jieba regex
 ```
 
 The next step is only required if you specified the [`separator`][separator]
@@ -77,6 +77,7 @@ proficient in Chinese (yet?). If you find a bug or think something can be
 improved, please [open an issue].
 
   [jieba]: https://pypi.org/project/jieba/
+  [regex]: https://pypi.org/project/regex/
   [zero-width whitespace]: https://en.wikipedia.org/wiki/Zero-width_space
   [separator]: ../../plugins/search.md#config.separator
   [q=支持]: ?q=支持

--- a/docs/plugins/search.md
+++ b/docs/plugins/search.md
@@ -301,13 +301,15 @@ The following pipeline functions can be used:
 ### Segmentation
 
 The plugin supports text segmentation of Chinese via [jieba], a popular
-Chinese text segmentation library. Other languages like Japanese and Korean are
+Chinese text segmentation library, combined with extended regular expression
+support provided by [regex]. Other languages like Japanese and Korean are
 currently segmented on the client side, but we're considering to move this
 functionality into the plugin in the future.
 
 The following settings are available for segmentation:
 
   [jieba]: https://pypi.org/project/jieba/
+  [regex]: https://pypi.org/project/regex/
 
 ---
 

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 import platform
-import regex
 import requests
 import site
 import sys
@@ -40,6 +39,11 @@ from zipfile import ZipFile, ZIP_DEFLATED
 
 from .config import InfoConfig
 from .patterns import get_exclusion_patterns
+
+try:
+    import regex as re
+except ImportError:
+    import re
 
 # -----------------------------------------------------------------------------
 # Classes
@@ -410,7 +414,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         pattern_path = _resolve_pattern(abspath, return_path = True)
 
         for pattern in self.exclusion_patterns:
-            if regex.search(pattern, pattern_path):
+            if re.search(pattern, pattern_path):
                 log.debug(f"Excluded pattern '{pattern}': {abspath}")
                 self.excluded_entries.append(f"{pattern} - {pattern_path}")
                 return True

--- a/material/plugins/search/plugin.py
+++ b/material/plugins/search/plugin.py
@@ -21,7 +21,6 @@
 import json
 import logging
 import os
-import regex as re
 
 from html import escape
 from html.parser import HTMLParser
@@ -33,6 +32,14 @@ from .config import SearchConfig
 try:
     import jieba
 except ImportError:
+    jieba = None
+
+try:
+    import regex as re
+except ImportError:
+    import re
+
+    # jieba support requires `\p{IsHan}` that is not supported by `re`
     jieba = None
 
 # -----------------------------------------------------------------------------

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 import platform
-import regex
 import requests
 import site
 import sys
@@ -40,6 +39,11 @@ from zipfile import ZipFile, ZIP_DEFLATED
 
 from .config import InfoConfig
 from .patterns import get_exclusion_patterns
+
+try:
+    import regex as re
+except ImportError:
+    import re
 
 # -----------------------------------------------------------------------------
 # Classes
@@ -410,7 +414,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         pattern_path = _resolve_pattern(abspath, return_path = True)
 
         for pattern in self.exclusion_patterns:
-            if regex.search(pattern, pattern_path):
+            if re.search(pattern, pattern_path):
                 log.debug(f"Excluded pattern '{pattern}': {abspath}")
                 self.excluded_entries.append(f"{pattern} - {pattern_path}")
                 return True

--- a/src/plugins/search/plugin.py
+++ b/src/plugins/search/plugin.py
@@ -21,7 +21,6 @@
 import json
 import logging
 import os
-import regex as re
 
 from html import escape
 from html.parser import HTMLParser
@@ -33,6 +32,14 @@ from .config import SearchConfig
 try:
     import jieba
 except ImportError:
+    jieba = None
+
+try:
+    import regex as re
+except ImportError:
+    import re
+
+    # jieba support requires `\p{IsHan}` that is not supported by `re`
     jieba = None
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Support using the standard Python library `re` module if the `regex` package is not available.  This improves the compatibility of plugins with environments where `regex` is not or cannot be installed, in particular when using PyPy.

The `regex` package is heavily relying on implementation details of CPython and has a significant technical debt, that is preventing the author from making the code more portable.  At the same time, the standard library `re` module provides most of the functionality used by mkdocs-material.

The `regex` package continues being used if it is installed in the environment, and the change should therefore remain backwards compatible.  When it is not installed, the `info` and `search` plugins will use the standard library `re` module, therefore it becomes possible to use them without having `regex` installed.  However, the Chinese search support via `jieba` requires `regex`, and therefore will be disabled if the fallback is used — much like it is currently disabled if `jieba` is not installed.

I could not find any formal declaration of `regex` or `jieba` requirements.  However, I did update the documentation to hint on the necessity of having both `jieba` and `regex` installed for the Chinese search to work.  I have also updated the old blog post — if that is undesirable, I can revert it.

Fixes #8031