### PR TITLE
Fix rendering of mermaid ERD

### DIFF
--- a/src/templates/assets/javascripts/components/content/mermaid/index.css
+++ b/src/templates/assets/javascripts/components/content/mermaid/index.css
@@ -25,11 +25,11 @@
  * ------------------------------------------------------------------------- */
 
 /* General node */
-.node circle,
-.node ellipse,
-.node path,
-.node polygon,
-.node rect {
+.node circle:not(.erDiagram *),
+.node ellipse:not(.erDiagram *),
+.node path:not(.erDiagram *),
+.node polygon:not(.erDiagram *),
+.node rect:not(.erDiagram *) {
   fill: var(--md-mermaid-node-bg-color);
   stroke: var(--md-mermaid-node-fg-color);
 }
@@ -280,65 +280,25 @@ defs #statediagram-barbEnd {
  * Rules: entity-relationship diagrams
  * ------------------------------------------------------------------------- */
 
-/* Entity-relationship diagram title */
-.entityTitleText {
-  fill: var(--md-mermaid-label-fg-color);
-}
-
-/* Attribute box */
-.attributeBoxEven,
-.attributeBoxOdd {
-  fill: var(--md-mermaid-node-bg-color);
-  stroke: var(--md-mermaid-node-fg-color);
-}
-
-/* Entity node */
-.entityBox {
-  fill: var(--md-mermaid-label-bg-color);
-  stroke: var(--md-mermaid-node-fg-color);
-}
-
-/* Entity node label */
-.entityLabel {
-  font-family: var(--md-mermaid-font-family);
-  fill: var(--md-mermaid-label-fg-color);
-}
-
-/* Entity relationship label container */
-.relationshipLabelBox {
-  background-color: var(--md-mermaid-label-bg-color);
-  opacity: 1;
-  fill: var(--md-mermaid-label-bg-color);
-  fill-opacity: 1;
-}
-
-/* Entity relationship label */
-.relationshipLabel {
-  fill: var(--md-mermaid-label-fg-color);
-}
-
 /* Entity relationship line { */
 .relationshipLine {
   stroke: var(--md-mermaid-edge-color);
 }
 
 /* Entity relationship line markers */
-defs #ZERO_OR_ONE_START *,
-defs #ZERO_OR_ONE_END *,
-defs #ZERO_OR_MORE_START *,
-defs #ZERO_OR_MORE_END *,
-defs #ONLY_ONE_START *,
-defs #ONLY_ONE_END *,
-defs #ONE_OR_MORE_START *,
-defs #ONE_OR_MORE_END * {
+defs .marker.onlyOne.er *,
+defs .marker.zeroOrOne.er *,
+defs .marker.oneOrMore.er *,
+defs .marker.zeroOrMore.er * {
   stroke: var(--md-mermaid-edge-color) !important;
 }
 
-/* Entity relationship line markers */
-defs #ZERO_OR_MORE_START circle,
-defs #ZERO_OR_MORE_END circle {
-  fill: var(--md-mermaid-label-bg-color);
-}
+
+g[id^="entity-"].node.default span.nodeLabel p {
+  color: black; 
+} 
+
+
 
 /* ----------------------------------------------------------------------------
  * Rules: sequence diagrams

--- a/src/templates/assets/javascripts/components/content/mermaid/index.css
+++ b/src/templates/assets/javascripts/components/content/mermaid/index.css
@@ -282,18 +282,13 @@ defs #statediagram-barbEnd {
 }
 
 /* Entity relationship line markers */
-defs .marker.onlyOne.er *,
-defs .marker.zeroOrOne.er *,
-defs .marker.oneOrMore.er *,
-defs .marker.zeroOrMore.er * {
+defs .marker.er * {
   stroke: var(--md-mermaid-edge-color) !important;
 }
-
 
 g[id^="entity-"].node.default span.nodeLabel p {
   color: black; 
 } 
-
 
 
 /* ----------------------------------------------------------------------------

--- a/src/templates/assets/javascripts/components/content/mermaid/index.css
+++ b/src/templates/assets/javascripts/components/content/mermaid/index.css
@@ -25,11 +25,7 @@
  * ------------------------------------------------------------------------- */
 
 /* General node */
-.node circle:not(.erDiagram *),
-.node ellipse:not(.erDiagram *),
-.node path:not(.erDiagram *),
-.node polygon:not(.erDiagram *),
-.node rect:not(.erDiagram *) {
+.node :where(circle, ellipse, path, polygon, rect):not(.erDiagram *) {
   fill: var(--md-mermaid-node-bg-color);
   stroke: var(--md-mermaid-node-fg-color);
 }


### PR DESCRIPTION
Fix the rendering of mermaid entity diagrams by removing the base .node configuration only for entity diagrams and fixing the relationship lines, marker stroke color, as well as the node labels.

This is for issue #8153 