### PR TITLE
Updated info plugin to exclude guessed venv paths

### DIFF
--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -282,6 +282,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                             *sys.argv[1:]
                         ]),
                         "env:$PYTHONPATH": os.getenv("PYTHONPATH", ""),
+                        "env:$VIRTUAL_ENV": os.getenv("VIRTUAL_ENV", ""),
                         "sys.path": sys.path,
                         "excluded_entries": self.excluded_entries
                     },

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -280,8 +280,13 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                 ]))
             )
 
+            # Try to get login to replace it with USERNAME placeholder
+            try:
+                username = getpass.getuser()
+            except Exception:
+                username = ""
+
             # Add information on platform
-            # Replace login with USERNAME placeholder
             f.writestr(
                 os.path.join(example, "platform.json"),
                 json.dumps(
@@ -301,7 +306,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                     },
                     default = str,
                     indent = 2
-                ).replace(getpass.getuser(), "USERNAME")
+                ).replace(username, "USERNAME")
             )
 
             # Retrieve list of processed files

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import getpass
 import glob
 import json
 import logging
@@ -267,6 +268,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             )
 
             # Add information on platform
+            # Replace login with USERNAME placeholder
             f.writestr(
                 os.path.join(example, "platform.json"),
                 json.dumps(
@@ -285,7 +287,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                     },
                     default = str,
                     indent = 2
-                )
+                ).replace(getpass.getuser(), "USERNAME")
             )
 
             # Retrieve list of processed files

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -201,6 +201,19 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             if path.startswith(os.getcwd()):
                 self.exclusion_patterns.append(_resolve_pattern(path))
 
+        # Guess other Virtual Environment paths in case we forget to activate
+        # them or in case we have multiple. Making sure which venv is activated
+        # is not necessary, as it is an optional step in the guidelines.
+        for path in glob.iglob(
+            pathname = "**/pyvenv.cfg",
+            root_dir = os.getcwd(),
+            recursive = True
+        ):
+            path = os.path.join(os.getcwd(), os.path.dirname(path))
+            if path not in site.PREFIXES:
+                print(f"Possible inactive venv: {path}")
+                self.exclusion_patterns.append(_resolve_pattern(path))
+
         # Exclude site_dir for projects
         if projects_plugin:
             for path in glob.iglob(

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -282,6 +282,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                             *sys.argv[1:]
                         ]),
                         "env:$PYTHONPATH": os.getenv("PYTHONPATH", ""),
+                        "env:$VIRTUAL_ENV": os.getenv("VIRTUAL_ENV", ""),
                         "sys.path": sys.path,
                         "excluded_entries": self.excluded_entries
                     },

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -280,8 +280,13 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                 ]))
             )
 
+            # Try to get login to replace it with USERNAME placeholder
+            try:
+                username = getpass.getuser()
+            except Exception:
+                username = ""
+
             # Add information on platform
-            # Replace login with USERNAME placeholder
             f.writestr(
                 os.path.join(example, "platform.json"),
                 json.dumps(
@@ -301,7 +306,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                     },
                     default = str,
                     indent = 2
-                ).replace(getpass.getuser(), "USERNAME")
+                ).replace(username, "USERNAME")
             )
 
             # Retrieve list of processed files

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import getpass
 import glob
 import json
 import logging
@@ -267,6 +268,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             )
 
             # Add information on platform
+            # Replace login with USERNAME placeholder
             f.writestr(
                 os.path.join(example, "platform.json"),
                 json.dumps(
@@ -285,7 +287,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
                     },
                     default = str,
                     indent = 2
-                )
+                ).replace(getpass.getuser(), "USERNAME")
             )
 
             # Retrieve list of processed files

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -201,6 +201,19 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             if path.startswith(os.getcwd()):
                 self.exclusion_patterns.append(_resolve_pattern(path))
 
+        # Guess other Virtual Environment paths in case we forget to activate
+        # them or in case we have multiple. Making sure which venv is activated
+        # is not necessary, as it is an optional step in the guidelines.
+        for path in glob.iglob(
+            pathname = "**/pyvenv.cfg",
+            root_dir = os.getcwd(),
+            recursive = True
+        ):
+            path = os.path.join(os.getcwd(), os.path.dirname(path))
+            if path not in site.PREFIXES:
+                print(f"Possible inactive venv: {path}")
+                self.exclusion_patterns.append(_resolve_pattern(path))
+
         # Exclude site_dir for projects
         if projects_plugin:
             for path in glob.iglob(


### PR DESCRIPTION
Hi 👋,
since the amount of cases with minimal reproduction containing an inactive Virtual Environment reached a comfortable threshold I decided to update it and detect/guess possible venv paths.

To guess the paths I use the `pyvenv.cfg` file, which is added in the default `python -m venv` call:
- https://github.com/python/cpython/blob/76dd0eee056fbb2a6dc5c3dbb52568ba61d04994/Lib/venv/__init__.py#L220

Perhaps other "venv" solutions don't do that, and a better alternative would be to use `site-packages` or look for "python" executables, but Linux might not use `python` but specifically some `python3.12` name variant, so I picked the simplest solution for now with the `pyvenv.cfg` :v:

[9.6.14-guess.zip](https://github.com/user-attachments/files/20968378/9.6.14-guess.zip)

```sh
$ mkdocs build
INFO    -  Started archive creation for bug report

Please name your bug report (2-4 words): guess
Possible inactive venv: C:\Users\...\material-info-venv-test\venv2
INFO    -  Archive successfully created:

  9.6.14-guess/docs/index.md 287.0 B
  9.6.14-guess/mkdocs.yml 61.0 B
  9.6.14-guess/platform.json 352.0 B
  9.6.14-guess/requirements.lock.txt 332.0 B

  9.6.14-guess.zip 1.6 kB
```

In the final `platform.json` I decided to hide the username as it's a potential breach of privacy, a bit late after months but better late than never :v:
`...` - in this case I obfuscated the username in the text here, however it would display for the user in the terminal.

Additionally, I added the output of the `VIRTUAL_ENV` environmental variable to make sure we see the activated venv and don't have to guess based on the `sys.path`

Ref:
- https://github.com/squidfunk/mkdocs-material/issues/8284#issuecomment-3015598360
- https://github.com/squidfunk/mkdocs-material/discussions/8198#discussioncomment-13042253