### PR TITLE
Add directory-within-build versioning support.

### DIFF
--- a/src/templates/assets/javascripts/_/index.ts
+++ b/src/templates/assets/javascripts/_/index.ts
@@ -81,9 +81,10 @@ export type Translations =
  * Versioning
  */
 export interface Versioning {
-  provider: "mike"                     /* Version provider */
+  provider: "mike" | "directory"       /* Version provider */
   default?: string | string[]          /* Default version */
   alias?: boolean                      /* Show alias */
+  declared_version: string             /* Version info from multi-version builds */
 }
 
 /**

--- a/src/templates/assets/javascripts/bundle.ts
+++ b/src/templates/assets/javascripts/bundle.ts
@@ -154,7 +154,7 @@ if (feature("navigation.instant"))
     .subscribe(document$)
 
 /* Set up version selector */
-if (config.version?.provider === "mike")
+if (config.version?.provider != undefined)
   setupVersionSelector({ document$ })
 
 /* Always close drawer and search on navigation */

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -394,9 +394,15 @@
 
       <!-- Versioning -->
       {%- if config.extra.version -%}
+        {%- if config.extra.version.provider == "mike" -%}
         {%- set mike = config.plugins.mike -%}
-        {%- if not mike or mike.config.version_selector -%}
-          {%- set _.version = config.extra.version -%}
+          {%- if not mike or mike.config.version_selector -%}
+            {%- set _.version = config.extra.version -%}
+          {%- endif -%}
+        {%- elif config.extra.version.provider == "directory" -%}
+          {%- if page and (page.meta.version) -%}
+            {%- set _.version = {"provider":"directory", "declared_version": page.meta.version | string} -%}
+          {%- endif -%}
         {%- endif -%}
       {%- endif -%}
 


### PR DESCRIPTION
Add "directory" versioning scheme, which permits versioned docs in one build.  These code changes would resolve https://github.com/squidfunk/mkdocs-material/issues/8453 as an intermediate option before the [full versioning and translation effort](https://squidfunk.github.io/mkdocs-material/blog/2024/08/19/how-were-transforming-material-for-mkdocs/) is complete.

If this looks acceptable (given that this is a fairly small patch), I'd be happy to add documentation to `docs/setup/setting-up-versioning.md`.  In the meantime, I've been using a fork and manually copying the built bundle into our assets (https://github.com/knative/docs/pull/6392), which feels kinda gross (I also needed to do this for the search URL, because this needs to override the `config` JSON data).

Fixes #8453 

Usage:
* Set `extra.version.provider: directory` in `mkdocs.yml`.
* Place versioned docs in subdirectories named after the version, e.g. `/v1.1/`, `/v1.2/`.
* Create a `.meta.yml` file in each version directory with version metadata, e.g.:
   ```yaml
   version: v1.2
   ```
* At the top level, create a `versions.json` file listing available versions, e.g.:
   ```json
   [
     {"version": "v1.2", title: "v1.2", "alias": "latest"},
     {"version": "v1.1", title: "v1.1"}
   ]
   ```