### PR TITLE
Improve caching in GitLab Pipeline

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -181,11 +181,16 @@ contents:
       script:
         - pip install mkdocs-material
         - mkdocs build --site-dir public
+      cache:
+        key: ${CI_COMMIT_REF_SLUG}
+        paths:
+          - .cache/
       artifacts:
         paths:
           - public
       rules:
         - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+
     ```
 
 === "Insiders"
@@ -197,6 +202,10 @@ contents:
       script: # (1)!
         - pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
         - mkdocs build --site-dir public
+      cache:
+        key: ${CI_COMMIT_REF_SLUG}
+        paths:
+          - .cache/
       artifacts:
         paths:
           - public

--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -184,7 +184,7 @@ contents:
       cache:
         key: ${CI_COMMIT_REF_SLUG}
         paths:
-          - .cache/
+          - .cache/ # (1)!
       artifacts:
         paths:
           - public
@@ -192,6 +192,9 @@ contents:
         - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 
     ```
+
+    1.  Some Material for MkDocs plugins use [caching] to speed up repeated
+        builds, and store the results in the `.cache` directory.
 
 === "Insiders"
 
@@ -205,7 +208,7 @@ contents:
       cache:
         key: ${CI_COMMIT_REF_SLUG}
         paths:
-          - .cache/
+          - .cache/ # (2)!
       artifacts:
         paths:
           - public
@@ -216,6 +219,9 @@ contents:
     1.  Remember to set the `GH_TOKEN` repository secret to the value of your
         [personal access token] when deploying [Insiders], which can be done
         using [masked custom variables].
+
+    2.  Some Material for MkDocs plugins use [caching] to speed up repeated
+        builds, and store the results in the `.cache` directory.
 
 Now, when a new commit is pushed to the [default branch] (typically `master` or
 `main`), the static site is automatically built and deployed. Commit and push


### PR DESCRIPTION
Based on #7990 I have improved the caching in GitLab pipelines. Now the `.cache` folder is stored in the cache.