### PR TITLE
Update publishing-your-site.md

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -267,9 +267,7 @@ other providers:
   [masked custom variables]: https://docs.gitlab.com/ee/ci/variables/#mask-a-cicd-variable
   [default branch]: https://docs.gitlab.com/ee/user/project/repository/branches/default.html
   [Cloudflare Pages]: https://deborahwrites.com/guides/deploy-host-mkdocs/deploy-mkdocs-material-cloudflare/
-  [DigitalOcean]: https://deborahwrites.com/guides/deploy-host-mkdocs/deploy-mkdocs-material-digitalocean-app-platform/
   [Flyio]: https://documentation.breadnet.co.uk/cloud/fly/mkdocs-on-fly/
   [Netlify]: https://deborahwrites.com/guides/deploy-host-mkdocs/deploy-mkdocs-material-netlify/
-  [Vercel]: https://deborahwrites.com/guides/deploy-host-mkdocs/deploy-mkdocs-material-vercel/
   [Scaleway]: https://www.scaleway.com/en/docs/tutorials/using-bucket-website-with-mkdocs/
 


### PR DESCRIPTION
No longer offering Digital Ocean or Vercel guides: just did a round of checks and updates. DO was never one I recommended highly, and the Vercel guide seems to need a complete re-write, so removing for now. I've refreshed the Netlify guide and that one is now nice and up to date at least . . .