### PR TITLE
Fix security issues in urllib3 and upgrade requests package to latest version (CVE-2025-66418 high severity, CVE-2025-66471 high severity)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ babel>=2.10
 colorama>=0.4
 paginate>=0.5
 backrefs>=5.7.post1
-requests>=2.26
+requests>=2.32.5
 


### PR DESCRIPTION
## Issue
Dependabot has recently issued high security alerts for urllib3 in several of my projects that use MkDocs Material for documentation sites. I'm using the latest version 9.7.0 of MkDocs Material. Details:

<img width="1224" height="708" alt="Screenshot 2025-12-17 at 09 11 26" src="https://github.com/user-attachments/assets/5603cde3-307d-4930-b2a8-0094e575bb49" />

<img width="1236" height="706" alt="Screenshot 2025-12-17 at 09 11 48" src="https://github.com/user-attachments/assets/0d5e2909-95d0-4628-ac28-9f2e8ee8269a" />

## Suggested Solution
It seems like urllib3 isn't directly used in the dependencies, but rather chained from the requests package, and I suspect this is the cause of the security issues. [Version 2.26 of requests](https://github.com/psf/requests/releases/tag/v2.26.0) depends on an older version of urllib3. From the setup.py file of the requests package:

```python
requires = [
    ...
    'urllib3>=1.21.1,<1.27',
    ...
]
```

... so I suggest [updating requests to the latest version 2.32.5](https://github.com/psf/requests/releases/tag/v2.32.5) where urllib3 appears to be updated. Recent setup.py file of the requests package:

```python
requires = [
    ...
    "urllib3>=1.21.1,<3",
    ...
]
```