### PR TITLE
bump required version of jinja2 to ~=3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 # Requirements for core
-jinja2~=3.0
+jinja2~=3.1
 markdown~=3.2
 mkdocs~=1.6
 mkdocs-material-extensions~=1.3


### PR DESCRIPTION
Commit `fb0c27c382d6921b2efe8cf7c91ac26c804811a2` switched to using the jinja2 'items' filter. That filter, however, was not added until jinja version 3.1.0 \[1\]. Therefore, bump the required version to prevent breakage.

On systems without an outdated jinja version, an error similar to the following will occur when running `mkdocs build`:

```
Traceback (most recent call last):
  File "/tmp/mkdocsbug/venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/mkdocs/commands/build.py", line 328, in build
    _build_theme_template(template, env, files, config, nav)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/mkdocs/commands/build.py", line 103, in _build_theme_template
    output = _build_template(template_name, template, files, config, nav)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/mkdocs/commands/build.py", line 83, in _build_template
    output = template.render(context)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/material/templates/404.html", line 4, in <module>
    {% extends "main.html" %}
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/material/templates/main.html", line 4, in <module>
    {% extends "base.html" %}
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/tmp/mkdocsbug/venv/lib/python3.10/site-packages/material/templates/base.html", line 80, in <module>
    <meta {% for key, value in tag | items %} {{ key }}="{{value}}" {% endfor %}>
jinja2.exceptions.TemplateAssertionError: No filter named 'items'.
```

\[1\]: https://jinja.palletsprojects.com/en/stable/changes/#version-3-1-0