### PR TITLE
Remove Regex from search

### DIFF
--- a/material/plugins/search/plugin.py
+++ b/material/plugins/search/plugin.py
@@ -21,7 +21,8 @@
 import json
 import logging
 import os
-import regex as re
+import re
+from backrefs import bre
 
 from html import escape
 from html.parser import HTMLParser
@@ -285,7 +286,7 @@ class SearchIndex:
 
     # Find and segment Chinese characters in string
     def _segment_chinese(self, data):
-        expr = re.compile(r"(\p{IsHan}+)", re.UNICODE)
+        expr = bre.compile(r"(\p{script: Han}+)", bre.UNICODE)
 
         # Replace callback
         def replace(match):

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ pymdown-extensions~=10.2
 babel~=2.10
 colorama~=0.4
 paginate~=0.5
-regex>=2022.4
+backrefs~=5.8
 requests~=2.26

--- a/src/plugins/search/plugin.py
+++ b/src/plugins/search/plugin.py
@@ -21,7 +21,8 @@
 import json
 import logging
 import os
-import regex as re
+import re
+import backrefs as bre
 
 from html import escape
 from html.parser import HTMLParser
@@ -285,7 +286,7 @@ class SearchIndex:
 
     # Find and segment Chinese characters in string
     def _segment_chinese(self, data):
-        expr = re.compile(r"(\p{IsHan}+)", re.UNICODE)
+        expr = bre.compile(r"(\p{script: Han}+)", bre.UNICODE)
 
         # Replace callback
         def replace(match):


### PR DESCRIPTION
Use Re in all places in the search plugin except where Unicode properties are desired (checking for Chinese chars). Use Backrefs' `bre` to check for Unicode properties. To minimize any differences, explicitly use `script` as Backrefs uses `script_extensions` (or `scx`) by default with `Is*` properties.

Resolves #8032 