### PR TITLE
Add rel=edit link to edit button link

### DIFF
--- a/src/templates/partials/actions.html
+++ b/src/templates/partials/actions.html
@@ -46,6 +46,7 @@
       href="{{ page.edit_url | replace(part, 'raw') }}"
       title="{{ lang.t('action.view') }}"
       class="md-content__button md-icon"
+      rel="edit"
     >
       {% set icon = config.theme.icon.view or "material/file-eye-outline" %}
       {% include ".icons/" ~ icon ~ ".svg" %}

--- a/src/templates/partials/actions.html
+++ b/src/templates/partials/actions.html
@@ -29,6 +29,7 @@
       href="{{ page.edit_url }}"
       title="{{ lang.t('action.edit') }}"
       class="md-content__button md-icon"
+      rel="edit"
     >
       {% set icon = config.theme.icon.edit or "material/file-edit-outline" %}
       {% include ".icons/" ~ icon ~ ".svg" %}
@@ -46,7 +47,6 @@
       href="{{ page.edit_url | replace(part, 'raw') }}"
       title="{{ lang.t('action.view') }}"
       class="md-content__button md-icon"
-      rel="edit"
     >
       {% set icon = config.theme.icon.view or "material/file-eye-outline" %}
       {% include ".icons/" ~ icon ~ ".svg" %}


### PR DESCRIPTION
This PR adds the rel="edit" attribute to the mkdocs material edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.