### PR TITLE
fix: Gitlab CI configuration was updated for site publishing

### DIFF
--- a/docs/publishing-your-site.md
+++ b/docs/publishing-your-site.md
@@ -135,9 +135,8 @@ pages:
     key: ${CI_COMMIT_REF_SLUG}
     paths:
       - ~/.cache/ # (1)!
-  artifacts:
-    paths:
-      - public
+  pages:
+    publish: public
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 ```


### PR DESCRIPTION
From version 17.10 the gitlab pages have a different configuration way:

> In GitLab 17.10 and later, for Pages jobs only, the public directory is appended automatically to [artifacts:paths](https://docs.gitlab.com/ci/yaml/#artifactspaths) when the [pages.publish](https://docs.gitlab.com/ci/yaml/#pagespublish) path is not explicitly specified

Reference: https://docs.gitlab.com/user/project/pages/getting_started/pages_from_scratch/#specify-the-public-directory-for-artifacts

Also, a more simple way (following the documentation) is just define `pages: true` but for me is more clear in this way, instead to know the default value reading the documentation. The match between `--site-dir public` and `pages: publish: public` is more intuitive. 