### PR TITLE
Fixed info venv guessing again

### DIFF
--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -284,7 +284,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             try:
                 username = getpass.getuser()
             except Exception:
-                username = ""
+                username = "USERNAME"
 
             # Add information on platform
             f.writestr(

--- a/material/plugins/info/plugin.py
+++ b/material/plugins/info/plugin.py
@@ -204,15 +204,16 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         # Guess other Virtual Environment paths in case we forget to activate
         # them or in case we have multiple. Making sure which venv is activated
         # is not necessary, as it is an optional step in the guidelines.
-        for path in glob.iglob(
-            pathname = "**/pyvenv.cfg",
-            root_dir = os.getcwd(),
-            recursive = True
-        ):
-            path = os.path.join(os.getcwd(), os.path.dirname(path))
-            if path not in site.PREFIXES:
-                print(f"Possible inactive venv: {path}")
-                self.exclusion_patterns.append(_resolve_pattern(path))
+        for abs_root, dirnames, filenames in os.walk(os.getcwd()):
+            for filename in filenames:
+                if filename.lower() != "pyvenv.cfg":
+                    continue
+
+                path = abs_root[0].upper() + abs_root[1:]
+
+                if path not in site.PREFIXES:
+                    print(f"Possible inactive venv: {path}")
+                    self.exclusion_patterns.append(_resolve_pattern(path))
 
         # Exclude site_dir for projects
         if projects_plugin:

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -284,7 +284,7 @@ class InfoPlugin(BasePlugin[InfoConfig]):
             try:
                 username = getpass.getuser()
             except Exception:
-                username = ""
+                username = "USERNAME"
 
             # Add information on platform
             f.writestr(

--- a/src/plugins/info/plugin.py
+++ b/src/plugins/info/plugin.py
@@ -204,15 +204,16 @@ class InfoPlugin(BasePlugin[InfoConfig]):
         # Guess other Virtual Environment paths in case we forget to activate
         # them or in case we have multiple. Making sure which venv is activated
         # is not necessary, as it is an optional step in the guidelines.
-        for path in glob.iglob(
-            pathname = "**/pyvenv.cfg",
-            root_dir = os.getcwd(),
-            recursive = True
-        ):
-            path = os.path.join(os.getcwd(), os.path.dirname(path))
-            if path not in site.PREFIXES:
-                print(f"Possible inactive venv: {path}")
-                self.exclusion_patterns.append(_resolve_pattern(path))
+        for abs_root, dirnames, filenames in os.walk(os.getcwd()):
+            for filename in filenames:
+                if filename.lower() != "pyvenv.cfg":
+                    continue
+
+                path = abs_root[0].upper() + abs_root[1:]
+
+                if path not in site.PREFIXES:
+                    print(f"Possible inactive venv: {path}")
+                    self.exclusion_patterns.append(_resolve_pattern(path))
 
         # Exclude site_dir for projects
         if projects_plugin:


### PR DESCRIPTION
Fixes: #8349 

Hi 👋 ,

this PR fixes the shortcomings of the previous #8286 PR, as it mainly adds the code that should've been there previously😅 
We can't use `glob.iglob` to look for hidden paths, as this was added in Python 3.11, so the best choice is `os.walk`

Change list:
- [x] .dotpath support in the venv guess logic
- [x] fixed empty username, str.replace("", "123") inputs 123 between every character
- [x] os.getcwd() usage stayed mostly as-is, because we want to support config file in another directory

However, the info plugin uses MkDocs paths, which could also have inconsistent drive letters. Therefore, I introduced a function, which slightly decreases the readability of the code, but hopefully there won't be too many issues ✌️

Works for me on both Windows and WSL paths.
Maybe @schneekluth could double check on both Windows and macOS

To install this branch run this command (edited)
```
pip install git+https://github.com/kamilkrzyskow/mkdocs-material.git@b1863de7271a76fadd4abbd18b9295845f6c5958#egg=mkdocs-material
```