### PR TITLE
Fix backref import

### DIFF
--- a/material/plugins/search/plugin.py
+++ b/material/plugins/search/plugin.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 import re
-import backrefs as bre
+from backrefs import bre
 
 from html import escape
 from html.parser import HTMLParser

--- a/src/plugins/search/plugin.py
+++ b/src/plugins/search/plugin.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 import re
-import backrefs as bre
+from backrefs import bre
 
 from html import escape
 from html.parser import HTMLParser


### PR DESCRIPTION
When originally committed, the copied search plugin had the correct import, but the source was mistakenly incorrect. On an update since, the copy was updated with the source and broke the plugin. Both src and the copy now properly use `from backrefs import bre`.

Fixes #8056 