### PR TITLE
Update python base image to alpine3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-FROM python:3.11-alpine3.19 AS build
+FROM python:3.11-alpine3.21 AS build
 
 # Build-time flags
 ARG WITH_PLUGINS=true


### PR DESCRIPTION
Updating the docker base image to alpine 3.21, as python dropped support for alpine 3.19.

See https://github.com/docker-library/python/commit/3d7b328b66525fe2e82af7063af10c176b6ee8cd


