### PR TITLE
Update document for lists, to mention sane_lists extension

### DIFF
--- a/docs/reference/lists.md
+++ b/docs/reference/lists.md
@@ -102,6 +102,14 @@ be re-numbered when rendered:
 
 </div>
 
+If you don't want your lists to be automatically re-numbered, you should enable
+the [`sane_lists` markdown extension](https://python-markdown.github.io/extensions/sane_lists/).
+
+```yml
+markdown_extensions:
+  - sane_lists
+```
+
 ### Using definition lists
 
 When [Definition Lists] is enabled, lists of arbitrary key-value pairs, e.g. the


### PR DESCRIPTION
This is similar to #7373, but far less broad. Instead of adding the extension by default, or giving an enormous amount of detail, it just mentions the existence of the extension.

This should provide a far better compromise between preventing users from option-hunting, and ensuring that `mkdocs-material` doesn't face increased maintenance burden by not implying stronger support for this extension than is actually offered.

I think the existence of this option should be documented, if only to prevent time wasted hunting through issues and discussions with GitHub's awful search UI.