### PR TITLE
docs: update copyright year

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ repo_name: squidfunk/mkdocs-material
 repo_url: https://github.com/squidfunk/mkdocs-material
 
 # Copyright
-copyright: Copyright &copy; 2016 - 2025 Martin Donath
+copyright: Copyright &copy; 2016 - 2026 Martin Donath
 
 # Configuration
 theme:


### PR DESCRIPTION
As maintainance mode includes critical bug fixes and security updates, I'm assuming it'd be reasonable to update the copyright year as well.