### PR TITLE
URLencode custom SVGs

### DIFF
--- a/material/templates/partials/icons.html
+++ b/material/templates/partials/icons.html
@@ -8,7 +8,7 @@
     {% set _ = style.append(
       "--md-admonition-icon--" ~ type ~ ":" ~
       "url('data:image/svg+xml;charset=utf-8," ~
-        icon | replace("\n", "") ~
+        icon | replace("\n", "") | urlencode ~
       "');"
     ) %}
   {% endfor %}
@@ -21,7 +21,7 @@
   {% set _ = style.append(
     "--md-annotation-icon:" ~
     "url('data:image/svg+xml;charset=utf-8," ~
-      icon | replace("\n", "") ~
+      icon | replace("\n", "") | urlencode ~
     "');"
   ) %}
   {% set _ = style.append("}\x3c/style\x3e") %}
@@ -38,7 +38,7 @@
       ".md-tag" ~ modifier ~ "{" ~
         "--md-tag-icon:" ~
         "url('data:image/svg+xml;charset=utf-8," ~
-          icon | replace("\n", "") ~
+          icon | replace("\n", "") | urlencode ~
         "');" ~
       "}"
     ) %}

--- a/src/templates/partials/icons.html
+++ b/src/templates/partials/icons.html
@@ -28,7 +28,7 @@
     {% set _ = style.append(
       "--md-admonition-icon--" ~ type ~ ":" ~
       "url('data:image/svg+xml;charset=utf-8," ~
-        icon | replace("\n", "") ~
+        icon | replace("\n", "") | urlencode ~
       "');"
     ) %}
   {% endfor %}
@@ -43,7 +43,7 @@
   {% set _ = style.append(
     "--md-annotation-icon:" ~
     "url('data:image/svg+xml;charset=utf-8," ~
-      icon | replace("\n", "") ~
+      icon | replace("\n", "") | urlencode ~
     "');"
   ) %}
   {% set _ = style.append("}\x3c/style\x3e") %}
@@ -62,7 +62,7 @@
       ".md-tag" ~ modifier ~ "{" ~
         "--md-tag-icon:" ~
         "url('data:image/svg+xml;charset=utf-8," ~
-          icon | replace("\n", "") ~
+          icon | replace("\n", "") | urlencode ~
         "');" ~
       "}"
     ) %}


### PR DESCRIPTION
When using custom SVGs that contained
characters breaking a URL, like a hash #
sign that is consiered a URL fragment,
the rendering broke. This adds a jinja
urlencode filter to the output.

Fixes #8086