### PR TITLE
add `--livereload` flag to `mkdocs serve` command

### DIFF
--- a/docs/creating-your-site.md
+++ b/docs/creating-your-site.md
@@ -196,7 +196,7 @@ write your documentation. The server will automatically rebuild the site upon
 saving. Start it with:
 
 ``` sh
-mkdocs serve # (1)!
+mkdocs serve --livereload # (1)!
 ```
 
 1.  If you have a large documentation project, it might take minutes until


### PR DESCRIPTION
Caused me a bit of pain when I was contributing documentation to this project here:
- https://github.com/EndstoneMC/endstone/pull/381#issue-4276183999

I believe it'd be best to not give too much explanation, as to not lead anyone down a rabbit hole, and instead include this flag in the base command. 
