### PR TITLE
Make timeout a variable

### DIFF
--- a/src/plugins/privacy/config.py
+++ b/src/plugins/privacy/config.py
@@ -41,3 +41,6 @@ class PrivacyConfig(Config):
     assets_fetch = Type(bool, default = True)
     assets_fetch_dir = Type(str, default = "assets/external")
     assets_expr_map = DictOfItems(Type(str), default = {})
+
+    # Settings for fetching
+    timeout = Type(int, default = 5)

--- a/src/plugins/privacy/plugin.py
+++ b/src/plugins/privacy/plugin.py
@@ -44,8 +44,6 @@ from xml.etree.ElementTree import Element, tostring
 from .config import PrivacyConfig
 from .parser import FragmentParser
 
-DEFAULT_TIMEOUT_IN_SECS = 5
-
 # -----------------------------------------------------------------------------
 # Classes
 # -----------------------------------------------------------------------------
@@ -428,7 +426,7 @@ class PrivacyPlugin(BasePlugin[PrivacyConfig]):
                             ]
                         )
                     },
-                    timeout=DEFAULT_TIMEOUT_IN_SECS,
+                    timeout=self.config.timeout,
                 )
                 res.raise_for_status()
 


### PR DESCRIPTION
Made the default timeout variable that was previously defined in source code a proper config variable. This way, users of the plugin can increase the timeout if their servers are too slow for mkdocs