### PR TITLE
Replace codecs.open() with open() since codecs.open() deprecated in 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tmp
 # IDEs & Editors
 .idea
 *~
+
+# uv Python package manager
+uv.lock

--- a/material/extensions/emoji.py
+++ b/material/extensions/emoji.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import codecs
 import functools
 import material
 import os
@@ -65,7 +64,7 @@ def to_svg(
 # Load icon
 @functools.lru_cache(maxsize = None)
 def _load(file: str):
-    with codecs.open(file, encoding = "utf-8") as f:
+    with open(file, encoding = "utf-8") as f:
         return f.read()
 
 # Load twemoji index and add icons

--- a/src/extensions/emoji.py
+++ b/src/extensions/emoji.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import codecs
 import functools
 import material
 import os
@@ -65,7 +64,7 @@ def to_svg(
 # Load icon
 @functools.lru_cache(maxsize = None)
 def _load(file: str):
-    with codecs.open(file, encoding = "utf-8") as f:
+    with open(file, encoding = "utf-8") as f:
         return f.read()
 
 # Load twemoji index and add icons


### PR DESCRIPTION
Replace `codecs.open()` with `open()` since the former is [deprecated in Python 3.14](https://docs.python.org/3.14/library/codecs.html#codecs.open)

`codecs.open` was necessary in Python 2 because the built-in `open()` function could not handle different text encodings like UTF-8. It provided a way to read and write text files containing Unicode characters, which the default open() could not do without causing errors.  With Python 3, the built-in `open()` function was changed to take an encoding argument and to handle text files as Unicode by default

Also:
- Added `uv.lock` to `.gitignore` to make it easier to test with uv virtual environments using things like a release candidate version of Python

Closes #8446