### PR TITLE
python3.14 -m pip install mkdocs-material[imaging] fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ on:
 
 env:
   NODE_VERSION: 18.x
-  PYTHON_VERSION: 3.x
+  PYTHON_VERSION: 3.14
 
 permissions:
   contents: read
@@ -101,6 +101,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: |
             pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
   "keywords"
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
@@ -63,7 +63,7 @@ git = [
   "mkdocs-git-revision-date-localized-plugin~=1.2,>=1.2.4"
 ]
 imaging = [
-  "pillow>=10.2,<12.0",
+  "pillow>=11.3,<12.0",
   "cairosvg~=2.6"
 ]
 


### PR DESCRIPTION
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc2

% `python3.14 -m pip install mkdocs-material[imaging]`
```
[ ... ]
Successfully built MarkupSafe pyyaml cffi
Failed to build pillow
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
╰─> pillow
```