### PR TITLE
Fixed typo: formely → formerly

### DIFF
--- a/docs/plugins/projects.md
+++ b/docs/plugins/projects.md
@@ -14,7 +14,7 @@ be used to split very large projects into smaller parts.
 !!! bug "The built-in projects plugin is deprecated"
 
     [Material for MkDocs is in maintenance mode]. The projects plugin, which was
-    formely part of the [Insiders] edition, was released in <!-- md:version 9.7.0 -->, the last release that includes all features from the Insiders edition.
+    formerly part of the [Insiders] edition, was released in <!-- md:version 9.7.0 -->, the last release that includes all features from the Insiders edition.
     Unfortunately, the projects plugin turned out impossible to maintain, and
     was one of the key motivators to create [Zensical].
 

--- a/docs/plugins/typeset.md
+++ b/docs/plugins/typeset.md
@@ -14,7 +14,7 @@ as defined in the page's content.
 !!! bug "The built-in typeset plugin is deprecated"
 
     [Material for MkDocs is in maintenance mode]. The typeset plugin, which was
-    formely part of the [Insiders] edition, was released in <!-- md:version 9.7.0 -->, the last release that includes all features from the Insiders edition.
+    formerly part of the [Insiders] edition, was released in <!-- md:version 9.7.0 -->, the last release that includes all features from the Insiders edition.
     Unfortunately, the typeset plugin turned out impossible to maintain, and
     was one of the key motivators to create [Zensical].
 


### PR DESCRIPTION
Fixes a small typo (`formely` → `formerly`) in the deprecation notices for the built-in `projects` and `typeset` plugins.