### PR TITLE
Update optimize.md with version requirement note

### DIFF
--- a/docs/plugins/optimize.md
+++ b/docs/plugins/optimize.md
@@ -103,6 +103,8 @@ and mentions some alternative environments.
   [built-in plugins]: index.md
   [image processing]: requirements/image-processing.md
 
+And, ensure that Material for MkDocs version is at least the minimum listed above.
+
 ### General
 
 The following settings are available:


### PR DESCRIPTION
Added note about Material for MkDocs version requirement. When trying to use plugin, building material errors out stating no optimize plugin found (not super helpful). The error probably occurs a lot because the release was just a couple months ago.

I might look into updating the error code later in build, but good to note in the documentation at least :).