### PR TITLE
escape aria-labels to prevent breaking HTML markup

### DIFF
--- a/src/templates/partials/toc-item.html
+++ b/src/templates/partials/toc-item.html
@@ -30,7 +30,7 @@
 
   <!-- Table of contents list -->
   {% if toc_item.children %}
-    <nav class="md-nav" aria-label="{{ toc_item.title | striptags }}">
+    <nav class="md-nav" aria-label="{{ toc_item.title | striptags | e }}">
       <ul class="md-nav__list">
         {% for toc_item in toc_item.children %}
           {% include "partials/toc-item.html" %}

--- a/src/templates/partials/toc.html
+++ b/src/templates/partials/toc.html
@@ -27,7 +27,7 @@
 {% endif %}
 
 <!-- Table of contents -->
-<nav class="md-nav md-nav--secondary" aria-label="{{ title }}">
+<nav class="md-nav md-nav--secondary" aria-label="{{ title | e }}">
   {% set toc = page.toc %}
 
   <!--


### PR DESCRIPTION
- Bug fix for #8052 
- The TOC titles are not sanitized, causing issues with characters such as double quotes when rendering the HTML. I verified this by adding a `print(toc_tokens)` in `get_toc` of mkdocs.

Let me know if you require a formal reproduction (something I didn't provide in #8052).