### PR TITLE
Make templates compatible with minijinja (Rust)

### DIFF
--- a/material/templates/base.html
+++ b/material/templates/base.html
@@ -58,8 +58,8 @@
     {% endblock %}
     {% block fonts %}
       {% if config.theme.font != false %}
-        {% set text = config.theme.font.get("text", "Roboto") %}
-        {% set code = config.theme.font.get("code", "Roboto Mono") %}
+        {% set text = config.theme.font.text | d("Roboto", true) %}
+        {% set code = config.theme.font.code | d("Roboto Mono", true) %}
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{
             text | replace(' ', '+') + ':300,300i,400,400i,700,700i%7C' +
@@ -214,38 +214,34 @@
       {% include "partials/javascripts/consent.html" %}
     {% endif %}
     {% block config %}
-      {%- set app = {
-        "base": base_url,
-        "features": features,
-        "translations": {},
-        "search": "assets/javascripts/workers/search.f8cc74c7.min.js" | url
-      } -%}
+      {% set _ = namespace() %}
+      {% set _.tags = config.extra.tags %}
       {%- if config.extra.version -%}
-        {%- set mike = config.plugins.get("mike") -%}
+        {%- set mike = config.plugins.mike -%}
         {%- if not mike or mike.config.version_selector -%}
-          {%- set _ = app.update({ "version": config.extra.version }) -%}
+          {%- set _.version = config.extra.version -%}
         {%- endif -%}
       {%- endif -%}
-      {%- if config.extra.tags -%}
-        {%- set _ = app.update({ "tags": config.extra.tags }) -%}
-      {%- endif -%}
-      {%- set translations = app.translations -%}
-      {%- for key in [
-        "clipboard.copy",
-        "clipboard.copied",
-        "search.result.placeholder",
-        "search.result.none",
-        "search.result.one",
-        "search.result.other",
-        "search.result.more.one",
-        "search.result.more.other",
-        "search.result.term.missing",
-        "select.version"
-      ] -%}
-        {%- set _ = translations.update({ key: lang.t(key) }) -%}
-      {%- endfor -%}
       <script id="__config" type="application/json">
-        {{- app | tojson -}}
+        {{- {
+          "base": base_url,
+          "features": features,
+          "translations": {
+            "clipboard.copy": lang.t("clipboard.copy"),
+            "clipboard.copied": lang.t("clipboard.copied"),
+            "search.result.placeholder": lang.t("search.result.placeholder"),
+            "search.result.none": lang.t("search.result.none"),
+            "search.result.one": lang.t("search.result.one"),
+            "search.result.other": lang.t("search.result.other"),
+            "search.result.more.one": lang.t("search.result.more.one"),
+            "search.result.more.other": lang.t("search.result.more.other"),
+            "search.result.term.missing": lang.t("search.result.term.missing"),
+            "select.version": lang.t("select.version")
+          },
+          "search": "assets/javascripts/workers/search.f8cc74c7.min.js" | url,
+          "tags": _.tags or none,
+          "version": _.version or none
+        } | tojson -}}
       </script>
     {% endblock %}
     {% block scripts %}

--- a/material/templates/base.html
+++ b/material/templates/base.html
@@ -77,7 +77,7 @@
     {% endblock %}
     {% if page.meta and page.meta.meta %}
       {% for tag in page.meta.meta %}
-        <meta {% for key, value in tag.items() %} {{ key }}="{{value}}" {% endfor %}>
+        <meta {% for key, value in tag | items %} {{ key }}="{{value}}" {% endfor %}>
       {% endfor %}
     {% endif %}
     {% block extrahead %}{% endblock %}

--- a/material/templates/partials/consent.html
+++ b/material/templates/partials/consent.html
@@ -1,17 +1,25 @@
 {#-
   This file was automatically generated - do not edit
 -#}
-{% set cookies = config.extra.consent.cookies | d({}) %}
-{% if config.extra.analytics %}
-  {% if "analytics" not in cookies %}
-    {% set _ = cookies.update({ "analytics": "Google Analytics" }) %}
+{% macro render_cookie(cookie, type) %}
+  {% set checked = "" %}
+  {% if cookie is string %}
+    {% set name = cookie %}
+    {% set checked = "checked" %}
+  {% else %}
+    {% set name = cookie.name %}
+    {% if cookie.checked %}
+      {% set checked = "checked" %}
+    {% endif %}
   {% endif %}
-{% endif %}
-{% if config.repo_url and "github.com" in config.repo_url %}
-  {% if "github" not in cookies %}
-    {% set _ = cookies.update({ "github": "GitHub" }) %}
-  {% endif %}
-{% endif %}
+  <li class="task-list-item">
+    <label class="task-list-control">
+      <input type="checkbox" name="{{ type }}" {{ checked }}>
+      <span class="task-list-indicator"></span>
+      {{ name }}
+    </label>
+  </li>
+{% endmacro %}
 {% set actions = config.extra.consent.actions %}
 {% if not actions %}
   {% set actions = ["accept", "manage"] %}
@@ -24,24 +32,21 @@
 <input class="md-toggle" type="checkbox" id="__settings" {{ checked }}>
 <div class="md-consent__settings">
   <ul class="task-list">
-    {% for type in cookies %}
-      {% set checked = "" %}
-      {% if cookies[type] is string %}
-        {% set name = cookies[type] %}
-        {% set checked = "checked" %}
-      {% else %}
-        {% set name = cookies[type].name %}
-        {% if cookies[type].checked %}
-          {% set checked = "checked" %}
-        {% endif %}
+    {% set cookies = config.extra.consent.cookies %}
+    {% if "analytics" not in cookies %}
+      {% if config.extra.analytics %}
+        {{ render_cookie("Google Analytics", "analytics") }}
       {% endif %}
-      <li class="task-list-item">
-        <label class="task-list-control">
-          <input type="checkbox" name="{{ type }}" {{ checked }}>
-          <span class="task-list-indicator"></span>
-          {{ name }}
-        </label>
-      </li>
+    {% endif %}
+    {% if "github" not in cookies %}
+      {% if config.repo_url and "github.com" in config.repo_url %}
+        {{ render_cookie("GitHub", "github") }}
+      {% endif %}
+    {% endif %}
+    {% for type in cookies %}
+      {% if cookies[type] %}
+        {{ render_cookie(cookies[type], type) }}
+      {% endif %}
     {% endfor %}
   </ul>
 </div>

--- a/material/templates/partials/feedback.html
+++ b/material/templates/partials/feedback.html
@@ -32,7 +32,12 @@
               {% else %}
                 {% set title = page.title | urlencode %}
               {% endif %}
-              {{ rating.note.format(url = url, title = title) }}
+              {% set note = rating.note %}
+              {% if note %}
+                {% set note = note | replace("{url}", url) %}
+                {% set note = note | replace("{title}", title) %}
+              {% endif %}
+              {{ note }}
             </div>
           {% endfor %}
         </div>

--- a/material/templates/partials/icons.html
+++ b/material/templates/partials/icons.html
@@ -2,47 +2,47 @@
   This file was automatically generated - do not edit
 -#}
 {% if config.theme.icon.admonition %}
-  {% set style = ["\x3cstyle\x3e:root{"] %}
-  {% for type, icon in config.theme.icon.admonition.items() %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
+  {% for type, icon in config.theme.icon.admonition | items %}
     {% import ".icons/" ~ icon ~ ".svg" as icon %}
-    {% set _ = style.append(
+    {% set _.style = _.style ~
       "--md-admonition-icon--" ~ type ~ ":" ~
       "url('data:image/svg+xml;charset=utf-8," ~
         icon | replace("\n", "") | urlencode ~
       "');"
-    ) %}
+    %}
   {% endfor %}
-  {% set _ = style.append("}\x3c/style\x3e") %}
-  {{ style | join }}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}
 {% if config.theme.icon.annotation %}
-  {% set style = ["\x3cstyle\x3e:root{"] %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
   {% import ".icons/" ~ config.theme.icon.annotation ~ ".svg" as icon %}
-  {% set _ = style.append(
+  {% set _.style = _.style ~
     "--md-annotation-icon:" ~
     "url('data:image/svg+xml;charset=utf-8," ~
       icon | replace("\n", "") | urlencode ~
     "');"
-  ) %}
-  {% set _ = style.append("}\x3c/style\x3e") %}
-  {{ style | join }}
+  %}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}
 {% if config.theme.icon.tag %}
-  {% set style = ["\x3cstyle\x3e"] %}
-  {% for type, icon in config.theme.icon.tag.items() %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
+  {% for type, icon in config.theme.icon.tag | items %}
     {% import ".icons/" ~ icon ~ ".svg" as icon %}
     {% if type != "default" %}
       {% set modifier = ".md-tag--" ~ type %}
     {% endif %}
-    {% set _ = style.append(
+    {% set _.style = _.style ~
       ".md-tag" ~ modifier ~ "{" ~
         "--md-tag-icon:" ~
         "url('data:image/svg+xml;charset=utf-8," ~
           icon | replace("\n", "") | urlencode ~
         "');" ~
       "}"
-    ) %}
+    %}
   {% endfor %}
-  {% set _ = style.append("\x3c/style\x3e") %}
-  {{ style | join }}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}

--- a/material/templates/partials/nav-item.html
+++ b/material/templates/partials/nav-item.html
@@ -40,7 +40,7 @@
     </a>
   {% endif %}
 {% endmacro %}
-{% macro render(nav_item, path, level) %}
+{% macro render(nav_item, path, level, parent) %}
   {% set class = "md-nav__item" %}
   {% if nav_item.active %}
     {% set class = class ~ " md-nav__item--active" %}
@@ -66,7 +66,7 @@
         {% set is_section = true %}
       {% endif %}
       {% if "navigation.sections" in features %}
-        {% if level == 2 and nav_item.parent.active %}
+        {% if level == 2 and parent.active %}
           {% set class = class ~ " md-nav__item--section" %}
           {% set is_section = true %}
         {% endif %}
@@ -116,9 +116,9 @@
             {{ nav_item.title }}
           </label>
           <ul class="md-nav__list" data-md-scrollfix>
-            {% for nav_item in nav_item.children %}
-              {% if not index or nav_item != index %}
-                {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% for item in nav_item.children %}
+              {% if not index or item != index %}
+                {{ render(item, path ~ "_" ~ loop.index, level + 1, nav_item) }}
               {% endif %}
             {% endfor %}
           </ul>

--- a/material/templates/partials/nav-item.html
+++ b/material/templates/partials/nav-item.html
@@ -10,7 +10,8 @@
     <span class="{{ class }}"></span>
   {% endif %}
 {% endmacro %}
-{% macro render_content(nav_item, ref = nav_item) %}
+{% macro render_content(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
   {% if nav_item.meta and nav_item.meta.icon %}
     {% include ".icons/" ~ nav_item.meta.icon ~ ".svg" %}
   {% endif %}
@@ -25,7 +26,8 @@
     {{ render_status(nav_item, nav_item.meta.status) }}
   {% endif %}
 {% endmacro %}
-{% macro render_pruned(nav_item, ref = nav_item) %}
+{% macro render_pruned(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
   {% set first = nav_item.children | first %}
   {% if first and first.children %}
     {{ render_pruned(first, ref) }}
@@ -49,14 +51,15 @@
     {% endif %}
   {% endif %}
   {% if nav_item.children %}
-    {% set indexes = [] %}
+    {% set _ = namespace(index = none) %}
     {% if "navigation.indexes" in features %}
-      {% for nav_item in nav_item.children %}
-        {% if nav_item.is_index and not index is defined %}
-          {% set _ = indexes.append(nav_item) %}
+      {% for item in nav_item.children %}
+        {% if item.is_index and _.index is none %}
+          {% set _.index = item %}
         {% endif %}
       {% endfor %}
     {% endif %}
+    {% set index = _.index %}
     {% if "navigation.tabs" in features %}
       {% if level == 1 and nav_item.active %}
         {% set class = class ~ " md-nav__item--section" %}
@@ -87,14 +90,13 @@
           {% set indeterminate = "md-toggle--indeterminate" %}
         {% endif %}
         <input class="md-nav__toggle md-toggle {{ indeterminate }}" type="checkbox" id="{{ path }}" {{ checked }}>
-        {% if not indexes %}
+        {% if not index %}
           {% set tabindex = "0" if not is_section %}
           <label class="md-nav__link" for="{{ path }}" id="{{ path }}_label" tabindex="{{ tabindex }}">
             {{ render_content(nav_item) }}
             <span class="md-nav__icon md-icon"></span>
           </label>
         {% else %}
-          {% set index = indexes | first %}
           {% set class = "md-nav__link--active" if index == page %}
           <div class="md-nav__link md-nav__container">
             <a href="{{ index.url | url }}" class="md-nav__link {{ class }}">
@@ -115,7 +117,7 @@
           </label>
           <ul class="md-nav__list" data-md-scrollfix>
             {% for nav_item in nav_item.children %}
-              {% if not indexes or nav_item != indexes | first %}
+              {% if not index or nav_item != index %}
                 {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
               {% endif %}
             {% endfor %}

--- a/material/templates/partials/social.html
+++ b/material/templates/partials/social.html
@@ -9,8 +9,8 @@
     {% endif %}
     {% set title = social.name %}
     {% if not title and "//" in social.link %}
-      {% set _, url = social.link.split("//") %}
-      {% set title  = url.split("/")[0] %}
+      {% set (_, url) = social.link.split("//") %}
+      {% set title = url.split("/") | first %}
     {% endif %}
     <a href="{{ social.link }}" target="_blank" rel="{{ rel }}" title="{{ title | e }}" class="md-social__link">
       {% include ".icons/" ~ social.icon ~ ".svg" %}

--- a/material/templates/partials/source-file.html
+++ b/material/templates/partials/source-file.html
@@ -18,7 +18,7 @@
   </span>
 {% endmacro %}
 {% macro render_authors(authors) %}
-  {% set git_authors = config.plugins.get("git-authors") %}
+  {% set git_authors = config.plugins["git-authors"] %}
   <span class="md-source-file__fact">
     <span class="md-icon" title="{{ lang.t('source.file.contributors') }}">
       {% if authors | length == 1 %}
@@ -101,7 +101,7 @@
       {{ render_created(created) }}
     {% endif %}
     {% if git_info %}
-      {{ render_authors(git_info.get("page_authors")) }}
+      {{ render_authors(git_info["page_authors"]) }}
     {% endif %}
     {% if committers %}
       {{ render_committers(committers) }}

--- a/material/templates/partials/tabs-item.html
+++ b/material/templates/partials/tabs-item.html
@@ -1,7 +1,8 @@
 {#-
   This file was automatically generated - do not edit
 -#}
-{% macro render_content(nav_item, ref = nav_item) %}
+{% macro render_content(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
   {% if nav_item == ref or "navigation.indexes" in features %}
     {% if nav_item.is_index and nav_item.meta.icon %}
       {% include ".icons/" ~ nav_item.meta.icon ~ ".svg" %}
@@ -9,7 +10,8 @@
   {% endif %}
   {{ ref.title }}
 {% endmacro %}
-{% macro render(nav_item, ref = nav_item) %}
+{% macro render(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
   {% set class = "md-tabs__item" %}
   {% if ref.active %}
     {% set class = class ~ " md-tabs__item--active" %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -126,8 +126,8 @@
 
       <!-- Load fonts from Google -->
       {% if config.theme.font != false %}
-        {% set text = config.theme.font.get("text", "Roboto") %}
-        {% set code = config.theme.font.get("code", "Roboto Mono") %}
+        {% set text = config.theme.font.text | d("Roboto", true) %}
+        {% set code = config.theme.font.code | d("Roboto Mono", true) %}
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
           rel="stylesheet"
@@ -387,46 +387,40 @@
 
     <!-- Theme-related configuration -->
     {% block config %}
-      {%- set app = {
-        "base": base_url,
-        "features": features,
-        "translations": {},
-        "search": "assets/javascripts/workers/search.js" | url
-      } -%}
+      {% set _ = namespace() %}
+
+      <!-- Extra configuration -->
+      {% set _.tags = config.extra.tags %}
 
       <!-- Versioning -->
       {%- if config.extra.version -%}
-        {%- set mike = config.plugins.get("mike") -%}
+        {%- set mike = config.plugins.mike -%}
         {%- if not mike or mike.config.version_selector -%}
-          {%- set _ = app.update({ "version": config.extra.version }) -%}
+          {%- set _.version = config.extra.version -%}
         {%- endif -%}
       {%- endif -%}
 
-      <!-- Tags -->
-      {%- if config.extra.tags -%}
-        {%- set _ = app.update({ "tags": config.extra.tags }) -%}
-      {%- endif -%}
-
-      <!-- Translations -->
-      {%- set translations = app.translations -%}
-      {%- for key in [
-        "clipboard.copy",
-        "clipboard.copied",
-        "search.result.placeholder",
-        "search.result.none",
-        "search.result.one",
-        "search.result.other",
-        "search.result.more.one",
-        "search.result.more.other",
-        "search.result.term.missing",
-        "select.version"
-      ] -%}
-        {%- set _ = translations.update({ key: lang.t(key) }) -%}
-      {%- endfor -%}
-
       <!-- Configuration -->
       <script id="__config" type="application/json">
-        {{- app | tojson -}}
+        {{- {
+          "base": base_url,
+          "features": features,
+          "translations": {
+            "clipboard.copy": lang.t("clipboard.copy"),
+            "clipboard.copied": lang.t("clipboard.copied"),
+            "search.result.placeholder": lang.t("search.result.placeholder"),
+            "search.result.none": lang.t("search.result.none"),
+            "search.result.one": lang.t("search.result.one"),
+            "search.result.other": lang.t("search.result.other"),
+            "search.result.more.one": lang.t("search.result.more.one"),
+            "search.result.more.other": lang.t("search.result.more.other"),
+            "search.result.term.missing": lang.t("search.result.term.missing"),
+            "select.version": lang.t("select.version")
+          },
+          "search": "assets/javascripts/workers/search.js" | url,
+          "tags": _.tags or none,
+          "version": _.version or none
+        } | tojson -}}
       </script>
     {% endblock %}
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -162,7 +162,7 @@
     {% if page.meta and page.meta.meta %}
       {% for tag in page.meta.meta %}
         <meta
-          {% for key, value in tag.items() %}
+          {% for key, value in tag | items %}
             {{ key }}="{{value}}"
           {% endfor %}
         />

--- a/src/templates/partials/consent.html
+++ b/src/templates/partials/consent.html
@@ -20,18 +20,32 @@
   IN THE SOFTWARE.
 -->
 
-<!-- Determine cookies -->
-{% set cookies = config.extra.consent.cookies | d({}) %}
-{% if config.extra.analytics %}
-  {% if "analytics" not in cookies %}
-    {% set _ = cookies.update({ "analytics": "Google Analytics" }) %}
+<!-- Render cookie checkbox -->
+{% macro render_cookie(cookie, type) %}
+  {% set checked = "" %}
+
+  <!-- Cookie with defaults -->
+  {% if cookie is string %}
+    {% set name = cookie %}
+    {% set checked = "checked" %}
+
+  <!-- Cookie with settings -->
+  {% else %}
+    {% set name = cookie.name %}
+    {% if cookie.checked %}
+      {% set checked = "checked" %}
+    {% endif %}
   {% endif %}
-{% endif %}
-{% if config.repo_url and "github.com" in config.repo_url %}
-  {% if "github" not in cookies %}
-    {% set _ = cookies.update({ "github": "GitHub" }) %}
-  {% endif %}
-{% endif %}
+  <li class="task-list-item">
+    <label class="task-list-control">
+      <input type="checkbox" name="{{ type }}" {{ checked }}>
+      <span class="task-list-indicator"></span>
+      {{ name }}
+    </label>
+  </li>
+{% endmacro %}
+
+<!-- ---------------------------------------------------------------------- -->
 
 <!-- Determine actions -->
 {% set actions = config.extra.consent.actions %}
@@ -57,24 +71,27 @@
 />
 <div class="md-consent__settings">
   <ul class="task-list">
-    {% for type in cookies %}
-      {% set checked = "" %}
-      {% if cookies[type] is string %}
-        {% set name = cookies[type] %}
-        {% set checked = "checked" %}
-      {% else %}
-        {% set name = cookies[type].name %}
-        {% if cookies[type].checked %}
-          {% set checked = "checked" %}
-        {% endif %}
+    {% set cookies = config.extra.consent.cookies %}
+
+    <!-- Google Analytics cookie, it not set -->
+    {% if "analytics" not in cookies %}
+      {% if config.extra.analytics %}
+        {{ render_cookie("Google Analytics", "analytics") }}
       {% endif %}
-      <li class="task-list-item">
-        <label class="task-list-control">
-          <input type="checkbox" name="{{ type }}" {{ checked }}>
-          <span class="task-list-indicator"></span>
-          {{ name }}
-        </label>
-      </li>
+    {% endif %}
+
+    <!-- GitHub cookie, if not set -->
+    {% if "github" not in cookies %}
+      {% if config.repo_url and "github.com" in config.repo_url %}
+        {{ render_cookie("GitHub", "github") }}
+      {% endif %}
+    {% endif %}
+
+    <!-- Configured cookies-->
+    {% for type in cookies %}
+      {% if cookies[type] %}
+        {{ render_cookie(cookies[type], type) }}
+      {% endif %}
     {% endfor %}
   </ul>
 </div>

--- a/src/templates/partials/feedback.html
+++ b/src/templates/partials/feedback.html
@@ -69,7 +69,12 @@
               {% endif %}
 
               <!-- Replace {url} and {title} placeholders in note -->
-              {{ rating.note.format(url = url, title = title) }}
+              {% set note = rating.note %}
+              {% if note %}
+                {% set note = note | replace("{url}", url) %}
+                {% set note = note | replace("{title}", title) %}
+              {% endif %}
+              {{ note }}
             </div>
           {% endfor %}
         </div>

--- a/src/templates/partials/icons.html
+++ b/src/templates/partials/icons.html
@@ -22,51 +22,51 @@
 
 <!-- Custom admonition icons -->
 {% if config.theme.icon.admonition %}
-  {% set style = ["\x3cstyle\x3e:root{"] %}
-  {% for type, icon in config.theme.icon.admonition.items() %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
+  {% for type, icon in config.theme.icon.admonition | items %}
     {% import ".icons/" ~ icon ~ ".svg" as icon %}
-    {% set _ = style.append(
+    {% set _.style = _.style ~
       "--md-admonition-icon--" ~ type ~ ":" ~
       "url('data:image/svg+xml;charset=utf-8," ~
         icon | replace("\n", "") | urlencode ~
       "');"
-    ) %}
+    %}
   {% endfor %}
-  {% set _ = style.append("}\x3c/style\x3e") %}
-  {{ style | join }}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}
 
 <!-- Custom annotation icon -->
 {% if config.theme.icon.annotation %}
-  {% set style = ["\x3cstyle\x3e:root{"] %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
   {% import ".icons/" ~ config.theme.icon.annotation ~ ".svg" as icon %}
-  {% set _ = style.append(
+  {% set _.style = _.style ~
     "--md-annotation-icon:" ~
     "url('data:image/svg+xml;charset=utf-8," ~
       icon | replace("\n", "") | urlencode ~
     "');"
-  ) %}
-  {% set _ = style.append("}\x3c/style\x3e") %}
-  {{ style | join }}
+  %}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}
 
 <!-- Custom tag icons -->
 {% if config.theme.icon.tag %}
-  {% set style = ["\x3cstyle\x3e"] %}
-  {% for type, icon in config.theme.icon.tag.items() %}
+  {% set _ = namespace(style = "\x3cstyle\x3e:root{") %}
+  {% for type, icon in config.theme.icon.tag | items %}
     {% import ".icons/" ~ icon ~ ".svg" as icon %}
     {% if type != "default" %}
       {% set modifier = ".md-tag--" ~ type %}
     {% endif %}
-    {% set _ = style.append(
+    {% set _.style = _.style ~
       ".md-tag" ~ modifier ~ "{" ~
         "--md-tag-icon:" ~
         "url('data:image/svg+xml;charset=utf-8," ~
           icon | replace("\n", "") | urlencode ~
         "');" ~
       "}"
-    ) %}
+    %}
   {% endfor %}
-  {% set _ = style.append("\x3c/style\x3e") %}
-  {{ style | join }}
+  {% set _.style = _.style ~ "}\x3c/style\x3e" %}
+  {{ _.style }}
 {% endif %}

--- a/src/templates/partials/nav-item.html
+++ b/src/templates/partials/nav-item.html
@@ -39,7 +39,8 @@
 {% endmacro %}
 
 <!-- Render navigation link content -->
-{% macro render_content(nav_item, ref = nav_item) %}
+{% macro render_content(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
 
   <!-- Navigation link icon -->
   {% if nav_item.meta and nav_item.meta.icon %}
@@ -64,7 +65,8 @@
 {% endmacro %}
 
 <!-- Render navigation item (pruned) -->
-{% macro render_pruned(nav_item, ref = nav_item) %}
+{% macro render_pruned(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
   {% set first = nav_item.children | first %}
 
   <!-- Recurse, if the first item has further nested items -->
@@ -104,14 +106,15 @@
   {% if nav_item.children %}
 
     <!-- Determine all nested items that are index pages -->
-    {% set indexes = [] %}
+    {% set _ = namespace(index = none) %}
     {% if "navigation.indexes" in features %}
-      {% for nav_item in nav_item.children %}
-        {% if nav_item.is_index and not index is defined %}
-          {% set _ = indexes.append(nav_item) %}
+      {% for item in nav_item.children %}
+        {% if item.is_index and _.index is none %}
+          {% set _.index = item %}
         {% endif %}
       {% endfor %}
     {% endif %}
+    {% set index = _.index %}
 
     <!-- Navigation tabs -->
     {% if "navigation.tabs" in features %}
@@ -171,7 +174,7 @@
         />
 
         <!-- Toggle to expand nested items -->
-        {% if not indexes %}
+        {% if not index %}
           {% set tabindex = "0" if not is_section %}
           <label
             class="md-nav__link"
@@ -185,7 +188,6 @@
 
         <!-- Toggle to expand nested items with link to index page -->
         {% else %}
-          {% set index = indexes | first %}
           {% set class = "md-nav__link--active" if index == page %}
           <div class="md-nav__link md-nav__container">
             <a
@@ -225,7 +227,7 @@
 
             <!-- Nested navigation item -->
             {% for nav_item in nav_item.children %}
-              {% if not indexes or nav_item != indexes | first %}
+              {% if not index or nav_item != index %}
                 {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
               {% endif %}
             {% endfor %}

--- a/src/templates/partials/nav-item.html
+++ b/src/templates/partials/nav-item.html
@@ -87,7 +87,7 @@
 {% endmacro %}
 
 <!-- Render navigation item -->
-{% macro render(nav_item, path, level) %}
+{% macro render(nav_item, path, level, parent) %}
 
   <!-- Determine classes -->
   {% set class = "md-nav__item" %}
@@ -129,7 +129,7 @@
       {% if "navigation.sections" in features %}
 
         <!-- Render 2nd level items with nested items as sections -->
-        {% if level == 2 and nav_item.parent.active %}
+        {% if level == 2 and parent.active %}
           {% set class = class ~ " md-nav__item--section" %}
           {% set is_section = true %}
         {% endif %}
@@ -226,9 +226,9 @@
           <ul class="md-nav__list" data-md-scrollfix>
 
             <!-- Nested navigation item -->
-            {% for nav_item in nav_item.children %}
-              {% if not index or nav_item != index %}
-                {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% for item in nav_item.children %}
+              {% if not index or item != index %}
+                {{ render(item, path ~ "_" ~ loop.index, level + 1, nav_item) }}
               {% endif %}
             {% endfor %}
           </ul>

--- a/src/templates/partials/social.html
+++ b/src/templates/partials/social.html
@@ -33,8 +33,8 @@
     <!-- Compute title and render link -->
     {% set title = social.name %}
     {% if not title and "//" in social.link %}
-      {% set _, url = social.link.split("//") %}
-      {% set title  = url.split("/")[0] %}
+      {% set (_, url) = social.link.split("//") %}
+      {% set title = url.split("/") | first %}
     {% endif %}
     <a
       href="{{ social.link }}"

--- a/src/templates/partials/source-file.html
+++ b/src/templates/partials/source-file.html
@@ -44,7 +44,7 @@
 
 <!-- Render authors -->
 {% macro render_authors(authors) %}
-  {% set git_authors = config.plugins.get("git-authors") %}
+  {% set git_authors = config.plugins["git-authors"] %}
   <span class="md-source-file__fact">
     <span class="md-icon" title="{{ lang.t('source.file.contributors') }}">
       {% if authors | length == 1 %}
@@ -161,7 +161,7 @@
 
     <!-- Authors (git-authors plugin) -->
     {% if git_info %}
-      {{ render_authors(git_info.get("page_authors")) }}
+      {{ render_authors(git_info["page_authors"]) }}
     {% endif %}
 
     <!-- Authors (git-committers plugin) -->

--- a/src/templates/partials/tabs-item.html
+++ b/src/templates/partials/tabs-item.html
@@ -21,7 +21,8 @@
 -->
 
 <!-- Render navigation link content -->
-{% macro render_content(nav_item, ref = nav_item) %}
+{% macro render_content(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
 
   <!-- Navigation link icon -->
   {% if nav_item == ref or "navigation.indexes" in features %}
@@ -35,7 +36,8 @@
 {% endmacro %}
 
 <!-- Render navigation item -->
-{% macro render(nav_item, ref = nav_item) %}
+{% macro render(nav_item, ref) %}
+  {% set ref = ref or nav_item %}
 
   <!-- Determine classes -->
   {% set class = "md-tabs__item" %}


### PR DESCRIPTION
This PR improves compatibility with [minijinja](https://github.com/mitsuhiko/minijinja), a template engine we're currently exploring. Additionally, it replaces several instances of Python function invocations with idiomatic use of template filters. All instances where variables have been mutated inside templates have been replaced. Most changes have been made in partials, and only a few in blocks, and all of them are fully backwards compatible, so no changes to your overrides are necessary.

Note that this PR does not replace the [jinja](https://jinja.palletsprojects.com/en/stable/) template engine with [minijinja](https://github.com/mitsuhiko/minijinja). However, our templates are now 99% compatible with minijinja, which means we can explore alternative jinja-compatible implementations. Additionally, immutability and removal of almost all Python function invocations means much more idiomatic templating ☺️

---

🙋‍♀️ __Want to help testing?__ Just check out this branch, and build your documentation with it – it only takes a minute:

```
pip install git+https://github.com/squidfunk/mkdocs-material.git@refactor/jinja-compat
mkdocs build
```

There should be no difference in output whatsoever. If there is, please let us know!