### PR TITLE
Fixed pin for `mkdocs-git-revision-date-localized-plugin` plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ recommended = [
 ]
 git = [
   "mkdocs-git-committers-plugin-2>=1.1,<3",
-  "mkdocs-git-revision-date-localized-plugin~=1.2,>=1.2.4"
+  "mkdocs-git-revision-date-localized-plugin>=1.2.4,<2"
 ]
 imaging = [
   "pillow~=10.2",


### PR DESCRIPTION
Hi,

Unfortunately the `~=` pins are a minefield and do not work the way you think. In #7845 you said:

>The current version range includes everything between `>=1.2.4,<2`.

However, `~=1.2` actually means `<=1.3.0`, so the current highest allowed plugin version is `1.3.0`. The latest version is at `1.4.5`, and it has a feature I need (git hashes), but I can't get it due to an overly restrictive pin.

Could you please accept the pin update? Thanks a lot!