### PR TITLE
Add mention of custom domain when publishing site using GitHub Actions

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -138,6 +138,8 @@ Page is set to `gh-pages`.
 
 Your documentation should shortly appear at `<username>.github.io/<repository>`.
 
+To publish your site on a custom domain, please refer to the [MkDocs documentation].
+
   [GitHub Actions]: https://github.com/features/actions
   [MkDocs plugins]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins
   [personal access token]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
@@ -147,6 +149,7 @@ Your documentation should shortly appear at `<username>.github.io/<repository>`.
   [publishing source branch]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
   [manual page]: https://man7.org/linux/man-pages/man1/date.1.html
   [caching]: plugins/requirements/caching.md
+  [MkDocs documentation]: https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains
 
 ### with MkDocs
 


### PR DESCRIPTION
I ran into the issue that the `CNAME` file that GitHub creates when specifying the custom domain in the repo settings gets overwritten on the next deploy.

This PR adds a sentence and refers to the MkDocs docs that explain the addition of the `CNAME` file.