### PR TITLE
Add Cappuccin theme based on Catppuccin color palette

### DIFF
--- a/CAPPUCCIN_THEME.md
+++ b/CAPPUCCIN_THEME.md
@@ -1,0 +1,151 @@
+# Cappuccin Theme для MkDocs Material
+
+## Опис
+
+Cappuccin - це власна кольорова схема для MkDocs Material, яка базується на популярній темі [Catppuccin](https://catppuccin.com/). Тема містить дві варіанти:
+
+- **Cappuccin Mocha** - темна схема з затишними, насиченими пастельними кольорами
+- **Cappuccin Latte** - світла схема, яка гармонійно інвертує темну версію
+
+## Використання
+
+### Основна конфігурація
+
+Додайте наступну конфігурацію до вашого `mkdocs.yml`:
+
+```yaml
+theme:
+  name: material
+  palette:
+    # Темна тема Cappuccin Mocha
+    - scheme: cappuccin-mocha
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+    # Світла тема Cappuccin Latte
+    - scheme: cappuccin-latte
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+```
+
+### Тільки темна тема
+
+```yaml
+theme:
+  name: material
+  palette:
+    scheme: cappuccin-mocha
+```
+
+### Тільки світла тема
+
+```yaml
+theme:
+  name: material
+  palette:
+    scheme: cappuccin-latte
+```
+
+### З основним кольором
+
+Ви також можете комбінувати схему Cappuccin з первинними та акцентними кольорами Material:
+
+```yaml
+theme:
+  name: material
+  palette:
+    - scheme: cappuccin-mocha
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+    - scheme: cappuccin-latte
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+```
+
+## Кольорова палітра
+
+### Cappuccin Mocha (Темна)
+
+Базується на [Catppuccin Mocha](https://catppuccin.com/palette/) - найтемнішому варіанті Catppuccin:
+
+- **Base (фон)**: `#1e1e2e`
+- **Text (текст)**: `#cdd6f4`
+- **Mantle**: `#181825`
+- **Акцентні кольори**: Blue `#89b4fa`, Mauve `#cba6f7`, Pink `#f5c2e7`, Green `#a6e3a1`
+
+### Cappuccin Latte (Світла)
+
+Базується на [Catppuccin Latte](https://catppuccin.com/palette/) - світлому варіанті Catppuccin:
+
+- **Base (фон)**: `#eff1f5`
+- **Text (текст)**: `#4c4f69`
+- **Mantle**: `#e6e9ef`
+- **Акцентні кольори**: Blue `#1e66f5`, Mauve `#8839ef`, Pink `#ea76cb`, Green `#40a02b`
+
+## Особливості
+
+- Повна підтримка підсвічування синтаксису коду з кольорами Catppuccin
+- Адаптовані кольори для всіх компонентів Material (таблиці, admonitions, кнопки тощо)
+- Підтримка перемикання між світлою та темною темами
+- Всі 26 кольорів Catppuccin доступні як CSS-змінні
+
+## Доступні CSS-змінні
+
+Всі кольори Catppuccin доступні як CSS-змінні:
+
+```css
+--catppuccin-rosewater
+--catppuccin-flamingo
+--catppuccin-pink
+--catppuccin-mauve
+--catppuccin-red
+--catppuccin-maroon
+--catppuccin-peach
+--catppuccin-yellow
+--catppuccin-green
+--catppuccin-teal
+--catppuccin-sky
+--catppuccin-sapphire
+--catppuccin-blue
+--catppuccin-lavender
+--catppuccin-text
+--catppuccin-subtext1
+--catppuccin-subtext0
+--catppuccin-overlay2
+--catppuccin-overlay1
+--catppuccin-overlay0
+--catppuccin-surface2
+--catppuccin-surface1
+--catppuccin-surface0
+--catppuccin-base
+--catppuccin-mantle
+--catppuccin-crust
+```
+
+Ви можете використовувати ці змінні у власних CSS-файлах для кастомізації:
+
+```css
+.custom-element {
+  background-color: var(--catppuccin-mauve);
+  color: var(--catppuccin-text);
+}
+```
+
+## Ліцензія
+
+Ця тема використовує кольорову схему [Catppuccin](https://github.com/catppuccin/catppuccin), яка ліцензована під MIT License.
+
+## Посилання
+
+- [Catppuccin Official Website](https://catppuccin.com/)
+- [Catppuccin Palette](https://catppuccin.com/palette/)
+- [Catppuccin GitHub](https://github.com/catppuccin/catppuccin)

--- a/examples/cappuccin-theme-example.yml
+++ b/examples/cappuccin-theme-example.yml
@@ -1,0 +1,66 @@
+# Приклад конфігурації для теми Cappuccin
+# Example configuration for Cappuccin theme
+
+site_name: Cappuccin Theme Example
+site_description: Example site using Cappuccin theme for MkDocs Material
+
+theme:
+  name: material
+
+  # Кольорова схема Cappuccin з перемиканням між темною та світлою темами
+  palette:
+    # Темна тема Cappuccin Mocha
+    - scheme: cappuccin-mocha
+      toggle:
+        icon: material/brightness-4
+        name: Переключити на світлу тему / Switch to light mode
+
+    # Світла тема Cappuccin Latte
+    - scheme: cappuccin-latte
+      toggle:
+        icon: material/brightness-7
+        name: Переключити на темну тему / Switch to dark mode
+
+  # Додаткові налаштування Material theme
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+# Розширення Markdown
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+
+# Навігація
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Documentation: documentation.md
+
+# Додаткові налаштування
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yourusername/yourrepo

--- a/src/templates/assets/stylesheets/palette/_scheme.scss
+++ b/src/templates/assets/stylesheets/palette/_scheme.scss
@@ -141,6 +141,260 @@
 
   // --------------------------------------------------------------------------
 
+  // Cappuccin Mocha theme - Catppuccin's darkest variant
+  [data-md-color-scheme="cappuccin-mocha"] {
+
+    // Indicate that the site is rendered with a dark color scheme
+    color-scheme: dark;
+
+    // Catppuccin Mocha color palette
+    // Base colors
+    --catppuccin-rosewater: #f5e0dc;
+    --catppuccin-flamingo:  #f2cdcd;
+    --catppuccin-pink:      #f5c2e7;
+    --catppuccin-mauve:     #cba6f7;
+    --catppuccin-red:       #f38ba8;
+    --catppuccin-maroon:    #eba0ac;
+    --catppuccin-peach:     #fab387;
+    --catppuccin-yellow:    #f9e2af;
+    --catppuccin-green:     #a6e3a1;
+    --catppuccin-teal:      #94e2d5;
+    --catppuccin-sky:       #89dceb;
+    --catppuccin-sapphire:  #74c7ec;
+    --catppuccin-blue:      #89b4fa;
+    --catppuccin-lavender:  #b4befe;
+
+    // Text colors
+    --catppuccin-text:      #cdd6f4;
+    --catppuccin-subtext1:  #bac2de;
+    --catppuccin-subtext0:  #a6adc8;
+
+    // Overlay colors
+    --catppuccin-overlay2:  #9399b2;
+    --catppuccin-overlay1:  #7f849c;
+    --catppuccin-overlay0:  #6c7086;
+
+    // Surface colors
+    --catppuccin-surface2:  #585b70;
+    --catppuccin-surface1:  #45475a;
+    --catppuccin-surface0:  #313244;
+
+    // Base background colors
+    --catppuccin-base:      #1e1e2e;
+    --catppuccin-mantle:    #181825;
+    --catppuccin-crust:     #11111b;
+
+    // Default color shades using Catppuccin Mocha
+    --md-default-fg-color:             var(--catppuccin-text);
+    --md-default-fg-color--light:      var(--catppuccin-subtext1);
+    --md-default-fg-color--lighter:    var(--catppuccin-subtext0);
+    --md-default-fg-color--lightest:   var(--catppuccin-overlay2);
+    --md-default-bg-color:             var(--catppuccin-base);
+    --md-default-bg-color--light:      var(--catppuccin-surface0);
+    --md-default-bg-color--lighter:    var(--catppuccin-surface1);
+    --md-default-bg-color--lightest:   var(--catppuccin-surface2);
+
+    // Code color shades
+    --md-code-fg-color:                var(--catppuccin-text);
+    --md-code-bg-color:                var(--catppuccin-mantle);
+    --md-code-bg-color--light:         var(--catppuccin-surface0);
+    --md-code-bg-color--lighter:       var(--catppuccin-surface1);
+
+    // Code highlighting color shades
+    --md-code-hl-color:                var(--catppuccin-blue);
+    --md-code-hl-color--light:         hsla(#{hex2hsl(#89b4fa)}, 0.1);
+
+    // Code highlighting syntax color shades (using Catppuccin colors)
+    --md-code-hl-number-color:         var(--catppuccin-peach);
+    --md-code-hl-special-color:        var(--catppuccin-pink);
+    --md-code-hl-function-color:       var(--catppuccin-blue);
+    --md-code-hl-constant-color:       var(--catppuccin-peach);
+    --md-code-hl-keyword-color:        var(--catppuccin-mauve);
+    --md-code-hl-string-color:         var(--catppuccin-green);
+    --md-code-hl-name-color:           var(--catppuccin-lavender);
+    --md-code-hl-operator-color:       var(--catppuccin-sky);
+    --md-code-hl-punctuation-color:    var(--catppuccin-overlay2);
+    --md-code-hl-comment-color:        var(--catppuccin-overlay0);
+    --md-code-hl-generic-color:        var(--catppuccin-pink);
+    --md-code-hl-variable-color:       var(--catppuccin-text);
+
+    // Typeset color shades
+    --md-typeset-color:                var(--catppuccin-text);
+
+    // Typeset `a` color shades
+    --md-typeset-a-color:              var(--catppuccin-blue);
+
+    // Typeset `kbd` color shades
+    --md-typeset-kbd-color:            var(--catppuccin-surface2);
+    --md-typeset-kbd-accent-color:     var(--catppuccin-surface1);
+    --md-typeset-kbd-border-color:     var(--catppuccin-overlay0);
+
+    // Typeset `mark` color shades
+    --md-typeset-mark-color:           hsla(#{hex2hsl(#f9e2af)}, 0.3);
+
+    // Typeset `table` color shades
+    --md-typeset-table-color:          var(--catppuccin-surface0);
+    --md-typeset-table-color--light:   var(--catppuccin-surface1);
+
+    // Admonition color shades
+    --md-admonition-fg-color:          var(--catppuccin-text);
+    --md-admonition-bg-color:          var(--catppuccin-base);
+
+    // Footer color shades
+    --md-footer-bg-color:              var(--catppuccin-mantle);
+    --md-footer-bg-color--dark:        var(--catppuccin-crust);
+
+    // Shadow depth 1
+    --md-shadow-z1:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.2),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.1);
+
+    // Shadow depth 2
+    --md-shadow-z2:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.3),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.25);
+
+    // Shadow depth 3
+    --md-shadow-z3:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.5),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.35);
+
+    // Hide images for light mode
+    img[src$="#only-light"],
+    img[src$="#gh-light-mode-only"] {
+      display: none;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+
+  // Cappuccin Latte theme - Catppuccin's light variant
+  [data-md-color-scheme="cappuccin-latte"] {
+
+    // Indicate that the site is rendered with a light color scheme
+    color-scheme: light;
+
+    // Catppuccin Latte color palette
+    // Base colors
+    --catppuccin-rosewater: #dc8a78;
+    --catppuccin-flamingo:  #dd7878;
+    --catppuccin-pink:      #ea76cb;
+    --catppuccin-mauve:     #8839ef;
+    --catppuccin-red:       #d20f39;
+    --catppuccin-maroon:    #e64553;
+    --catppuccin-peach:     #fe640b;
+    --catppuccin-yellow:    #df8e1d;
+    --catppuccin-green:     #40a02b;
+    --catppuccin-teal:      #179299;
+    --catppuccin-sky:       #04a5e5;
+    --catppuccin-sapphire:  #209fb5;
+    --catppuccin-blue:      #1e66f5;
+    --catppuccin-lavender:  #7287fd;
+
+    // Text colors
+    --catppuccin-text:      #4c4f69;
+    --catppuccin-subtext1:  #5c5f77;
+    --catppuccin-subtext0:  #6c6f85;
+
+    // Overlay colors
+    --catppuccin-overlay2:  #7c7f93;
+    --catppuccin-overlay1:  #8c8fa1;
+    --catppuccin-overlay0:  #9ca0b0;
+
+    // Surface colors
+    --catppuccin-surface2:  #acb0be;
+    --catppuccin-surface1:  #bcc0cc;
+    --catppuccin-surface0:  #ccd0da;
+
+    // Base background colors
+    --catppuccin-base:      #eff1f5;
+    --catppuccin-mantle:    #e6e9ef;
+    --catppuccin-crust:     #dce0e8;
+
+    // Default color shades using Catppuccin Latte
+    --md-default-fg-color:             var(--catppuccin-text);
+    --md-default-fg-color--light:      var(--catppuccin-subtext1);
+    --md-default-fg-color--lighter:    var(--catppuccin-subtext0);
+    --md-default-fg-color--lightest:   var(--catppuccin-overlay2);
+    --md-default-bg-color:             var(--catppuccin-base);
+    --md-default-bg-color--light:      var(--catppuccin-surface0);
+    --md-default-bg-color--lighter:    var(--catppuccin-surface1);
+    --md-default-bg-color--lightest:   var(--catppuccin-surface2);
+
+    // Code color shades
+    --md-code-fg-color:                var(--catppuccin-text);
+    --md-code-bg-color:                var(--catppuccin-mantle);
+    --md-code-bg-color--light:         var(--catppuccin-surface0);
+    --md-code-bg-color--lighter:       var(--catppuccin-surface1);
+
+    // Code highlighting color shades
+    --md-code-hl-color:                var(--catppuccin-blue);
+    --md-code-hl-color--light:         hsla(#{hex2hsl(#1e66f5)}, 0.1);
+
+    // Code highlighting syntax color shades (using Catppuccin colors)
+    --md-code-hl-number-color:         var(--catppuccin-peach);
+    --md-code-hl-special-color:        var(--catppuccin-pink);
+    --md-code-hl-function-color:       var(--catppuccin-blue);
+    --md-code-hl-constant-color:       var(--catppuccin-peach);
+    --md-code-hl-keyword-color:        var(--catppuccin-mauve);
+    --md-code-hl-string-color:         var(--catppuccin-green);
+    --md-code-hl-name-color:           var(--catppuccin-lavender);
+    --md-code-hl-operator-color:       var(--catppuccin-sky);
+    --md-code-hl-punctuation-color:    var(--catppuccin-overlay2);
+    --md-code-hl-comment-color:        var(--catppuccin-overlay0);
+    --md-code-hl-generic-color:        var(--catppuccin-pink);
+    --md-code-hl-variable-color:       var(--catppuccin-text);
+
+    // Typeset color shades
+    --md-typeset-color:                var(--catppuccin-text);
+
+    // Typeset `a` color shades
+    --md-typeset-a-color:              var(--catppuccin-blue);
+
+    // Typeset `kbd` color shades
+    --md-typeset-kbd-color:            var(--catppuccin-surface2);
+    --md-typeset-kbd-accent-color:     var(--catppuccin-surface1);
+    --md-typeset-kbd-border-color:     var(--catppuccin-overlay0);
+
+    // Typeset `mark` color shades
+    --md-typeset-mark-color:           hsla(#{hex2hsl(#df8e1d)}, 0.3);
+
+    // Typeset `table` color shades
+    --md-typeset-table-color:          var(--catppuccin-surface0);
+    --md-typeset-table-color--light:   var(--catppuccin-surface1);
+
+    // Admonition color shades
+    --md-admonition-fg-color:          var(--catppuccin-text);
+    --md-admonition-bg-color:          var(--catppuccin-base);
+
+    // Footer color shades
+    --md-footer-bg-color:              var(--catppuccin-mantle);
+    --md-footer-bg-color--dark:        var(--catppuccin-crust);
+
+    // Shadow depth 1
+    --md-shadow-z1:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.05),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.1);
+
+    // Shadow depth 2
+    --md-shadow-z2:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.1),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.15);
+
+    // Shadow depth 3
+    --md-shadow-z3:
+      0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.15),
+      0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.2);
+
+    // Hide images for dark mode
+    img[src$="#only-dark"],
+    img[src$="#gh-dark-mode-only"] {
+      display: none;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+
   // Switching in progress - disable all transitions temporarily
   [data-md-color-switching] *,
   [data-md-color-switching] *::before,


### PR DESCRIPTION
This commit introduces two new color schemes for MkDocs Material:
- Cappuccin Mocha: Dark theme based on Catppuccin Mocha
- Cappuccin Latte: Light theme based on Catppuccin Latte

Changes include:
- Added color scheme definitions in palette/_scheme.scss
- Implemented all 26 Catppuccin colors as CSS variables
- Custom syntax highlighting colors using Catppuccin palette
- Documentation with usage examples (CAPPUCCIN_THEME.md)
- Example configuration file (examples/cappuccin-theme-example.yml)

The themes provide full support for all Material components including code highlighting, admonitions, tables, and more.