### PR TITLE
fix: source file (raw/blob) view button generates invalid file path

### DIFF
--- a/src/templates/partials/actions.html
+++ b/src/templates/partials/actions.html
@@ -39,17 +39,17 @@
   <!-- View button -->
   {% if "content.action.view" in features %}
     {% if "/blob/" in page.edit_url %}
-      {% set part = "blob" %}
+      {% set part = "/blob/" %}
     {% else %}
-      {% set part = "edit" %}
-    {% endif %}
-    <a
-      href="{{ page.edit_url | replace(part, 'raw') }}"
-      title="{{ lang.t('action.view') }}"
-      class="md-content__button md-icon"
-    >
-      {% set icon = config.theme.icon.view or "material/file-eye-outline" %}
-      {% include ".icons/" ~ icon ~ ".svg" %}
-    </a>
+      {% set part = "/edit/" %}
+    {% endif %}      
+      <a
+        href="{{ page.edit_url | replace(part, '/raw/') }}"
+        title="{{ lang.t('action.view') }}"
+        class="md-content__button md-icon"
+      >
+        {% set icon = config.theme.icon.view or "material/file-eye-outline" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </a>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Discoved in https://github.com/Atlas-OS/docs/issues/281 

> ### [BUG]: Page Source Link is Wrong on Text Editors
> 
> On the [Text Editors page](https://docs.atlasos.net/getting-started/post-installation/software/text-editors/), clicking the view source link leads to a 404. The link looks to be changed from text-editors.md to text-rawors.md with edit -> raw.
> 

## fix: source file (raw/blob) view button generates invalid file path

This PR is to fix the gen logic for the view buttons, which wrongfully converted all text in the **docs edit link** with the word `edit` to `raw`. PR tested locally with `mkdocs-serve` and confirm fixes the issue.

e.g. for http://docs.atlasos.net/post-install/software/text-editors/

#### Edit link: 

github.com/Atlas-OS/docs/**edit**/main/docs/post-install/software/text-**edit**ors.md

#### What its supposed to convert to: 

github.com/Atlas-OS/docs/**raw**/main/docs/post-install/software/text-**edit**ors.md

#### But it was presented as:

github.com/Atlas-OS/docs/**raw**/main/docs/post-install/software/text-**raw**ors.md

### Affected files:
https://github.com/squidfunk/mkdocs-material/blob/0d11a2d01174a0ab3bec97300c4432da44128253/src/templates/partials/actions.html#L47