### PR TITLE
Update "Creating your site" article to include -u option for "docker run" in Unix environment

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -10,7 +10,13 @@ mkdocs new .
 
 Alternatively, if you're running Material for MkDocs from within Docker, use:
 
-=== "Unix, Powershell"
+=== "Unix"
+
+    ```
+    docker run --rm -it -v ${PWD}:/docs -u $(id -u):$(id -g) squidfunk/mkdocs-material new .
+    ```
+
+=== "Powershell"
 
     ```
     docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material new .


### PR DESCRIPTION
Hello!

Right now if you follow the instructions, CLI will create a file structure owned by root user and with write permission only for the owner of the file:

```shell
$ sudo docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material new .
INFO    -  Writing config file: ./mkdocs.yml
INFO    -  Writing initial docs: ./docs/index.md

$ ls -larth
total 16K
drwxrwxrwt 13 root     root     4.0K Mar 16 14:07 ..
-rw-r--r--  1 root     root       19 Mar 16 14:07 mkdocs.yml
drwxr-xr-x  2 root     root     4.0K Mar 16 14:07 docs
drwxr-xr-x  3 dbychkov dbychkov 4.0K Mar 16 14:07 .
```

which adds the necessity to change file's ownership as it is cannot be edited right away.


This can be avoided by using -u option in docker run command:

```shell
$ sudo docker run --rm -it -v ${PWD}:/docs -u $(id -u):$(id -g) squidfunk/mkdocs-material new .
INFO    -  Writing config file: ./mkdocs.yml
INFO    -  Writing initial docs: ./docs/index.md

$ ls -larth
total 16K
drwxrwxrwt 13 root     root     4.0K Mar 16 14:11 ..
-rw-r--r--  1 dbychkov dbychkov   19 Mar 16 14:11 mkdocs.yml
drwxr-xr-x  2 dbychkov dbychkov 4.0K Mar 16 14:11 docs
drwxr-xr-x  3 dbychkov dbychkov 4.0K Mar 16 14:11 .
```

Hence the proposed change 
